### PR TITLE
fix(tabs): refine IconTab size 20 class matching

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -455,9 +455,6 @@ const ComposedModalDialog = React.forwardRef<
   );
 
   // Generate aria-label based on Modal Header label if one is not provided (L253)
-  //
-  // TODO: Confirm whether `ModalHeader` `label` should allow `ReactNode`. If
-  // so, define how to derive a string for `aria-label`.
   let generatedAriaLabel: ComponentProps<typeof ModalHeader>['label'];
   const childrenWithProps = React.Children.toArray(children).map((child) => {
     if (isComponentElement(child, ModalHeader)) {

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1603,10 +1603,7 @@ const IconTab = React.forwardRef<HTMLDivElement, IconTabProps>(
 
     const hasSize20 =
       isValidElement<ComponentProps<CarbonIconType>>(children) &&
-      // TODO: The interface allows `size` to be a string. Should this case be
-      // handled here, or should the prop type be restricted to `number`
-      // instead?
-      children.props.size === 20;
+      (children.props.size === 20 || children.props.size === '20');
 
     const classNames = cx(
       `${prefix}--tabs__nav-item--icon-only`,

--- a/packages/react/src/components/Tabs/__tests__/Tabs-test.js
+++ b/packages/react/src/components/Tabs/__tests__/Tabs-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -264,6 +264,66 @@ describe('Tab', () => {
     const iconTab = screen.getByTestId('icon-tab-with-badge');
     const badgeIndicator = iconTab.querySelector(`.${prefix}--badge-indicator`);
     expect(badgeIndicator).not.toBeNull();
+  });
+
+  it('should apply icon-only 20 class when IconTab child size is 20 as a number', () => {
+    render(
+      <Tabs>
+        <TabList aria-label="List of tabs">
+          <IconTab data-testid="icon-tab-size-number" label="Notifications">
+            <Notification size={20} aria-label="Notification" />
+          </IconTab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Icon Tab Panel</TabPanel>
+        </TabPanels>
+      </Tabs>
+    );
+
+    const iconTab = screen.getByTestId('icon-tab-size-number');
+
+    expect(iconTab).toHaveClass(`${prefix}--tabs__nav-item--icon-only`);
+    expect(iconTab).toHaveClass(`${prefix}--tabs__nav-item--icon-only__20`);
+  });
+
+  it('should apply icon-only 20 class when IconTab child size is 20 as a string', () => {
+    render(
+      <Tabs>
+        <TabList aria-label="List of tabs">
+          <IconTab data-testid="icon-tab-size-string" label="Notifications">
+            <Notification size="20" aria-label="Notification" />
+          </IconTab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Icon Tab Panel</TabPanel>
+        </TabPanels>
+      </Tabs>
+    );
+
+    const iconTab = screen.getByTestId('icon-tab-size-string');
+
+    expect(iconTab).toHaveClass(`${prefix}--tabs__nav-item--icon-only`);
+    expect(iconTab).toHaveClass(`${prefix}--tabs__nav-item--icon-only__20`);
+  });
+
+  it('should not apply icon-only 20 class when IconTab child size is not 20', () => {
+    render(
+      <Tabs>
+        <TabList aria-label="List of tabs">
+          <IconTab data-testid="icon-tab-size-non-20" label="Notifications">
+            <Notification size="1.25rem" aria-label="Notification" />
+          </IconTab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Icon Tab Panel</TabPanel>
+        </TabPanels>
+      </Tabs>
+    );
+
+    const iconTab = screen.getByTestId('icon-tab-size-non-20');
+
+    expect(iconTab).toHaveClass(`${prefix}--tabs__nav-item--icon-only`);
+    expect(iconTab).not.toHaveClass(`${prefix}--tabs__nav-item--icon-only__20`);
   });
 
   it('should call onClick from props if provided', async () => {


### PR DESCRIPTION
No issue.

Fixed `IconTab` `size` `20` class matching.

### Changelog

**Changed**

- Fixed `IconTab` `size` `20` class matching.

#### Testing / Reviewing

There were no comments on the `TODO` in https://github.com/carbon-design-system/carbon/pull/21311, so I proceeded with adding support for everything that the interface permitted.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
