### PR TITLE
chore: prevent web components `dist` folder from being packed

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -107,7 +107,6 @@
     "rimraf": "^6.0.1",
     "rollup": "^4.41.1",
     "rollup-plugin-copy": "^3.5.0",
-    "rollup-plugin-visualizer": "^6.0.5",
     "sass": "^1.93.2",
     "storybook": "^9.1.8",
     "storybook-addon-accessibility-checker": "^9.2.0-rc.3",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -13,7 +13,6 @@
   "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "custom-elements.json",
-    "dist/**/*",
     "es/**/*",
     "es-custom/**/*",
     "lib/**/*",
@@ -43,7 +42,6 @@
     "./es/": "./es/",
     "./es-custom/*": "./es-custom/*",
     "./lib/": "./lib/",
-    "./dist/": "./dist/",
     "./scss/": "./scss/",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
@@ -52,7 +50,7 @@
     "prebuild": "node tools/fix-carbon-sass-imports.js",
     "build": "yarn clean && node tasks/build-dist.js && node tasks/build.js && yarn wca",
     "ci-check": "yarn wca && yarn typecheck",
-    "clean": "rimraf es lib scss dist storybook-static",
+    "clean": "rimraf es es-custom lib scss dist storybook-static",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "serve": "node tasks/build.js --serve",
     "start": "yarn storybook",
@@ -109,6 +107,7 @@
     "rimraf": "^6.0.1",
     "rollup": "^4.41.1",
     "rollup-plugin-copy": "^3.5.0",
+    "rollup-plugin-visualizer": "^6.0.5",
     "sass": "^1.93.2",
     "storybook": "^9.1.8",
     "storybook-addon-accessibility-checker": "^9.2.0-rc.3",


### PR DESCRIPTION
This PR removes the `dist` folder references from the `files` and `exports` fields in our Web Components `package.json`. The `dist` folder is primarily used for our CDN artifacts, so doesn't need to be included in the npm bundle. By removing the `dist` folder, we reduce the bundle size by 6.5 MB (18.36% decrease). 

### Changelog

**Changed**

- include `es-custom` in the `yarn clean` of our web components scripts

**Removed**

- references to the `dist` build folder in the `package.json`

#### Testing / Reviewing

Check that it passes ci-checks

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
