### PR TITLE
refactor(data-table): remove compact prop

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2696,9 +2696,6 @@ Map {
       "columnCount": {
         "type": "number",
       },
-      "compact": {
-        "type": "bool",
-      },
       "headers": {
         "args": [
           {

--- a/packages/react/examples/custom-data-table-state-manager-vite/src/misc/enums.js
+++ b/packages/react/examples/custom-data-table-state-manager-vite/src/misc/enums.js
@@ -3,11 +3,6 @@
  */
 export const TABLE_SIZE = {
   /**
-   * Compact size.
-   */
-  COMPACT: 'compact',
-
-  /**
    * Short size.
    */
   SHORT: 'short',

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,7 +13,6 @@ import { headers } from '../DataTable/stories/shared';
 
 const props = () => ({
   zebra: false,
-  compact: false,
   showHeader: true,
   showToolbar: true,
 });

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.tsx
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,12 +29,6 @@ export interface DataTableSkeletonProps
    * Specify the number of columns that you want to render in the skeleton state
    */
   columnCount?: number;
-
-  /**
-   * Optionally specify whether you want the Skeleton to be rendered as a
-   * compact DataTable
-   */
-  compact?: boolean;
 
   /**
    * Optionally specify the displayed headers
@@ -76,7 +70,6 @@ const DataTableSkeleton = ({
   rowCount = 5,
   columnCount = 5,
   zebra = false,
-  compact = false,
   className,
   showHeader = true,
   showToolbar = true,
@@ -89,7 +82,6 @@ const DataTableSkeleton = ({
     [`${prefix}--data-table`]: true,
     [`${prefix}--data-table--${size}`]: size,
     [`${prefix}--data-table--zebra`]: zebra,
-    [`${prefix}--data-table--compact`]: compact,
   });
 
   const rowRepeat = rowCount;
@@ -158,12 +150,6 @@ DataTableSkeleton.propTypes = {
    * Specify the number of columns that you want to render in the skeleton state
    */
   columnCount: PropTypes.number,
-
-  /**
-   * Optionally specify whether you want the Skeleton to be rendered as a
-   * compact DataTable
-   */
-  compact: PropTypes.bool,
 
   /**
    * Optionally specify the displayed headers

--- a/packages/react/src/components/DataTableSkeleton/__tests__/DataTableSkeleton-test.js
+++ b/packages/react/src/components/DataTableSkeleton/__tests__/DataTableSkeleton-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,14 +38,6 @@ describe('DataTableSkeleton', () => {
       render(<DataTableSkeleton columnCount={3} />);
 
       expect(screen.getAllByRole('columnheader').length).toEqual(3);
-    });
-
-    it('should respect the compact prop', () => {
-      render(<DataTableSkeleton compact />);
-
-      expect(screen.getByRole('table')).toHaveClass(
-        `${prefix}--data-table--compact`
-      );
     });
 
     it('should respect the headers prop', () => {

--- a/packages/styles/scss/components/data-table/sort/_data-table-sort.scss
+++ b/packages/styles/scss/components/data-table/sort/_data-table-sort.scss
@@ -208,9 +208,9 @@
   }
 
   //----------------------------------------------------------------------------
-  // Compact, Short, Tall Sortable
+  // Extra small, Short, Tall Sortable
   //----------------------------------------------------------------------------
-  // Sortable compact
+  // Sortable Extra small
   .#{$prefix}--data-table--xs.#{$prefix}--data-table--sort th {
     block-size: convert.to-rem(24px);
   }

--- a/packages/web-components/src/components/data-table/stories/data-table-skeleton.stories.ts
+++ b/packages/web-components/src/components/data-table/stories/data-table-skeleton.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,6 @@ const headers = [
 ];
 
 const defaultArgs = {
-  compact: false,
   columnCount: 5,
   rowCount: 5,
   showHeader: true,
@@ -28,10 +27,6 @@ const defaultArgs = {
 };
 
 const controls = {
-  compact: {
-    control: 'boolean',
-    description: 'Compact',
-  },
   columnCount: {
     control: 'number',
     description: 'Column count',
@@ -57,19 +52,11 @@ const controls = {
 export const Default = {
   args: defaultArgs,
   argTypes: controls,
-  render: ({
-    compact,
-    columnCount,
-    rowCount,
-    showHeader,
-    showToolbar,
-    zebra,
-  }) => {
+  render: ({ columnCount, rowCount, showHeader, showToolbar, zebra }) => {
     const dynamicHeaders = headers.slice(0, columnCount);
     return html`
       <cds-table-skeleton
         .headers=${dynamicHeaders}
-        .compact=${compact}
         column-count=${columnCount}
         row-count=${rowCount}
         ?show-header=${showHeader}

--- a/packages/web-components/src/components/data-table/table-skeleton.ts
+++ b/packages/web-components/src/components/data-table/table-skeleton.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,12 +24,6 @@ class CDSTableSkeleton extends LitElement {
    */
   @property()
   private headers: string[] = [];
-
-  /**
-   * Optionally specify whether you want the Skeleton to be rendered as a compact DataTable
-   */
-  @property({ type: Boolean, reflect: true })
-  compact = false;
 
   /**
    * Specify the number of columns that you want to render in the skeleton state
@@ -111,11 +105,10 @@ class CDSTableSkeleton extends LitElement {
   }
 
   render() {
-    const { compact, columnCount, headers, rowCount, zebra } = this;
+    const { columnCount, headers, rowCount, zebra } = this;
     const classes = classMap({
       [`${prefix}--skeleton`]: true,
       [`${prefix}--data-table`]: true,
-      [`${prefix}--data-table--compact`]: compact,
       [`${prefix}--data-table--zebra`]: zebra,
     });
     return html`


### PR DESCRIPTION
No issue. https://github.com/carbon-design-system/carbon/pull/21111#discussion_r2717030371

Removed the `compact` prop from `DataTable`.

### Changelog

**Removed**

- Removed the `compact` prop from `DataTable`.
- Remove testing and other code related to the `compact` prop from `DataTable`.

#### Testing / Reviewing

See the linked pull request comment

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
