### PR TITLE
fix(carouselUtility): remove recycle classes on reset to avoid glitch

### DIFF
--- a/packages/utilities/src/carousel/carousel.ts
+++ b/packages/utilities/src/carousel/carousel.ts
@@ -370,6 +370,13 @@ export const initCarousel = (
    * @returns {void}
    */
   const reset = () => {
+    // Remove recycle classes from all views before resetting
+    Array.from(viewItems).forEach((viewItem: HTMLElement) => {
+      removeReCycleClasses(viewItem);
+    });
+
+    // Update previous stack to avoid recycle-out class being applied
+    previousViewIndexStack = [0];
     viewIndexStack = [0];
     performAnimation(false);
   };


### PR DESCRIPTION
Contributes [#7411](https://github.com/carbon-design-system/ibm-products/issues/7411)

We need to remove the recycle classes that was applied while calling `reset` api to avoid a visual glitch.

### Changelog





**Changed**

- carousel.ts



#### Testing / Reviewing

local 

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
