### PR TITLE
fix(DataTable): add header isSortable support

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2605,6 +2605,9 @@ Map {
                   "isRequired": true,
                   "type": "node",
                 },
+                "isSortable": {
+                  "type": "bool",
+                },
                 "key": {
                   "isRequired": true,
                   "type": "string",

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -113,6 +113,7 @@ export interface DataTableHeader {
   header: ReactNode;
   slug?: ReactElement;
   decorator?: ReactElement;
+  isSortable?: boolean;
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
 export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
@@ -347,7 +348,7 @@ export const DataTable = <RowType, ColTypes extends any[]>(
     render,
     translateWithId: t = defaultTranslateWithId,
     size,
-    isSortable: isSortableProp,
+    isSortable,
     useZebraStyles,
     useStaticWidth,
     stickyHeader,
@@ -393,7 +394,7 @@ export const DataTable = <RowType, ColTypes extends any[]>(
   const getHeaderProps: RenderProps['getHeaderProps'] = ({
     header,
     onClick,
-    isSortable = isSortableProp,
+    isSortable: headerIsSortable,
     ...rest
   }) => {
     const { sortDirection, sortHeaderKey } = state;
@@ -403,7 +404,7 @@ export const DataTable = <RowType, ColTypes extends any[]>(
       ...rest,
       key,
       sortDirection,
-      isSortable,
+      isSortable: headerIsSortable ?? header.isSortable ?? isSortable,
       isSortHeader: sortHeaderKey === key,
       slug,
       decorator,
@@ -589,7 +590,7 @@ export const DataTable = <RowType, ColTypes extends any[]>(
     return {
       useZebraStyles,
       size: size ?? 'lg',
-      isSortable: isSortableProp,
+      isSortable,
       useStaticWidth,
       stickyHeader,
       overflowMenuOnHover: overflowMenuOnHover ?? false,
@@ -910,6 +911,7 @@ DataTable.propTypes = {
     PropTypes.shape({
       key: PropTypes.string.isRequired,
       header: PropTypes.node.isRequired,
+      isSortable: PropTypes.bool,
     })
   ).isRequired,
 

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2025
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -220,6 +220,57 @@ describe('DataTable', () => {
           'Field 3:A',
           'Field 3:B',
         ]);
+      });
+
+      it('should resolve isSortable from header, override, and table defaults', () => {
+        const headersWithSort = [
+          { key: 'princess', header: 'Princess', isSortable: false },
+          { key: 'peach', header: 'Peach' },
+        ];
+        const { render: _render, ...baseProps } = mockProps;
+
+        render(
+          <DataTable {...baseProps} headers={headersWithSort} isSortable={true}>
+            {({ headers, getHeaderProps }) => {
+              const firstDefault = getHeaderProps({ header: headers[0] });
+              const secondDefault = getHeaderProps({ header: headers[1] });
+              const firstOverride = getHeaderProps({
+                header: headers[0],
+                isSortable: true,
+              });
+
+              return (
+                <div>
+                  <span
+                    data-testid="first-default"
+                    data-issortable={firstDefault.isSortable}
+                  />
+                  <span
+                    data-testid="second-default"
+                    data-issortable={secondDefault.isSortable}
+                  />
+                  <span
+                    data-testid="first-override"
+                    data-issortable={firstOverride.isSortable}
+                  />
+                </div>
+              );
+            }}
+          </DataTable>
+        );
+
+        expect(screen.getByTestId('first-default')).toHaveAttribute(
+          'data-issortable',
+          'false'
+        );
+        expect(screen.getByTestId('second-default')).toHaveAttribute(
+          'data-issortable',
+          'true'
+        );
+        expect(screen.getByTestId('first-override')).toHaveAttribute(
+          'data-issortable',
+          'true'
+        );
       });
 
       it('should re-sort new row props by the current sort state', async () => {

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -67,14 +67,14 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
               >
                 <input
                   class="cds--radio-button"
-                  id="data-table-17__select-row-b"
-                  name="select-row-17"
+                  id="data-table-18__select-row-b"
+                  name="select-row-18"
                   type="radio"
                   value=""
                 />
                 <label
                   class="cds--radio-button__label"
-                  for="data-table-17__select-row-b"
+                  for="data-table-18__select-row-b"
                 >
                   <span
                     class="cds--radio-button__appearance"
@@ -105,14 +105,14 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
               >
                 <input
                   class="cds--radio-button"
-                  id="data-table-17__select-row-a"
-                  name="select-row-17"
+                  id="data-table-18__select-row-a"
+                  name="select-row-18"
                   type="radio"
                   value=""
                 />
                 <label
                   class="cds--radio-button__label"
-                  for="data-table-17__select-row-a"
+                  for="data-table-18__select-row-a"
                 >
                   <span
                     class="cds--radio-button__appearance"
@@ -143,14 +143,14 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
               >
                 <input
                   class="cds--radio-button"
-                  id="data-table-17__select-row-c"
-                  name="select-row-17"
+                  id="data-table-18__select-row-c"
+                  name="select-row-18"
                   type="radio"
                   value=""
                 />
                 <label
                   class="cds--radio-button__label"
-                  for="data-table-17__select-row-c"
+                  for="data-table-18__select-row-c"
                 >
                   <span
                     class="cds--radio-button__appearance"
@@ -245,14 +245,14 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
               >
                 <input
                   class="cds--radio-button"
-                  id="data-table-16__select-row-b"
-                  name="select-row-16"
+                  id="data-table-17__select-row-b"
+                  name="select-row-17"
                   type="radio"
                   value=""
                 />
                 <label
                   class="cds--radio-button__label"
-                  for="data-table-16__select-row-b"
+                  for="data-table-17__select-row-b"
                 >
                   <span
                     class="cds--radio-button__appearance"
@@ -283,14 +283,14 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
               >
                 <input
                   class="cds--radio-button"
-                  id="data-table-16__select-row-a"
-                  name="select-row-16"
+                  id="data-table-17__select-row-a"
+                  name="select-row-17"
                   type="radio"
                   value=""
                 />
                 <label
                   class="cds--radio-button__label"
-                  for="data-table-16__select-row-a"
+                  for="data-table-17__select-row-a"
                 >
                   <span
                     class="cds--radio-button__appearance"
@@ -321,14 +321,14 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
               >
                 <input
                   class="cds--radio-button"
-                  id="data-table-16__select-row-c"
-                  name="select-row-16"
+                  id="data-table-17__select-row-c"
+                  name="select-row-17"
                   type="radio"
                   value=""
                 />
                 <label
                   class="cds--radio-button__label"
-                  for="data-table-16__select-row-c"
+                  for="data-table-17__select-row-c"
                 >
                   <span
                     class="cds--radio-button__appearance"
@@ -653,13 +653,13 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               >
                 <input
                   class="cds--checkbox"
-                  id="data-table-7__select-all"
-                  name="select-all-7"
+                  id="data-table-8__select-all"
+                  name="select-all-8"
                   type="checkbox"
                 />
                 <label
                   class="cds--checkbox-label"
-                  for="data-table-7__select-all"
+                  for="data-table-8__select-all"
                 >
                   <span
                     class="cds--visually-hidden"
@@ -708,13 +708,13 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               >
                 <input
                   class="cds--checkbox"
-                  id="data-table-7__select-row-b"
-                  name="select-row-7"
+                  id="data-table-8__select-row-b"
+                  name="select-row-8"
                   type="checkbox"
                 />
                 <label
                   class="cds--checkbox-label"
-                  for="data-table-7__select-row-b"
+                  for="data-table-8__select-row-b"
                 >
                   <span
                     class="cds--visually-hidden"
@@ -741,13 +741,13 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               >
                 <input
                   class="cds--checkbox"
-                  id="data-table-7__select-row-a"
-                  name="select-row-7"
+                  id="data-table-8__select-row-a"
+                  name="select-row-8"
                   type="checkbox"
                 />
                 <label
                   class="cds--checkbox-label"
-                  for="data-table-7__select-row-a"
+                  for="data-table-8__select-row-a"
                 >
                   <span
                     class="cds--visually-hidden"
@@ -774,13 +774,13 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               >
                 <input
                   class="cds--checkbox"
-                  id="data-table-7__select-row-c"
-                  name="select-row-7"
+                  id="data-table-8__select-row-c"
+                  name="select-row-8"
                   type="checkbox"
                 />
                 <label
                   class="cds--checkbox-label"
-                  for="data-table-7__select-row-c"
+                  for="data-table-8__select-row-c"
                 >
                   <span
                     class="cds--visually-hidden"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18172

Added `header` `isSortable` support in `DataTable`.

### Changelog

**New**

- Added `header` `isSortable` support in `DataTable`.

**Changed**

- Simplified the `isSortable` props and variables.

#### Testing / Reviewing

`DataTableHeader` didn’t include `isSortable` in its type, even though `getHeaderProps` accepts it. That forced users to pass `isSortable: header.isSortable` manually and/or ignore type errors, despite header level sorting already being a supported concept.

I added an `isSortable` type to `DataTableHeader` and adjusted `getHeaderProps` so it resolves `isSortable` in a reasonable order: explicit override passed to `getHeaderProps`, then `header.isSortable`, then the table level `isSortable`. The test should verify this precedence.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
