### PR TITLE
fix(link): update html for icon within link

### DIFF
--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -147,9 +147,9 @@ const LinkBase = React.forwardRef<
         onClick={handleOnClick}>
         {children}
         {!inline && Icon && (
-          <div className={`${prefix}--link__icon`}>
+          <span className={`${prefix}--link__icon`}>
             <Icon />
-          </div>
+          </span>
         )}
       </BaseComponentAsAny>
     );


### PR DESCRIPTION
The current implementation of a Link with an icon is rendering a div inside of a p tag, which is invalid HTML. This fixes it by changing icon wrapper from div to span so no matter the wrapping element it will be valid.

### Changelog


**Changed**

- Changed icon wrapper element from div to span in Link component to ensure valid HTML structure


#### Testing / Reviewing

- [ ] Verify Link component renders correctly with icons
- [ ] Confirm HTML is correct 


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [] Updated documentation and storybook examples~
~- [] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
