### PR TITLE
fix(text-input): show helper text when provided only via slot

### DIFF
--- a/packages/web-components/src/components/text-input/__test__/text-input-test.js
+++ b/packages/web-components/src/components/text-input/__test__/text-input-test.js
@@ -60,6 +60,21 @@ describe('cds-text-input', () => {
     expect(helper.textContent).to.include('Helpful info');
   });
 
+  it('should render helper text from slot without helper-text attribute', async () => {
+    const el = await fixture(html`
+      <cds-text-input label-text="Text input">
+        <cds-text-input-label slot="label-text"
+          >Text input</cds-text-input-label
+        >
+        <span slot="helper-text"><strong>Rich</strong> helper text</span>
+      </cds-text-input>
+    `);
+    await el.updateComplete;
+    const helper = el.shadowRoot.querySelector('.cds--form__helper-text');
+    expect(helper).to.exist;
+    expect(helper.hidden).to.be.false;
+  });
+
   it('should apply disabled attribute', async () => {
     const el = await fixture(html`
       <cds-text-input disabled label-text="Disabled">

--- a/packages/web-components/src/components/text-input/text-input.ts
+++ b/packages/web-components/src/components/text-input/text-input.ts
@@ -480,8 +480,7 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
     </div>`;
 
     const hasHelperText =
-      helperText ||
-      (this._slotHelperTextNode?.assignedNodes().length ?? 0) > 0;
+      helperText || (this._slotHelperTextNode?.assignedNodes().length ?? 0) > 0;
 
     const helper = html`<div
       class="${helperTextClasses}"

--- a/packages/web-components/src/components/text-input/text-input.ts
+++ b/packages/web-components/src/components/text-input/text-input.ts
@@ -78,6 +78,9 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
   @query('input')
   protected _input!: HTMLInputElement;
 
+  @query('slot[name="helper-text"]')
+  protected _slotHelperTextNode!: HTMLSlotElement;
+
   /**
    * The internal value.
    */
@@ -99,6 +102,10 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
     if (!disabled) {
       formData.append(name, value);
     }
+  }
+
+  protected _handleHelperTextSlotChange() {
+    this.requestUpdate();
   }
 
   /**
@@ -472,14 +479,22 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
       ${counter}
     </div>`;
 
-    const helper = helperText
-      ? html`<div
-          class="${helperTextClasses}"
-          id="helper-text"
-          ?hidden="${normalizedProps.invalid || normalizedProps.warn}">
-          <slot name="helper-text"> ${helperText} </slot>
-        </div>`
-      : null;
+    const hasHelperText =
+      helperText ||
+      (this._slotHelperTextNode?.assignedNodes().length ?? 0) > 0;
+
+    const helper = html`<div
+      class="${helperTextClasses}"
+      id="helper-text"
+      ?hidden="${normalizedProps.invalid ||
+      normalizedProps.warn ||
+      !hasHelperText}">
+      <slot
+        name="helper-text"
+        @slotchange="${this._handleHelperTextSlotChange}">
+        ${helperText}
+      </slot>
+    </div>`;
 
     const validationMessage =
       normalizedProps.invalid || normalizedProps.warn
@@ -508,7 +523,7 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
               class="${inputClasses}"
               ?data-invalid="${invalid}"
               ?disabled="${disabled}"
-              aria-describedby="helper-text"
+              ?aria-describedby="${hasHelperText ? 'helper-text' : undefined}"
               id="input"
               name="${ifNonEmpty(this.name)}"
               pattern="${ifNonEmpty(this.pattern)}"


### PR DESCRIPTION
Closes #21431


- Helper text now shows when provided only via the helper-text slot (no helper-text attribute required).

### Changelog

- Changed

- Helper text renders from slot content without the helper-text attribute.

### Testing / Reviewing

- Render <cds-text-input><span slot="helper-text">Help</span></cds-text-input> with no attribute and confirm the helper text is visible.

### PR Checklist

- As the author of this PR, before marking ready for review, confirm you:

[ ] Reviewed every line of the diff
[ ] Updated documentation and storybook examples
