### PR TITLE
fix: add missing web component breakpoints for column

### DIFF
--- a/packages/web-components/src/components/grid/column.ts
+++ b/packages/web-components/src/components/grid/column.ts
@@ -27,7 +27,7 @@ export type ColumnSpec =
 class CDSColumn extends LitElement {
   /**
    * Specify column size
-   * Keys sm, md or lg
+   * Keys sm, md, lg, xlg, max
    *
    * Values
    * - N, P, { span:N start:S}, { start: S, end: E}
@@ -44,6 +44,12 @@ class CDSColumn extends LitElement {
 
   @property({ reflect: true })
   lg?: ColumnSpec;
+
+  @property({ reflect: true })
+  xlg?: ColumnSpec;
+
+  @property({ reflect: true })
+  max?: ColumnSpec;
 
   @property({ reflect: true })
   span?: ColumnSpecSimple;


### PR DESCRIPTION
Noted that the web components column component does not support xlg and max breakpoints. This PR adds those properties, the SCSS was already correct.

### Changelog

**Changed**

- Web components CDS column adding xlg and max properties.

#### Testing / Reviewing

Reviewed in storybook by adding xlg and max values.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
