### PR TITLE
fix(datepicker): react storybook update locale control usage

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.stories.js
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.js
@@ -119,7 +119,7 @@ const sharedArgTypes = {
 };
 
 export const Default = ({ readOnly, ...args }) => {
-  const locale = useDocumentLang();
+  const locale = useDocumentLang().split('-')[0];
   return (
     <DatePicker
       datePickerType="single"


### PR DESCRIPTION
Closes #

updates the story to pass only the language code 'ja' and omit country code '-JP'. as the Datepicker seems to accept only language code. and doesn't seem to respond to full string 'ja-JP'

screenshot of error on localhost
<img width="592" height="143" alt="Screenshot 2026-01-29 at 3 43 46 PM" src="https://github.com/user-attachments/assets/319c6015-d709-4f89-85a9-bb64223280c0" />

i have also referred number input, which accepts full string without issues. so if the datepicker need to be enhanced to support full string. for consistency. lets discuss and open an enhancement issue.

### Changelog

**Changed**

- const locale = useDocumentLang().split('-')[0];

#### Testing / Reviewing

Make sure the language updates the component Datepicker. from the locale control from the storybook toolbar.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
