### PR TITLE
feat: add badgeCount prop and add badge functionality tests

### DIFF
--- a/packages/react/src/components/UIShell/HeaderGlobalAction.tsx
+++ b/packages/react/src/components/UIShell/HeaderGlobalAction.tsx
@@ -9,7 +9,9 @@ import cx from 'classnames';
 import React, { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
+import BadgeIndicator from '../BadgeIndicator';
 import Button from '../Button';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 
 export interface HeaderGlobalActionProps {
@@ -61,6 +63,12 @@ export interface HeaderGlobalActionProps {
    * Default is true
    */
   tooltipHighContrast?: boolean;
+
+  /**
+   * **Experimental**: Display a badge on the button. An empty/dot badge if 0, a numbered badge if > 0.
+   * Must be used with size="lg" and kind="ghost"
+   */
+  badgeCount?: number;
 }
 
 /**
@@ -79,8 +87,10 @@ const HeaderGlobalAction = React.forwardRef<
     {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      badgeCount,
       children,
       className: customClassName,
+      disabled,
       onClick,
       tooltipHighContrast = true,
       tooltipDropShadow,
@@ -91,6 +101,7 @@ const HeaderGlobalAction = React.forwardRef<
     ref
   ) => {
     const prefix = usePrefix();
+    const badgeId = useId('badge-indicator');
     const className = cx({
       [customClassName as string]: !!customClassName,
       [`${prefix}--header__action`]: true,
@@ -99,6 +110,7 @@ const HeaderGlobalAction = React.forwardRef<
     const accessibilityLabel = {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': rest['aria-describedby'] || (badgeCount !== undefined ? badgeId : undefined),
     };
     return (
       <Button
@@ -117,6 +129,12 @@ const HeaderGlobalAction = React.forwardRef<
         tooltipHighContrast={tooltipHighContrast}
         ref={ref}>
         {children}
+        {!disabled && badgeCount !== undefined && (
+          <BadgeIndicator
+            id={badgeId}
+            count={badgeCount > 0 ? badgeCount : undefined}
+          />
+        )}
       </Button>
     );
   }
@@ -166,6 +184,12 @@ HeaderGlobalAction.propTypes = {
    * Default is true
    */
   tooltipHighContrast: PropTypes.bool,
+
+  /**
+   * **Experimental**: Display a badge on the button. An empty/dot badge if 0, a numbered badge if > 0.
+   * Must be used with size="lg" and kind="ghost"
+   */
+  badgeCount: PropTypes.number,
 };
 
 HeaderGlobalAction.displayName = 'HeaderGlobalAction';

--- a/packages/react/src/components/UIShell/__tests__/HeaderGlobalAction-test.js
+++ b/packages/react/src/components/UIShell/__tests__/HeaderGlobalAction-test.js
@@ -83,4 +83,50 @@ describe('HeaderGlobalAction', () => {
 
     expect(onClick).toHaveBeenCalled();
   });
+
+  it('should render badge indicator when badgeCount is provided', () => {
+    render(
+      <HeaderGlobalAction aria-label="test" badgeCount={5}>
+        <svg />
+      </HeaderGlobalAction>
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByLabelText('test')).toHaveAttribute('aria-describedby');
+  });
+
+  it('should render dot badge when badgeCount is 0', () => {
+    render(
+      <HeaderGlobalAction aria-label="test" badgeCount={0}>
+        <svg />
+      </HeaderGlobalAction>
+    );
+
+    // When badgeCount is 0, BadgeIndicator renders without count (dot style)
+    const badgeIndicator = document.querySelector('.cds--badge-indicator');
+    expect(badgeIndicator).toBeInTheDocument();
+    expect(badgeIndicator).not.toHaveTextContent('0');
+  });
+
+  it('should not render badge indicator when badgeCount is undefined', () => {
+    render(
+      <HeaderGlobalAction aria-label="test">
+        <svg />
+      </HeaderGlobalAction>
+    );
+
+    const badgeIndicator = document.querySelector('.cds--badge-indicator');
+    expect(badgeIndicator).not.toBeInTheDocument();
+  });
+
+  it('should not render badge indicator when disabled', () => {
+    render(
+      <HeaderGlobalAction aria-label="test" badgeCount={3} disabled>
+        <svg />
+      </HeaderGlobalAction>
+    );
+
+    const badgeIndicator = document.querySelector('.cds--badge-indicator');
+    expect(badgeIndicator).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## PR Description

### **Add badge support to HeaderGlobalAction**

- Adds badgeCount prop to HeaderGlobalAction for notification badges.

Closes #21355

### Changelog

**New**

- badgeCount prop for badges
- Auto-hide when disabled/undefined  
- aria-describedby accessibility

**Changed**

- HeaderGlobalAction with badge rendering