### PR TITLE
build(eslint): allow ts-nocheck in figma files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,12 @@ export default tseslint.config([
     },
   },
   {
+    files: ['packages/react/code-connect/**/*.figma.tsx'],
+    rules: {
+      '@typescript-eslint/ban-ts-comment': ['error', { 'ts-nocheck': false }],
+    },
+  },
+  {
     // TODO: Should we ignore all files in the .gitignore? If so, handle the
     // nested .gitignore files too.
     ignores: [

--- a/packages/react/code-connect/AILabel/AILabel.figma.tsx
+++ b/packages/react/code-connect/AILabel/AILabel.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { AILabel } from '@carbon/react';

--- a/packages/react/code-connect/AILabel/AILabelActions.figma.tsx
+++ b/packages/react/code-connect/AILabel/AILabelActions.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { AILabelActions } from '@carbon/react';

--- a/packages/react/code-connect/AILabel/AILabelContent.figma.tsx
+++ b/packages/react/code-connect/AILabel/AILabelContent.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { AILabelContent } from '@carbon/react';

--- a/packages/react/code-connect/Button/Button.figma.tsx
+++ b/packages/react/code-connect/Button/Button.figma.tsx
@@ -1,10 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+
 // @ts-nocheck
 import React from 'react';
 import { Button, ButtonSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/Checkbox/Checkbox.figma.tsx
+++ b/packages/react/code-connect/Checkbox/Checkbox.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Checkbox, CheckboxSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/CodeSnippet/CodeSnippet.figma.tsx
+++ b/packages/react/code-connect/CodeSnippet/CodeSnippet.figma.tsx
@@ -1,10 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+
 // @ts-nocheck
 import React from 'react';
 import { CodeSnippet, CodeSnippetSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/ComboBox/ComboBox.figma.tsx
+++ b/packages/react/code-connect/ComboBox/ComboBox.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { ComboBox, DropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/ComboBox/FluidComboBox.figma.tsx
+++ b/packages/react/code-connect/ComboBox/FluidComboBox.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidComboBox, FluidDropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/ComboButton/ComboButton.figma.tsx
+++ b/packages/react/code-connect/ComboButton/ComboButton.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { ComboButton } from '@carbon/react';

--- a/packages/react/code-connect/ComposedModal/ComposedModal.figma.tsx
+++ b/packages/react/code-connect/ComposedModal/ComposedModal.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React, { useState } from 'react';
 import { ComposedModal } from '@carbon/react';

--- a/packages/react/code-connect/ComposedModal/ModalFooter.figma.tsx
+++ b/packages/react/code-connect/ComposedModal/ModalFooter.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { ModalFooter } from '@carbon/react';

--- a/packages/react/code-connect/ContainedList/ContainedList.figma.tsx
+++ b/packages/react/code-connect/ContainedList/ContainedList.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { ContainedList } from '@carbon/react';

--- a/packages/react/code-connect/ContainedList/ContainedListItem.figma.tsx
+++ b/packages/react/code-connect/ContainedList/ContainedListItem.figma.tsx
@@ -1,10 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+
 // @ts-nocheck
 import React from 'react';
 import { ContainedListItem } from '@carbon/react';

--- a/packages/react/code-connect/DataTable/DataTable.figma.tsx
+++ b/packages/react/code-connect/DataTable/DataTable.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/DataTable/TableCell.figma.tsx
+++ b/packages/react/code-connect/DataTable/TableCell.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TableCell } from '@carbon/react';

--- a/packages/react/code-connect/DataTable/TableHeader.figma.tsx
+++ b/packages/react/code-connect/DataTable/TableHeader.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TableHeader } from '@carbon/react';

--- a/packages/react/code-connect/DataTable/TableRow.figma.tsx
+++ b/packages/react/code-connect/DataTable/TableRow.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/DataTable/TableToolbar.figma.tsx
+++ b/packages/react/code-connect/DataTable/TableToolbar.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/DatePicker/DatePicker.figma.tsx
+++ b/packages/react/code-connect/DatePicker/DatePicker.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { DatePicker, DatePickerInput, DatePickerSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/DatePicker/FluidDatePicker.figma.tsx
+++ b/packages/react/code-connect/DatePicker/FluidDatePicker.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/Dropdown/FluidDropdown.figma.tsx
+++ b/packages/react/code-connect/Dropdown/FluidDropdown.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidDropdown, FluidDropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/FileUploader/FileUploader.figma.tsx
+++ b/packages/react/code-connect/FileUploader/FileUploader.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/Form/Form.figma.tsx
+++ b/packages/react/code-connect/Form/Form.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Form } from '@carbon/react';

--- a/packages/react/code-connect/Menu/Menu.figma.tsx
+++ b/packages/react/code-connect/Menu/Menu.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Menu } from '@carbon/react';

--- a/packages/react/code-connect/Menu/MenuItem.figma.tsx
+++ b/packages/react/code-connect/Menu/MenuItem.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { MenuItem, MenuItemSelectable, MenuItemDivider } from '@carbon/react';

--- a/packages/react/code-connect/MenuButton/MenuButton.figma.tsx
+++ b/packages/react/code-connect/MenuButton/MenuButton.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { MenuButton } from '@carbon/react';

--- a/packages/react/code-connect/MultiSelect/FilterableMultiSelect.figma.tsx
+++ b/packages/react/code-connect/MultiSelect/FilterableMultiSelect.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FilterableMultiSelect, DropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/MultiSelect/FluidFilterableMultiSelect.figma.tsx
+++ b/packages/react/code-connect/MultiSelect/FluidFilterableMultiSelect.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidMultiSelect, FluidDropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/MultiSelect/FluidMultiSelect.figma.tsx
+++ b/packages/react/code-connect/MultiSelect/FluidMultiSelect.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidMultiSelect, FluidDropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/MultiSelect/MultiSelect.figma.tsx
+++ b/packages/react/code-connect/MultiSelect/MultiSelect.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { MultiSelect, DropdownSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/Notification/Notification.figma.tsx
+++ b/packages/react/code-connect/Notification/Notification.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/OverflowMenu/Overflow.figma.tsx
+++ b/packages/react/code-connect/OverflowMenu/Overflow.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { OverflowMenu, OverflowMenuItem } from '@carbon/react';

--- a/packages/react/code-connect/Pagination/Pagination.figma.tsx
+++ b/packages/react/code-connect/Pagination/Pagination.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Pagination } from '@carbon/react';

--- a/packages/react/code-connect/Pagination/PaginationNav.figma.tsx
+++ b/packages/react/code-connect/Pagination/PaginationNav.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { PaginationNav } from '@carbon/react';

--- a/packages/react/code-connect/PasswordInput/FluidPasswordInput.figma.tsx
+++ b/packages/react/code-connect/PasswordInput/FluidPasswordInput.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidPasswordInput, FluidTextInputSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/PasswordInput/PasswordInput.figma.tsx
+++ b/packages/react/code-connect/PasswordInput/PasswordInput.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { PasswordInput, TextInputSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/Popover/Popover.figma.tsx
+++ b/packages/react/code-connect/Popover/Popover.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Popover, PopoverContent } from '@carbon/react';

--- a/packages/react/code-connect/ProgressIndicator/ProgressStep.figma.tsx
+++ b/packages/react/code-connect/ProgressIndicator/ProgressStep.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { ProgressStep } from '@carbon/react';

--- a/packages/react/code-connect/Select/FluidSelect.figma.tsx
+++ b/packages/react/code-connect/Select/FluidSelect.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidSelect, SelectItem } from '@carbon/react';

--- a/packages/react/code-connect/Select/Select.figma.tsx
+++ b/packages/react/code-connect/Select/Select.figma.tsx
@@ -1,10 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+
 // @ts-nocheck
 import React from 'react';
 import { Select, SelectItem, SelectSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/Slider/Slider.figma.tsx
+++ b/packages/react/code-connect/Slider/Slider.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Slider, SliderSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/Slider/SliderRange.figma.tsx
+++ b/packages/react/code-connect/Slider/SliderRange.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 // import React from 'react';
 // import { Slider, SliderSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/StructuredList/StructuredList.figma.tsx
+++ b/packages/react/code-connect/StructuredList/StructuredList.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/Tabs/Tab.figma.tsx
+++ b/packages/react/code-connect/Tabs/Tab.figma.tsx
@@ -1,10 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+
 // @ts-nocheck
 import React from 'react';
 import { Tab, IconTab } from '@carbon/react';

--- a/packages/react/code-connect/Tabs/Tabs.figma.tsx
+++ b/packages/react/code-connect/Tabs/Tabs.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/Tag/Tag.figma.tsx
+++ b/packages/react/code-connect/Tag/Tag.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/TextArea/FluidTextArea.figma.tsx
+++ b/packages/react/code-connect/TextArea/FluidTextArea.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidTextArea } from '@carbon/react';

--- a/packages/react/code-connect/TextArea/TextArea.figma.tsx
+++ b/packages/react/code-connect/TextArea/TextArea.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TextArea, TextAreaSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/TextInput/FluidTextInput.figma.tsx
+++ b/packages/react/code-connect/TextInput/FluidTextInput.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { FluidTextInput, FluidTextInputSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/TextInput/TextInput.figma.tsx
+++ b/packages/react/code-connect/TextInput/TextInput.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TextInput, TextInputSkeleton } from '@carbon/react';

--- a/packages/react/code-connect/Tile/Tile.figma.tsx
+++ b/packages/react/code-connect/Tile/Tile.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/TimePicker/FluidTimePicker.figma.tsx
+++ b/packages/react/code-connect/TimePicker/FluidTimePicker.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/TimePicker/TimePicker.figma.tsx
+++ b/packages/react/code-connect/TimePicker/TimePicker.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TimePicker, TimePickerSelect, SelectItem } from '@carbon/react';

