### PR TITLE
fix: issue with header name spacing with multiple words

### DIFF
--- a/packages/react/src/components/UIShell/HeaderName.tsx
+++ b/packages/react/src/components/UIShell/HeaderName.tsx
@@ -33,7 +33,7 @@ export default function HeaderName<E extends ElementType = 'a'>({
           &nbsp;
         </>
       )}
-      {children}
+      <span>{children}</span>
     </Link>
   );
 }

--- a/packages/web-components/src/components/ui-shell/header-name.ts
+++ b/packages/web-components/src/components/ui-shell/header-name.ts
@@ -45,7 +45,7 @@ class CDSHeaderName extends FocusMixin(LitElement) {
         `;
     return html`
       <a part="link" class="${prefix}--header__name" href="${ifDefined(href)}"
-        >${namePrefixPart}&nbsp;<slot></slot
+        >${namePrefixPart}&nbsp;<span><slot></slot></span
       ></a>
     `;
   }


### PR DESCRIPTION
Closes #21281

Currently when multiple words are displayed as the product name they wrap with inconsistent spacing. This PR addresses this for @carbon/react and @carbon/web-components

#### Testing / Reviewing

React after
<img width="337" height="68" alt="image" src="https://github.com/user-attachments/assets/d1da7b11-5ebf-4651-8a4f-e38f3ef6537f" />
<img width="341" height="64" alt="image" src="https://github.com/user-attachments/assets/0755062b-78b1-41bf-9591-1ce69bb4c55c" />


Web components after
<img width="343" height="69" alt="image" src="https://github.com/user-attachments/assets/892e8e16-9aa3-4f9c-bf39-9d6094fd09d6" />
<img width="333" height="60" alt="image" src="https://github.com/user-attachments/assets/50eb6eee-6135-48e2-b860-7348fe0749eb" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
