### PR TITLE
fix(file-uploader): ignore directories on drop

### DIFF
--- a/packages/react/src/components/FileUploader/__tests__/FileUploaderDropContainer-test.js
+++ b/packages/react/src/components/FileUploader/__tests__/FileUploaderDropContainer-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -555,6 +555,33 @@ describe('FileUploaderDropContainer', () => {
 
     expect(onAddFiles).toHaveBeenCalledWith(expect.anything(), {
       addedFiles: [files[0]],
+    });
+  });
+
+  it('should ignore directory items dropped via dataTransfer.items', () => {
+    const onAddFiles = jest.fn();
+    const { container } = render(
+      <FileUploaderDropContainer onAddFiles={onAddFiles} {...requiredProps} />
+    );
+    const dropArea = container.firstChild;
+    const directoryItem = {
+      kind: 'file',
+      getAsFile: jest.fn(() => null),
+      webkitGetAsEntry: jest.fn(() => ({ isDirectory: true })),
+    };
+    const dropEvent = {
+      dataTransfer: {
+        items: [directoryItem],
+        files: [],
+      },
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    };
+
+    fireEvent.drop(dropArea, dropEvent);
+
+    expect(onAddFiles).toHaveBeenCalledWith(expect.anything(), {
+      addedFiles: [],
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21012

Ignored directories on drop in `FileUploaderDropContainer`.

### Changelog

**Changed**

- Ignored directories on drop in `FileUploaderDropContainer`.
- Converted handlers to arrow functions for consistency.

#### Testing / Reviewing

Reference commits: https://github.com/carbon-design-system/carbon/compare/7eb98cd59033a31356aa42af4f0728ec9e89b1f9...2945ee96c5dd863a2c9f7ca046b38e9b81cdbc8b

`FileUploaderDropContainer` was accepting directory drops even when only files should be allowed. When a directory was dragged into the component, they were exposed through `dataTransfer.items`. The component treated these entries as valid files or in some cases fell back to an empty file list.

The fix filters dropped items to exclude directories and normalizes the drop payload so that it contains only actual `File` objects. It also handles empty drops to prevent validation from running on `undefined`, ensuring that only valid files are passed to `onAddFiles`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
