### PR TITLE
fix: drop title a11y handling and address todos

### DIFF
--- a/config/jest-config-carbon/setup/setup.js
+++ b/config/jest-config-carbon/setup/setup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,9 +9,7 @@ import { jest } from '@jest/globals';
 
 jest.setTimeout(20000);
 
-global.requestAnimationFrame = function requestAnimationFrame(callback) {
-  // TODO: replace with async version
-  // setTimeout(callback);
+global.requestAnimationFrame = (callback) => {
   callback();
 };
 

--- a/packages/icon-helpers/README.md
+++ b/packages/icon-helpers/README.md
@@ -42,8 +42,8 @@ const attributes = getAttributes({ width: 20, height: 20 });
 ```
 
 In order for the icon to be considered focusable, you will need to provide
-either `aria-label`, `aria-labelledby`, or `title` in the given `attributes` in
-addition to `tabindex`. For example:
+either `aria-label` or `aria-labelledby` in the given `attributes` in addition
+to `tabindex`. For example:
 
 ```js
 const { getAttributes } = require('@carbon/icon-helpers');

--- a/packages/icon-helpers/src/__tests__/getAttributes-test.js
+++ b/packages/icon-helpers/src/__tests__/getAttributes-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ describe('getAttributes', () => {
   // currently is that if we are provided a tabindex in addition to an aria
   // label then we can set focusable and tabindex on the result attribute set.
   // However, if we get ONLY tabindex then we do not pass it along as the SVG
-  // should have an aria label (or title) available.
+  // should have an aria label available.
   test.each([
     [
       'false',
@@ -66,21 +66,6 @@ describe('getAttributes', () => {
         'aria-labelledby': 'id',
       },
     ],
-    [
-      'true',
-      'title and tabindex',
-      {
-        title: 'title',
-        tabindex: 0,
-      },
-    ],
-    [
-      'false',
-      'only title',
-      {
-        title: 'title',
-      },
-    ],
   ])(
     'should set `focusable="%s"` when using %s',
     (focusable, _, attributes) => {
@@ -94,7 +79,7 @@ describe('getAttributes', () => {
     }
   );
 
-  test.each(['aria-label', 'aria-labelledby', 'title'])(
+  test.each(['aria-label', 'aria-labelledby'])(
     'should set role and remove aria-hidden if `%s` is set',
     (attr) => {
       const attrs = getAttributes({

--- a/packages/icon-helpers/src/getAttributes.ts
+++ b/packages/icon-helpers/src/getAttributes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2018, 2024
+ * Copyright IBM Corp. 2018, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,13 +33,7 @@ export default function getAttributes({
     viewBox,
   };
 
-  // TODO: attributes.title assumes that the consumer will implement <title> and
-  // correctly set `aria-labelledby`.
-  if (
-    iconAttributes['aria-label'] ||
-    iconAttributes['aria-labelledby'] ||
-    iconAttributes.title
-  ) {
+  if (iconAttributes['aria-label'] || iconAttributes['aria-labelledby']) {
     iconAttributes.role = 'img';
 
     // Reference:

--- a/packages/icons-react/.gitignore
+++ b/packages/icons-react/.gitignore
@@ -1,2 +1,0 @@
-# TODO: remove in v11
-/next

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2025
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -119,13 +119,8 @@ describe('DataTable', () => {
             <Table {...getTableProps()}>
               <TableHead>
                 <TableRow>
-                  {headers.map((header, i) => (
-                    // TODO: `getHeaderProps` returns a `key`. Using it instead
-                    // of overwriting it with the `key` prop may improve test
-                    // coverage.
-                    //
-                    // This comment applies here and elsewhere.
-                    <TableHeader key={i} {...getHeaderProps({ header })}>
+                  {headers.map((header) => (
+                    <TableHeader {...getHeaderProps({ header })}>
                       {header.header}
                     </TableHeader>
                   ))}
@@ -133,10 +128,6 @@ describe('DataTable', () => {
               </TableHead>
               <TableBody>
                 {rows.map((row) => (
-                  // TODO: `getRowProps` returns a `key`. Using it may improve
-                  // test coverage.
-                  //
-                  // This comment applies here and elsewhere.
                   <TableRow {...getRowProps({ row })}>
                     {row.cells.map((cell) => (
                       <TableCell {...getCellProps({ cell })}>
@@ -396,8 +387,8 @@ describe('DataTable', () => {
                   <TableHead>
                     <TableRow>
                       <TableSelectAll {...getSelectionProps()} />
-                      {headers.map((header, i) => (
-                        <TableHeader key={i} {...getHeaderProps({ header })}>
+                      {headers.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })}>
                           {header.header}
                         </TableHeader>
                       ))}
@@ -568,8 +559,8 @@ describe('DataTable', () => {
                   <TableHead>
                     <TableRow>
                       <TableSelectAll {...getSelectionProps()} />
-                      {headers.map((header, i) => (
-                        <TableHeader key={i} {...getHeaderProps({ header })}>
+                      {headers.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })}>
                           {header.header}
                         </TableHeader>
                       ))}
@@ -711,8 +702,8 @@ describe('DataTable', () => {
                 <Table>
                   <TableHead>
                     <TableRow>
-                      {headers.map((header, i) => (
-                        <TableHeader key={i} {...getHeaderProps({ header })}>
+                      {headers.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })}>
                           {header.header}
                         </TableHeader>
                       ))}
@@ -842,8 +833,8 @@ describe('DataTable', () => {
                     <TableRow>
                       <TableExpandHeader {...getExpandHeaderProps()} />
                       <TableSelectAll {...getSelectionProps()} />
-                      {headers.map((header, i) => (
-                        <TableHeader key={i} {...getHeaderProps({ header })}>
+                      {headers.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })}>
                           {header.header}
                         </TableHeader>
                       ))}
@@ -1102,9 +1093,7 @@ describe('DataTable', () => {
                 <TableHead>
                   <TableRow>
                     {headers.map((header) => (
-                      <TableHeader
-                        key={header.key}
-                        {...getHeaderProps({ header })}>
+                      <TableHeader {...getHeaderProps({ header })}>
                         {header.header}
                       </TableHeader>
                     ))}
@@ -1166,9 +1155,7 @@ describe('DataTable', () => {
                 <TableHead>
                   <TableRow>
                     {headers.map((header) => (
-                      <TableHeader
-                        key={header.key}
-                        {...getHeaderProps({ header })}>
+                      <TableHeader {...getHeaderProps({ header })}>
                         {header.header}
                       </TableHeader>
                     ))}
@@ -1252,9 +1239,7 @@ describe('DataTable', () => {
                 <TableHead>
                   <TableRow>
                     {headers.map((header) => (
-                      <TableHeader
-                        key={header.key}
-                        {...getHeaderProps({ header })}>
+                      <TableHeader {...getHeaderProps({ header })}>
                         {header.header}
                       </TableHeader>
                     ))}
@@ -1328,9 +1313,7 @@ describe('DataTable', () => {
                 <TableHead>
                   <TableRow>
                     {headers.map((header) => (
-                      <TableHeader
-                        key={header.key}
-                        {...getHeaderProps({ header })}>
+                      <TableHeader {...getHeaderProps({ header })}>
                         {header.header}
                       </TableHeader>
                     ))}

--- a/packages/react/src/components/DataTable/__tests__/TableExpandHeader-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableExpandHeader-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -150,8 +150,8 @@ describe('TableExpandHeader', () => {
                       enableToggle={true}
                       {...getExpandHeaderProps({ onExpand })}
                     />
-                    {headers.map((header, i) => (
-                      <TableHeader key={i} {...getHeaderProps({ header })}>
+                    {headers.map((header) => (
+                      <TableHeader {...getHeaderProps({ header })}>
                         {header.header}
                       </TableHeader>
                     ))}
@@ -246,9 +246,7 @@ describe('TableExpandHeader', () => {
                         {...getExpandHeaderProps()}
                       />
                       {headers.map((header) => (
-                        <TableHeader
-                          key={header.key}
-                          {...getHeaderProps({ header })}>
+                        <TableHeader {...getHeaderProps({ header })}>
                           {header.header}
                         </TableHeader>
                       ))}


### PR DESCRIPTION
No issue.

Dropped `title` accessibility handling in `getAttributes` icon helper and addressed `TODO`s.

### Changelog


**Changed**

- Addressed `TODO`s.

**Removed**

- Dropped `title` accessibility handling in `getAttributes` icon helper.

#### Testing / Reviewing

I removed `title` handling in `getAttributes` because it implied accessibility support the function didn't actually implement. `getAttributes` can't create a `<title>` element or wire up `aria-labelledby`, so treating `title` as a valid accessible name was misleading and could produce icons with `role="img"` but no real accessible name.

Limiting the logic to `aria-label` and `aria-labelledby` keeps behavior aligned with what the function can guarantee, avoids an accessibility pitfall, and matches docs/tests until `<title>` injection is implemented elsewhere.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
