### PR TITLE
fix(Toggletip): use label styles for ToggletipLabel

### DIFF
--- a/packages/styles/scss/components/toggletip/_toggletip.scss
+++ b/packages/styles/scss/components/toggletip/_toggletip.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2018, 2023
+// Copyright IBM Corp. 2018, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@
 
 @mixin toggletip() {
   .#{$prefix}--toggletip-label {
-    @include type.type-style('body-01');
+    @include type.type-style('label-01');
 
     color: theme.$text-secondary;
     margin-inline-end: spacing.$spacing-03;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21216

Used label styles for `ToggletipLabel`.

### Changelog

**Changed**

- Used label styles for `ToggletipLabel`.

#### Testing / Reviewing

Create a test story using the reproduction in the issue and verify that the labels for all fields have the same characteristics.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