--- a/packages/react/code-connect/Toggletip/Toggletip.figma.tsx
+++ b/packages/react/code-connect/Toggletip/Toggletip.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Toggletip, ToggletipLabel, ToggletipButton } from '@carbon/react';

--- a/packages/react/code-connect/Tooltip/Tooltip.figma.tsx
+++ b/packages/react/code-connect/Tooltip/Tooltip.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { DefinitionTooltip, Tooltip } from '@carbon/react';

--- a/packages/react/code-connect/TreeView/TreeNode.figma.tsx
+++ b/packages/react/code-connect/TreeView/TreeNode.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TreeNode } from '@carbon/react';

--- a/packages/react/code-connect/TreeView/TreeView.figma.tsx
+++ b/packages/react/code-connect/TreeView/TreeView.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { TreeView } from '@carbon/react';

--- a/packages/react/code-connect/UIShell/Header.figma.tsx
+++ b/packages/react/code-connect/UIShell/Header.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import {

--- a/packages/react/code-connect/UIShell/HeaderGlobalAction.figma.tsx
+++ b/packages/react/code-connect/UIShell/HeaderGlobalAction.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { HeaderGlobalAction } from '@carbon/react';

--- a/packages/react/code-connect/UIShell/HeaderMenuButton.figma.tsx
+++ b/packages/react/code-connect/UIShell/HeaderMenuButton.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { HeaderMenuButton } from '@carbon/react';

--- a/packages/react/code-connect/UIShell/HeaderMenuItem.figma.tsx
+++ b/packages/react/code-connect/UIShell/HeaderMenuItem.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { HeaderMenu, HeaderMenuItem } from '@carbon/react';

--- a/packages/react/code-connect/UIShell/HeaderPanel.figma.tsx
+++ b/packages/react/code-connect/UIShell/HeaderPanel.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { Header, HeaderPanel } from '@carbon/react';

--- a/packages/react/code-connect/UIShell/SideNav.figma.tsx
+++ b/packages/react/code-connect/UIShell/SideNav.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { SideNav, SideNavItems, SideNavMenu } from '@carbon/react';

--- a/packages/react/code-connect/UIShell/SideNavMenuItem.figma.tsx
+++ b/packages/react/code-connect/UIShell/SideNavMenuItem.figma.tsx
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
 // @ts-nocheck
 import React from 'react';
 import { SideNavMenu, SideNavMenuItem } from '@carbon/react';

--- a/packages/web-components/src/components/date-picker/range-plugin.ts
+++ b/packages/web-components/src/components/date-picker/range-plugin.ts
@@ -1,12 +1,10 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-// @ts-nocheck
 import rangePlugin from 'flatpickr/dist/esm/plugins/rangePlugin.js';
 import type { Config } from 'flatpickr/dist/plugins/rangePlugin';
 import { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Allowed `ts-nocheck` in Figma files.

### Changelog

**Changed**

- Allowed `ts-nocheck` in Figma files.

#### Testing / Reviewing

I updated the names of some files for consistency and to ensure the ESLint directive would apply to them.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
