### PR TITLE
fix(tooltip): resolve tooltip sass if() deprecation warning

### DIFF
--- a/packages/styles/scss/utilities/_tooltip.scss
+++ b/packages/styles/scss/utilities/_tooltip.scss
@@ -11,6 +11,7 @@
 @use 'z-index' as *;
 @use '../config' as *;
 @use '../motion' as *;
+@use '../spacing' as *;
 @use '../theme' as *;
 @use '../type';
 
@@ -37,9 +38,9 @@
 
   z-index: z('floating');
   @if $tooltip-type == 'definition' {
-    padding: convert.to-rem(8px) convert.to-rem(16px);
+    padding: $spacing-03 $spacing-05;
   } @else {
-    padding: convert.to-rem(3px) convert.to-rem(16px);
+    padding: convert.to-rem(3px) $spacing-05;
   }
 
   border-radius: convert.to-rem(2px);
@@ -234,10 +235,10 @@
   $align: 'center'
 ) {
   // position and alignment
-  $caret-spacing: convert.to-rem(8px);
+  $caret-spacing: $spacing-03;
 
   @if $tooltip-type == 'definition' {
-    $caret-spacing: convert.to-rem(4px);
+    $caret-spacing: $spacing-02;
   }
 
   // space between caret and trigger button

--- a/packages/styles/scss/utilities/_tooltip.scss
+++ b/packages/styles/scss/utilities/_tooltip.scss
@@ -36,11 +36,12 @@
   @include box-shadow;
 
   z-index: z('floating');
-  padding: if(
-    sass($tooltip-type == 'definition'),
-    convert.to-rem(8px) convert.to-rem(16px),
-    convert.to-rem(3px) convert.to-rem(16px)
-  );
+  @if $tooltip-type == 'definition' {
+    padding: convert.to-rem(8px) convert.to-rem(16px);
+  } @else {
+    padding: convert.to-rem(3px) convert.to-rem(16px);
+  }
+
   border-radius: convert.to-rem(2px);
   background-color: $background-inverse;
   block-size: auto;
@@ -233,11 +234,11 @@
   $align: 'center'
 ) {
   // position and alignment
-  $caret-spacing: if(
-    sass($tooltip-type == 'definition'),
-    convert.to-rem(4px),
-    convert.to-rem(8px)
-  );
+  $caret-spacing: convert.to-rem(8px);
+
+  @if $tooltip-type == 'definition' {
+    $caret-spacing: convert.to-rem(4px);
+  }
 
   // space between caret and trigger button
   $caret-height: convert.to-rem(5px);


### PR DESCRIPTION
Closes #21288

Resolve remaining Sass `if(`) deprecation in tooltip utility, switching to `@if/@else` removes the warning while keeping tooltip spacing the same and compatible with our supported Sass versions.

### Changelog

**New**

- ~None~

**Changed**

- Replaced legacy `if()` usage in `_tooltip.scss` padding and caret spacing with `@if/@else` to clear Sass deprecation warnings without changing spacing behavior.

**Removed**

- ~None~

#### Testing / Reviewing

- Everything should build and all CI/tests should pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
