### PR TITLE
fix(menu): guard missing slot in _registerMenuItems

### DIFF
--- a/packages/web-components/src/components/menu/menu.ts
+++ b/packages/web-components/src/components/menu/menu.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -510,11 +510,12 @@ class CDSMenu extends HostListenerMixin(LitElement) {
   _registerMenuItems = () => {
     let items;
     if (this.isChild) {
-      items = (
-        this.querySelector('slot[name="submenu"]') as HTMLSlotElement
-      ).assignedElements();
+      const submenuSlot = this.querySelector(
+        'slot[name="submenu"]'
+      ) as HTMLSlotElement | null;
+      items = submenuSlot?.assignedElements() ?? [];
     } else {
-      items = this.shadowRoot?.querySelector('slot')?.assignedElements();
+      items = this.shadowRoot?.querySelector('slot')?.assignedElements() ?? [];
     }
     this.items = items?.filter((item) => {
       if (item.tagName === 'CDS-MENU-ITEM') {


### PR DESCRIPTION
No issue.

Guarded missing slot in `_registerMenuItems` in `menu`.

### Changelog

**Changed**

- Guarded missing slot in `_registerMenuItems` in `menu`.

#### Testing / Reviewing

There was also a runtime error in https://github.com/carbon-design-system/carbon/actions/runs/21048909218/job/60530290228?pr=21289 in `CDSMenu._registerMenuItems` when a submenu slot was missing, triggering a null `TypeError`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
