### PR TITLE
fix(TreeView): scope button focus styles to tree labels

### DIFF
--- a/packages/styles/scss/components/treeview/_treeview.scss
+++ b/packages/styles/scss/components/treeview/_treeview.scss
@@ -298,7 +298,10 @@
   .#{$prefix}--tree-node__label .#{$prefix}--popover-container {
     inline-size: 100%;
   }
-  .#{$prefix}--tooltip-trigger__wrapper .#{$prefix}--btn--ghost:focus {
+  .#{$prefix}--tree
+    .#{$prefix}--tree-node__label
+    .#{$prefix}--tooltip-trigger__wrapper
+    .#{$prefix}--btn--ghost:focus {
     box-shadow: none;
     outline: 2px solid $focus;
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21150

Scoped button focus styles to tree labels in `TreeView`.

### Changelog

**Changed**

- Scoped button focus styles to tree labels in `TreeView`.

#### Testing / Reviewing

Preferably, contributors to https://github.com/carbon-design-system/carbon/pull/19043 could review.

Alternate fix:

```scss
.#{$prefix}--tree-node__label
  .#{$prefix}--tooltip-trigger__wrapper
  .#{$prefix}--btn--ghost:focus {
  box-shadow: none;
  outline: 2px solid $focus;
}
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
