### PR TITLE
fix: replace HTMLElement casts with type guards

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -427,7 +427,11 @@ const ComboBox = forwardRef(
           }
         : {}
     );
-    const parentWidth = (refs?.reference?.current as HTMLElement)?.clientWidth;
+    const referenceElement = refs?.reference?.current;
+    const parentWidth =
+      referenceElement instanceof HTMLElement
+        ? referenceElement.clientWidth
+        : undefined;
 
     useEffect(() => {
       if (enableFloatingStyles) {

--- a/packages/react/src/components/DataTable/Table.tsx
+++ b/packages/react/src/components/DataTable/Table.tsx
@@ -172,7 +172,8 @@ export const Table = ({
           const label = th.querySelector(`.${prefix}--table-header-label`);
 
           return (
-            label && isElementWrappingContent(label as HTMLElement, context)
+            label instanceof HTMLElement &&
+            isElementWrappingContent(label, context)
           );
         });
 

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -690,12 +690,15 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((props, ref) => {
             calendarContainer.querySelector('.selected') && fpSelectedDateElem;
           const todayDateElem =
             calendarContainer.querySelector('.today') && fpTodayDateElem;
-          (
-            (selectedDateElem ||
-              todayDateElem ||
-              calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
-              calendarContainer) as HTMLElement
-          ).focus();
+          const focusTarget =
+            selectedDateElem ||
+            todayDateElem ||
+            calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
+            calendarContainer;
+
+          if (focusTarget instanceof HTMLElement) {
+            focusTarget.focus();
+          }
 
           if (event.target === startInputField.current) {
             lastFocusedField.current = startInputField.current;

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2025
+ * Copyright IBM Corp. 2023, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -188,11 +188,15 @@ const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
 
   function handleOpen() {
     if (menu.current) {
-      focusReturn.current = document.activeElement as HTMLElement;
+      const { activeElement, dir } = document;
+
+      focusReturn.current =
+        activeElement instanceof HTMLElement ? activeElement : null;
+
       if (legacyAutoalign) {
         const pos = calculatePosition();
         if (
-          (document?.dir === 'rtl' || direction === 'rtl') &&
+          (dir === 'rtl' || direction === 'rtl') &&
           !rest?.id?.includes('MenuButton')
         ) {
           menu.current.style.insetInlineStart = `initial`;

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -635,7 +635,10 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
 
   useEffect(() => {
     const handleClickOutside = (event: Event) => {
-      const target = event.target as HTMLElement;
+      const target = event.target;
+
+      if (!(target instanceof Node)) return;
+
       const wrapper = document
         .getElementById(id)
         ?.closest(`.${prefix}--multi-select__wrapper`);

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -471,7 +471,10 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
         menuBody.ownerDocument,
         focusinEventName,
         (event: Event) => {
-          const target = event.target as HTMLElement;
+          const target = event.target;
+
+          if (!(target instanceof Element)) return;
+
           const triggerEl = triggerRef.current;
           if (typeof target.matches === 'function') {
             if (

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1310,10 +1310,11 @@ const Tab = forwardRef<HTMLElement, TabProps>(
         const tabCount = Array.from(
           tabRef.current.parentElement.childNodes
         ).filter((node) => {
-          const element = node as HTMLElement;
+          if (!(node instanceof HTMLElement)) return false;
+
           return (
-            element.classList.contains(`${prefix}--tabs__nav-link`) &&
-            !element.classList.contains(`${prefix}--tabs__nav-item--disabled`)
+            node.classList.contains(`${prefix}--tabs__nav-link`) &&
+            !node.classList.contains(`${prefix}--tabs__nav-item--disabled`)
           );
         }).length;
 
@@ -1324,9 +1325,12 @@ const Tab = forwardRef<HTMLElement, TabProps>(
         // if removing last tab focus on previous tab
         else {
           const prevTabIndex = (tabCount - 2) * 2;
-          (
-            tabRef.current.parentElement.childNodes[prevTabIndex] as HTMLElement
-          )?.focus();
+          const previousTab =
+            tabRef.current.parentElement.childNodes[prevTabIndex];
+
+          if (previousTab instanceof HTMLElement) {
+            previousTab.focus();
+          }
         }
       }
     };
@@ -1762,7 +1766,9 @@ function TabPanels({ children }: TabPanelsProps) {
       // set max height to TabList
       const heights = refs.current.map((ref) => ref?.offsetHeight || 0);
       const max = Math.max(...heights);
-      (tabContainer as HTMLElement).style.height = max + 'px';
+      if (tabContainer instanceof HTMLElement) {
+        tabContainer.style.height = max + 'px';
+      }
 
       // re-hide hidden Tab Panels
       refs.current.forEach((ref, index) => {

--- a/packages/react/src/components/UIShell/HeaderPanel.tsx
+++ b/packages/react/src/components/UIShell/HeaderPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -76,7 +76,7 @@ const HeaderPanel = React.forwardRef<HTMLDivElement, HeaderPanelProps>(
     const expandedProp = controlled ? expanded : expandedState;
 
     const [lastClickedElement, setLastClickedElement] =
-      useState<HTMLElement | null>(null);
+      useState<Element | null>(null);
 
     const className = cx(`${prefix}--header-panel`, {
       [`${prefix}--header-panel--expanded`]: expandedProp,
@@ -114,8 +114,8 @@ const HeaderPanel = React.forwardRef<HTMLDivElement, HeaderPanelProps>(
     }
 
     useWindowEvent('click', (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (!(target instanceof HTMLElement)) return;
+      const { target } = event;
+      if (!(target instanceof Element)) return;
       setLastClickedElement(target);
 
       const isChildASwitcher =

--- a/packages/react/src/components/UIShell/Switcher.tsx
+++ b/packages/react/src/components/UIShell/Switcher.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -112,9 +112,9 @@ const Switcher = forwardRef<HTMLUListElement, SwitcherProps>(
         }
       })();
 
-      const switcherItem = switcherRef.current?.children[nextValidIndex]
-        ?.children[0] as HTMLElement;
-      if (switcherItem) {
+      const switcherItem =
+        switcherRef.current?.children[nextValidIndex]?.children[0];
+      if (switcherItem instanceof HTMLElement) {
         switcherItem.focus();
       }
     };


### PR DESCRIPTION
No issue.

Replaced `HTMLElement` casts with type guards in `@carbon/react`.

### Changelog

**Changed**

- Replaced `HTMLElement` casts with type guards in `@carbon/react`.

#### Testing / Reviewing

Existing tests should cover these changes.

I plan to make the same updates in the other packages.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
