### PR TITLE
fix(data-table): use layer-02 for open overflow menu in table rows

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -511,6 +511,10 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
       }
     );
 
+    const isInDataTableRow = Boolean(
+      open && triggerRef.current?.closest(`.${prefix}--table-column-menu`)
+    );
+
     const overflowMenuOptionsClasses = classNames(
       menuOptionsClass,
       `${prefix}--overflow-menu-options`,
@@ -519,6 +523,7 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
         [`${prefix}--overflow-menu-options--open`]: open,
         [`${prefix}--overflow-menu-options--light`]: light,
         [`${prefix}--overflow-menu-options--${size}`]: size,
+        [`${prefix}--overflow-menu-options--data-table`]: isInDataTableRow,
       }
     );
 

--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -149,6 +149,14 @@
     }
   }
 
+  .#{$prefix}--overflow-menu-options--data-table {
+    background-color: $layer-02;
+
+    &::after {
+      background-color: $layer-02;
+    }
+  }
+
   .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open:hover {
     background-color: $layer-hover;
   }

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.scss
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.scss
@@ -89,6 +89,10 @@
   @extend .#{$prefix}--overflow-menu-options--open;
 }
 
+:host(#{$prefix}-overflow-menu-body[data-table]) {
+  @extend .#{$prefix}--overflow-menu-options--data-table;
+}
+
 :host(#{$prefix}-overflow-menu-body[size='xs']) {
   @extend .#{$prefix}--overflow-menu-options--xs;
 }

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.ts
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.ts
@@ -141,6 +141,7 @@ class CDSOverflowMenu
       this.attachShadow({ mode: 'open' });
     }
     super.connectedCallback();
+    this.dataTable = Boolean(this.closest?.(`${prefix}-table-cell`));
 
     adoptStyles(this.renderRoot as ShadowRoot, [iconButtonStyles, styles]);
   }
@@ -166,6 +167,7 @@ class CDSOverflowMenu
       const { _menuBody: menuBody, size } = this;
       if (menuBody) {
         menuBody.setAttribute('breadcrumb', String(Boolean(this.breadcrumb)));
+        menuBody.setAttribute('data-table', String(Boolean(this.dataTable)));
         menuBody.open = open;
         menuBody.size = size;
 
@@ -180,6 +182,10 @@ class CDSOverflowMenu
     if (changedProperties.has('dataTable')) {
       const tooltip = this.shadowRoot?.querySelector(`${prefix}-tooltip`);
       tooltip?.setAttribute('data-table', '');
+      const { _menuBody: menuBody } = this;
+      if (menuBody) {
+        menuBody.setAttribute('data-table', String(Boolean(this.dataTable)));
+      }
     }
 
     if (changedProperties.has('size')) {


### PR DESCRIPTION
Closes : #21419


### short description

- Fixes data table row overflow menu layering: the open dropdown now uses layer-02 instead of layer-01 so it sits above the row.

### Changelog

- changed
- Data table row overflow menu open dropdown now uses $layer-02 instead of $layer-01.

### New

- (None)

### Removed

- (None)

### Testing / Reviewing
[ ] Open Data Table → Toolbar → With Overflow Menu (React and WC).
[ ] Open the row overflow menu and confirm the dropdown background is layer-02 (slightly elevated vs the row).
[ ] Confirm no layout or a11y regressions.

### PR Checklist
- As the author of this PR, before marking ready for review, confirm you:
[ ] Reviewed every line of the diff
[ ] Updated documentation and storybook examples