### PR TITLE
fix(radio-button-group): avoid state updates during render

### DIFF
--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup-test.js
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -205,6 +205,23 @@ describe('RadioButtonGroup', () => {
         screen.getByRole('radio', {
           checked: true,
         })
+      );
+    });
+
+    it('should keep `defaultSelected` when `valueSelected` is undefined', () => {
+      render(
+        <RadioButtonGroup
+          defaultSelected="test-1"
+          valueSelected={undefined}
+          name="test"
+          legendText="test">
+          <RadioButton labelText="test-1" value="test-1" />
+          <RadioButton labelText="test-2" value="test-2" />
+        </RadioButtonGroup>
+      );
+
+      expect(screen.getByLabelText('test-1')).toEqual(
+        screen.getByRole('radio', { checked: true })
       );
     });
 

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React, {
   cloneElement,
   createContext,
+  useEffect,
   useRef,
   useState,
   type ReactElement,
@@ -164,18 +165,16 @@ const RadioButtonGroup = React.forwardRef(
     const prefix = usePrefix();
 
     const [selected, setSelected] = useState(valueSelected ?? defaultSelected);
-    const [prevValueSelected, setPrevValueSelected] = useState(valueSelected);
+    const prevValueSelected = useRef(valueSelected);
 
     const radioButtonGroupInstanceId = useId();
 
-    /**
-     * prop + state alignment - getDerivedStateFromProps
-     * only update if selected prop changes
-     */
-    if (valueSelected !== prevValueSelected) {
-      setSelected(valueSelected);
-      setPrevValueSelected(valueSelected);
-    }
+    useEffect(() => {
+      if (valueSelected !== prevValueSelected.current) {
+        setSelected(valueSelected);
+        prevValueSelected.current = valueSelected;
+      }
+    }, [valueSelected]);
 
     function getRadioButtons() {
       const mappedChildren = React.Children.map(


### PR DESCRIPTION
No issue.

Avoided state updates during render in `RadioButtonGroup`.

### Changelog

**Changed**

- Avoided state updates during render in `RadioButtonGroup`.

#### Testing / Reviewing

`RadioButtonGroup` was updating state during render which is an anti-pattern.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
