### PR TITLE
fix(ComboBox): fire onChange when clearing custom value

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -351,6 +351,24 @@ describe('ComboBox', () => {
     assertMenuClosed();
     expect(mockProps.onChange).toHaveBeenCalledWith({
       inputValue: 'Apple',
+      selectedItem: null,
+    });
+  });
+
+  it('should call onChange when clearing a committed custom value', async () => {
+    render(<ComboBox {...mockProps} allowCustomValue />);
+
+    const input = findInputNode();
+
+    await userEvent.type(input, 'Apple');
+    await userEvent.keyboard('[Enter]');
+    mockProps.onChange.mockClear();
+
+    await userEvent.clear(input);
+
+    expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+    expect(mockProps.onChange).toHaveBeenCalledWith({
+      inputValue: '',
       selectedItem: null,
     });
   });

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -489,6 +489,7 @@ const ComboBox = forwardRef(
       // eslint-disable-next-line  react-hooks/exhaustive-deps -- https://github.com/carbon-design-system/carbon/issues/20452
     }, [typeahead, inputValue, items, itemToString, autocompleteCustomFilter]);
     const isManualClearingRef = useRef(false);
+    const committedCustomValueRef = useRef('');
     const [isClearing, setIsClearing] = useState(false);
     const prefix = usePrefix();
     const { isFluid } = useContext(FormContext);
@@ -602,9 +603,15 @@ const ComboBox = forwardRef(
               const nextSelectedItem =
                 items.find((item) => itemToString(item) === inputValue) ??
                 inputValue;
+              const isCustomSelection =
+                typeof nextSelectedItem === 'string' &&
+                !items.some((item) => isEqual(item, nextSelectedItem));
 
               if (!isEqual(currentSelectedItem, nextSelectedItem) && onChange) {
                 onChange({ selectedItem: nextSelectedItem, inputValue });
+                committedCustomValueRef.current = isCustomSelection
+                  ? inputValue
+                  : '';
               }
 
               return {
@@ -877,6 +884,10 @@ const ComboBox = forwardRef(
           typeof newSelectedItem !== 'undefined' &&
           !isEqual(selectedItemProp, newSelectedItem)
         ) {
+          if (items.some((item) => isEqual(item, newSelectedItem))) {
+            committedCustomValueRef.current = '';
+          }
+
           onChange({ selectedItem: newSelectedItem });
         }
       },
@@ -884,7 +895,7 @@ const ComboBox = forwardRef(
 
     // Keep the dropdown highlight in sync with either the controlled value or
     // Downshift's own selection when uncontrolled.
-    const menuSelectedItem =
+    const currentSelectedItem =
       typeof selectedItemProp !== 'undefined' ? selectedItemProp : selectedItem;
 
     useEffect(() => {
@@ -1032,8 +1043,21 @@ const ComboBox = forwardRef(
                 ...inputProps,
                 onChange: (e) => {
                   const newValue = e.target.value;
+                  const shouldClearSelection =
+                    allowCustomValue &&
+                    committedCustomValueRef.current &&
+                    inputValue === committedCustomValueRef.current &&
+                    newValue === '';
+
                   setInputValue(newValue);
                   downshiftSetInputValue(newValue);
+
+                  if (shouldClearSelection) {
+                    setIsClearing(true);
+                    onChange({ selectedItem: null, inputValue: '' });
+                    selectItem(null);
+                    committedCustomValueRef.current = '';
+                  }
                 },
                 ref: mergeRefs(textInput, ref, inputRef),
                 onKeyDown: (
@@ -1071,6 +1095,7 @@ const ComboBox = forwardRef(
                       inputValue &&
                       highlightedIndex === -1
                     ) {
+                      committedCustomValueRef.current = inputValue;
                       onChange({ selectedItem: null, inputValue });
                     }
 
@@ -1156,6 +1181,7 @@ const ComboBox = forwardRef(
                   setInputValue('');
                   onChange({ selectedItem: null });
                   selectItem(null);
+                  committedCustomValueRef.current = '';
                   handleSelectionClear();
                 }}
                 translateWithId={translateWithId}
@@ -1211,7 +1237,7 @@ const ComboBox = forwardRef(
                     return (
                       <ListBox.MenuItem
                         key={itemProps.id}
-                        isActive={isEqual(menuSelectedItem, item)}
+                        isActive={isEqual(currentSelectedItem, item)}
                         isHighlighted={highlightedIndex === index}
                         title={title}
                         disabled={disabled}
@@ -1221,7 +1247,7 @@ const ComboBox = forwardRef(
                         ) : (
                           itemToString(item)
                         )}
-                        {isEqual(menuSelectedItem, item) && (
+                        {isEqual(currentSelectedItem, item) && (
                           <Checkmark
                             className={`${prefix}--list-box__menu-item__selected-icon`}
                           />


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21091

Fired `onChange` in `ComboBox` when clearing custom values.

### Changelog

**Changed**

- Fired `onChange` in `ComboBox` when clearing custom values.

#### Testing / Reviewing

The issue was that `allowCustomValue` commits don't create a real `selectedItem`. They leave it `null` and only update `inputValue`. The original clear logic looked for a non-`null` selection to decide whether to fire `onChange`, so clearing a committed custom value via `CMD+A` + `Backspace` never met that condition and `onChange` didn't run. That's why `selectedItem` stayed `null` while `inputValue` still reflected the last committed value.

The fix tracks the last committed custom value separately and treats clearing that exact value as a meaningful selection change. When the input is emptied and the previous value matches the committed custom value, the component now fires `onChange({ selectedItem: null, inputValue: '' })` and clears that commit marker. This change should preserve existing selection behavior and ensure custom commits are correctly invalidated when cleared.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
