### PR TITLE
fix(multiselect): avoid state updates during render

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -17,6 +17,7 @@ import isEqual from 'react-fast-compare';
 import PropTypes from 'prop-types';
 import React, {
   cloneElement,
+  useEffect,
   isValidElement,
   useCallback,
   useContext,
@@ -350,11 +351,11 @@ export const MultiSelect = React.forwardRef(
     const prefix = usePrefix();
     const { isFluid } = useContext(FormContext);
     const multiSelectInstanceId = useId();
+    const prevOpenPropRef = useRef(open);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- https://github.com/carbon-design-system/carbon/issues/20452
     const [isFocused, setIsFocused] = useState(false);
     const [inputFocused, setInputFocused] = useState(false);
     const [isOpen, setIsOpen] = useState(open || false);
-    const [prevOpenProp, setPrevOpenProp] = useState(open);
     const [topItems, setTopItems] = useState<ItemType[]>([]);
     const [itemsCleared, setItemsCleared] = useState(false);
 
@@ -526,13 +527,13 @@ export const MultiSelect = React.forwardRef(
       }
     };
 
-    /**
-     * programmatically control this `open` prop
-     */
-    if (prevOpenProp !== open) {
-      setIsOpenWrapper(open);
-      setPrevOpenProp(open);
-    }
+    useEffect(() => {
+      if (prevOpenPropRef.current !== open) {
+        setIsOpen(open);
+        onMenuChange?.(open);
+        prevOpenPropRef.current = open;
+      }
+    }, [open, onMenuChange]);
 
     const normalizedProps = useNormalizedInputProps({
       id,

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -237,6 +237,77 @@ describe('MultiSelect', () => {
       // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('[aria-expanded="true"][aria-haspopup="listbox"]')
     ).toBeFalsy();
+  });
+
+  it('should not call `onMenuChange` on mount when `open` remains unchanged', async () => {
+    const onMenuChange = jest.fn();
+    const items = generateItems(4, generateGenericItem);
+    const { rerender } = render(
+      <MultiSelect
+        id="test"
+        label="test-label"
+        items={items}
+        open={false}
+        onMenuChange={onMenuChange}
+      />
+    );
+    await waitForPosition();
+
+    expect(onMenuChange).not.toHaveBeenCalled();
+
+    rerender(
+      <MultiSelect
+        id="test"
+        label="test-label"
+        items={items}
+        open={false}
+        onMenuChange={onMenuChange}
+      />
+    );
+    await waitForPosition();
+
+    expect(onMenuChange).not.toHaveBeenCalled();
+  });
+
+  it('should call `onMenuChange` when the controlled `open` prop changes', async () => {
+    const onMenuChange = jest.fn();
+    const items = generateItems(4, generateGenericItem);
+    const { rerender } = render(
+      <MultiSelect
+        id="test"
+        label="test-label"
+        items={items}
+        open={false}
+        onMenuChange={onMenuChange}
+      />
+    );
+    await waitForPosition();
+
+    rerender(
+      <MultiSelect
+        id="test"
+        label="test-label"
+        items={items}
+        open={true}
+        onMenuChange={onMenuChange}
+      />
+    );
+    await waitForPosition();
+    expect(onMenuChange).toHaveBeenCalledTimes(1);
+    expect(onMenuChange).toHaveBeenLastCalledWith(true);
+
+    rerender(
+      <MultiSelect
+        id="test"
+        label="test-label"
+        items={items}
+        open={false}
+        onMenuChange={onMenuChange}
+      />
+    );
+    await waitForPosition();
+    expect(onMenuChange).toHaveBeenCalledTimes(2);
+    expect(onMenuChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should toggle selection with enter', async () => {
@@ -1021,12 +1092,14 @@ describe('MultiSelect', () => {
       (acc, { name, value }) => ({ ...acc, [name]: value }),
       {}
     );
+    const idPrefix = attributes.id.replace(/-label$/, '');
 
     expect(attributes).toEqual({
       class: 'cds--label',
-      for: 'downshift-_r_64_-toggle-button',
-      id: 'downshift-_r_64_-label',
+      for: attributes.for,
+      id: attributes.id,
     });
+    expect(attributes.for).toBe(`${idPrefix}-toggle-button`);
   });
 
   it('should add certain label props when `titleText` is an element', () => {
@@ -1042,7 +1115,7 @@ describe('MultiSelect', () => {
 
     expect(attributes).toEqual({
       class: 'cds--label',
-      id: 'downshift-_r_67_-label',
+      id: attributes.id,
     });
   });
 


### PR DESCRIPTION
No issue.

Avoided state updates during render in `MultiSelect`.

### Changelog

**Changed**

- Avoided state updates during render in `MultiSelect`.

#### Testing / Reviewing

`MultiSelect` was updating state during render which is an anti-pattern.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
