### PR TITLE
fix: set up maxHeight config for carousel utility

### DIFF
--- a/packages/utilities/src/carousel/README.md
+++ b/packages/utilities/src/carousel/README.md
@@ -15,10 +15,8 @@ building swipeable, carousel like components
 ## Getting started
 
 The utility can be initialized from any on-load function by passing in the
-carousel container element. You may optionally set a height on the container—if
-not provided, the utility will automatically use the smallest height among the
-items. Once initialized, it returns a set of APIs that enable programmatic
-navigation between views.
+carousel container element. Once initialized, it returns a set of APIs that
+enable programmatic navigation between views.
 
 By default, the carousel responds to swipe gestures, horizontal scroll gestures,
 and click-and-drag interactions. To disable this behavior, you can set the
@@ -52,6 +50,133 @@ carousel.next();
 carousel.prev();
 carousel.goToIndex(2);
 carousel.reset();
+```
+
+## Height Management
+
+The carousel automatically calculates and manages the height of the carousel
+container based on the content of the carousel items. Understanding how height
+is calculated helps you control the carousel's appearance.
+
+### Height Calculation Modes
+
+#### Default Mode (Minimum Height)
+
+By default, the carousel calculates height based on the **smallest item**:
+
+```ts
+const carousel = initCarousel(container);
+// Uses the smallest item height (minimum 10rem/160px)
+```
+
+**How it works:**
+
+- Finds the smallest height among all carousel items
+- Enforces a minimum threshold of **4rem ** at default font size
+- If the smallest item is less than the threshold, uses the threshold height
+- Ensures all items fit within the container without overflow
+
+#### Maximum Height Mode
+
+Use `useMaxHeight: true` to calculate based on the **largest item**:
+
+```ts
+const carousel = initCarousel(container, {
+  useMaxHeight: true,
+});
+// Uses the largest item height
+```
+
+**How it works:**
+
+- Finds the largest height among all carousel items
+- Sets the container to accommodate the tallest item
+- Ensures the tallest item is fully visible without scrolling
+- All items are positioned absolutely within this maximum height
+
+### Controlling Carousel Height
+
+You have several options to control the carousel height:
+
+#### 1. Use the `useMaxHeight` Configuration
+
+```ts
+// Use maximum item height
+const carousel = initCarousel(container, {
+  useMaxHeight: true,
+});
+```
+
+#### 2. Set CSS Height on the Container
+
+The carousel respects any height set via CSS. If the container height is greater
+than the minimum threshold (4rem), automatic height calculation is bypassed:
+
+```css
+#myCarousel {
+  height: 500px; /* Fixed height */
+}
+```
+
+```ts
+const carousel = initCarousel(document.getElementById('myCarousel'));
+// Will use the 500px height from CSS
+```
+
+#### 3. Set Height on Individual Items
+
+You can set explicit heights on carousel items, and the carousel will calculate
+based on those heights:
+
+```css
+#myCarousel > div {
+  height: 300px;
+}
+```
+
+```ts
+const carousel = initCarousel(document.getElementById('myCarousel'));
+// Will calculate based on 300px item heights
+```
+
+### Height Calculation Examples
+
+**Example 1: Variable height items (default mode)**
+
+```html
+<div id="carousel">
+  <div style="height: 200px">Slide 1</div>
+  <div style="height: 300px">Slide 2</div>
+  <div style="height: 250px">Slide 3</div>
+</div>
+```
+
+```ts
+const carousel = initCarousel(document.getElementById('carousel'));
+// Container height will be 200px (smallest item)
+```
+
+**Example 2: Variable height items (max height mode)**
+
+```ts
+const carousel = initCarousel(document.getElementById('carousel'), {
+  useMaxHeight: true,
+});
+// Container height will be 300px (largest item)
+```
+
+**Example 3: Fixed container height**
+
+```html
+<div id="carousel" style="height: 400px">
+  <div>Slide 1</div>
+  <div>Slide 2</div>
+</div>
+```
+
+```ts
+const carousel = initCarousel(document.getElementById('carousel'));
+// Container height remains 400px (CSS takes precedence)
 ```
 
 ## Styling

--- a/packages/utilities/src/carousel/carousel.ts
+++ b/packages/utilities/src/carousel/carousel.ts
@@ -10,6 +10,7 @@ import {
   CarouselResponse,
   CarouselStackHistory,
   Config,
+  CarouselHTMLElement,
 } from './types';
 import { registerSwipeEvents } from './swipeEvents';
 
@@ -26,12 +27,16 @@ export const initCarousel = (
   const prefix = 'carousel';
   let viewIndexStack = [0];
   let previousViewIndexStack = [0];
-  const refs: Record<number, HTMLElement | null> = {};
+  const refs: Record<number, CarouselHTMLElement | null> = {};
 
-  const minHeight = 10; // 10 rem
+  const minHeight = 4; // 4 rem
 
-  const { onViewChangeStart, onViewChangeEnd, excludeSwipeSupport } =
-    config || {};
+  const {
+    onViewChangeStart,
+    onViewChangeEnd,
+    excludeSwipeSupport,
+    useMaxHeight,
+  } = config || {};
 
   /**
    * Registers an HTMLElement at a specific index in the refs array.
@@ -70,7 +75,7 @@ export const initCarousel = (
   const getHistory = () => {
     return viewIndexStack.map((id) => ({
       id,
-      elem: refs[id],
+      elem: refs[id] as HTMLLIElement,
     }));
   };
   /**
@@ -145,11 +150,9 @@ export const initCarousel = (
    * Handles the 'transitionend' event for a given element.
    * This function checks if the element has a 'data-index' attribute and if its value matches the current view index.
    * If both conditions are met, it calls the 'onViewChangeEnd' callback with the response from 'getCallbackResponse'.
-   *
-   * @param {HTMLElement | null} el - The element to handle the 'transitionend' event for.
    * @returns {void}
    */
-  const transitionToViewIndex = (idx: number) => {
+  const transitionToViewIndex = (idx: number): void => {
     const sanitizedIndex = sanitizeIndex(idx);
     if (viewIndexStack[0] !== sanitizedIndex) {
       handleTransitionStart();
@@ -240,6 +243,8 @@ export const initCarousel = (
    */
   const performAnimation = (isInitial: boolean) => {
     let itemHeightSmallest = 0;
+    let itemHeightMaximum = 0;
+
     Array.from(viewItems).forEach((viewItem: HTMLElement, index) => {
       const stackIndex = viewIndexStack.findIndex((idx) => idx === index);
       const stackIndexInstanceCount = previousViewIndexStack.filter(
@@ -271,15 +276,25 @@ export const initCarousel = (
         registerRef(index, viewItem);
 
         setTimeout(() => {
-          if (
-            !itemHeightSmallest ||
-            (viewItem.offsetHeight < itemHeightSmallest &&
-              itemHeightSmallest > remToPx(minHeight))
-          ) {
-            itemHeightSmallest = viewItem.offsetHeight;
+          if (useMaxHeight) {
+            const heights: number[] = Array.from(viewItems).map(
+              (viewItem) => viewItem.scrollHeight
+            );
+            itemHeightMaximum = Math.max(...heights);
+
+            viewItem.style.position = 'absolute';
+            updateHeightForWrapper(itemHeightMaximum);
+          } else {
+            if (
+              !itemHeightSmallest ||
+              (viewItem.offsetHeight < itemHeightSmallest &&
+                itemHeightSmallest > remToPx(minHeight))
+            ) {
+              itemHeightSmallest = viewItem.offsetHeight;
+            }
+            viewItem.style.position = 'absolute';
+            updateHeightForWrapper(itemHeightSmallest);
           }
-          viewItem.style.position = 'absolute';
-          updateHeightForWrapper(itemHeightSmallest);
         });
 
         const listener = (e: Event) => {
@@ -290,8 +305,7 @@ export const initCarousel = (
           }
         };
         // store reference on the element for later removal
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-        (viewItem as any)._carouselListener = listener;
+        (viewItem as CarouselHTMLElement)._carouselListener = listener;
 
         viewItem.addEventListener('animationend', listener);
         viewItem.addEventListener('transitionend', listener);
@@ -366,12 +380,10 @@ export const initCarousel = (
    */
   const destroyEvents = () => {
     Object.values(refs).forEach((el) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-      if (el && (el as any)._carouselListener) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-        el.removeEventListener('animationend', (el as any)._carouselListener);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-        el.removeEventListener('transitionend', (el as any)._carouselListener);
+      const carouselEl = el as CarouselHTMLElement;
+      if (el && carouselEl._carouselListener) {
+        el.removeEventListener('animationend', carouselEl._carouselListener);
+        el.removeEventListener('transitionend', carouselEl._carouselListener);
       }
     });
     if (!excludeSwipeSupport) {
@@ -416,7 +428,7 @@ export const initCarousel = (
     reset,
     goToIndex,
     getActiveItem,
-    destroyEvents: destroyEvents,
+    destroyEvents,
     allViews: refs,
   };
 };

--- a/packages/utilities/src/carousel/types.ts
+++ b/packages/utilities/src/carousel/types.ts
@@ -9,6 +9,9 @@ interface CarouselStackHistory {
   id: number;
   elem: HTMLLIElement;
 }
+export interface CarouselHTMLElement extends HTMLElement {
+  _carouselListener?: EventListener;
+}
 
 type CarouselResponse = {
   currentIndex: number;
@@ -26,6 +29,7 @@ export type Config = {
   onViewChangeStart?: (args: CarouselResponse) => void;
   onViewChangeEnd?: (args: CarouselResponse) => void;
   excludeSwipeSupport?: boolean;
+  useMaxHeight?: boolean;
 };
 
 interface InitCarousel {


### PR DESCRIPTION
Closes [#8857](https://github.com/carbon-design-system/ibm-products/issues/8857)

Currently, the carousel utility calculates item height based on the carousel container. If no container height is available, it falls back to the minimum item height.

We need to add a configuration option (useMaxHeight) to allow using the maximum height of the items instead. The height management options should also be updated in the README.

Also fixed few ts errors

### Changelog



**Changed**

- packages/utilities/src/carousel/README.md
- packages/utilities/src/carousel/carousel.ts
- packages/utilities/src/carousel/types.ts



#### Testing / Reviewing

locally in storybook

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
