### PR TITLE
refactor: replace deprecated MutableRefObject types

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -28,6 +28,7 @@ import React, {
   type ReactElement,
   type ReactNode,
   type RefAttributes,
+  type RefObject,
 } from 'react';
 import { Text } from '../Text';
 import {
@@ -223,9 +224,7 @@ export interface ComboBoxProps<ItemType>
    * cases they can not be shimmed by Carbon to shield you from potentially breaking
    * changes.
    */
-  downshiftActions?: React.MutableRefObject<
-    UseComboboxActions<ItemType> | undefined
-  >;
+  downshiftActions?: RefObject<UseComboboxActions<ItemType> | undefined>;
 
   /**
    * Provide helper text that is used alongside the control label for

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2025
+ * Copyright IBM Corp. 2023, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,7 +14,6 @@ import React, {
   type HTMLAttributes,
   type KeyboardEvent,
   type MouseEvent,
-  type MutableRefObject,
   type ReactElement,
   type ReactNode,
   type RefObject,
@@ -296,9 +295,7 @@ const ComposedModalDialog = React.forwardRef<
   const button = useRef<HTMLButtonElement>(null);
   const startSentinel = useRef<HTMLButtonElement>(null);
   const endSentinel = useRef<HTMLButtonElement>(null);
-  const onMouseDownTarget: MutableRefObject<Node | null> = useRef<Node | null>(
-    null
-  );
+  const onMouseDownTarget = useRef<Node | null>(null);
 
   const presenceContext = useContext(ComposedModalPresenceContext);
   const mergedRefs = useMergeRefs([ref, presenceContext?.presenceRef]);

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,6 @@
 
 import PropTypes from 'prop-types';
 import React, {
-  MutableRefObject,
   useEffect,
   useRef,
   useState,
@@ -146,8 +145,7 @@ const Dialog = React.forwardRef(
     // will be null. A "backup" ref is needed to ensure the dialog's instance
     // methods can always be called within this component.
     const backupRef = useRef<HTMLDialogElement>(null);
-    const ref = (forwardRef ??
-      backupRef) as MutableRefObject<HTMLDialogElement>;
+    const ref = (forwardRef ?? backupRef) as RefObject<HTMLDialogElement>;
 
     // Clicks on the backdrop of an open modal dialog should request the consuming component to close
     // the dialog. Clicks elsewhere, or on non-modal dialogs should not request
@@ -618,7 +616,7 @@ const DialogBody = React.forwardRef<HTMLDivElement, DialogBodyProps>(
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
-        (ref as React.MutableRefObject<HTMLDivElement>).current = el;
+        ref.current = el;
       }
       contentRef.current = el;
     };

--- a/packages/react/src/components/ListBox/ListBoxMenuItem.tsx
+++ b/packages/react/src/components/ListBox/ListBoxMenuItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,9 +12,9 @@ import React, {
   useRef,
   useState,
   type HTMLAttributes,
-  type MutableRefObject,
   type ReactNode,
   type Ref,
+  type RefObject,
 } from 'react';
 import PropTypes from 'prop-types';
 import { usePrefix } from '../../internal/usePrefix';
@@ -98,7 +98,7 @@ const ListBoxMenuItem = forwardRef<HTMLLIElement, ListBoxMenuItemProps>(
     const menuItemOptionRefProp =
       forwardedRef && typeof forwardedRef !== 'function'
         ? (
-            forwardedRef as MutableRefObject<HTMLLIElement | null> & {
+            forwardedRef as RefObject<HTMLLIElement | null> & {
               menuItemOptionRef?: Ref<HTMLDivElement>;
             }
           ).menuItemOptionRef

--- a/packages/react/src/components/SkeletonText/SkeletonText.tsx
+++ b/packages/react/src/components/SkeletonText/SkeletonText.tsx
@@ -1,12 +1,12 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React, { MutableRefObject, ReactNode, useRef } from 'react';
+import React, { useRef, type ReactNode } from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import useIsomorphicEffect from '../../internal/useIsomorphicEffect';
@@ -69,7 +69,7 @@ const SkeletonText = ({
     lineCountNumber = lineCount;
   }
 
-  const refs: MutableRefObject<(HTMLParagraphElement | null)[]> = useRef([]);
+  const refs = useRef<(HTMLParagraphElement | null)[]>([]);
 
   useIsomorphicEffect(() => {
     refs.current.map((item, j) => {

--- a/packages/react/src/components/Text/TextDirectionContext.ts
+++ b/packages/react/src/components/Text/TextDirectionContext.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createContext, type MutableRefObject } from 'react';
+import { createContext, type RefObject } from 'react';
 
 export type TextDir = 'ltr' | 'rtl' | 'auto' | string;
 
@@ -13,7 +13,7 @@ export type GetTextDirection = (text: string | string[] | undefined) => TextDir;
 
 export interface TextDirectionContextType {
   direction: TextDir;
-  getTextDirection: MutableRefObject<GetTextDirection | undefined>;
+  getTextDirection: RefObject<GetTextDirection | undefined>;
 }
 
 export const TextDirectionContext = createContext<TextDirectionContextType>({

--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,7 +17,6 @@ import React, {
   type ElementType,
   type FocusEvent,
   type MouseEvent,
-  type MutableRefObject,
 } from 'react';
 import { keys, match, matches } from '../../internal/keyboard';
 import { deprecate } from '../../prop-types/deprecate';
@@ -346,8 +345,7 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
       if (typeof forwardedRef === 'function') {
         forwardedRef(element);
       } else if (forwardedRef) {
-        (forwardedRef as MutableRefObject<HTMLElement | null>).current =
-          element;
+        forwardedRef.current = element;
       }
     };
 


### PR DESCRIPTION
No issue.

Replaced deprecated `MutableRefObject` types.

### Changelog

**Changed**

- Replaced deprecated `MutableRefObject` types.

#### Testing / Reviewing

Check for type errors.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
