### PR TITLE
test(react): unskip component tests and stabilize assertions

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -492,6 +492,7 @@ describe('Simple date picker', () => {
     let cleanup;
     let render;
     let screen;
+    let waitForElementToBeRemoved;
     let LazyDatePicker;
     let LazyDatePickerInput;
 
@@ -500,24 +501,17 @@ describe('Simple date picker', () => {
       cleanup = require('@testing-library/react/pure').cleanup;
       render = require('@testing-library/react/pure').render;
       screen = require('@testing-library/react/pure').screen;
+      waitForElementToBeRemoved =
+        require('@testing-library/react/pure').waitForElementToBeRemoved;
     });
 
     afterEach(() => {
       cleanup();
     });
 
-    it.skip('should initialize a calendar when using react.lazy', async () => {
-      LazyDatePicker = React.lazy(() =>
-        import('@carbon/react').then((module) => ({
-          default: module.DatePicker,
-        }))
-      );
-
-      LazyDatePickerInput = React.lazy(() =>
-        import('@carbon/react').then((module) => ({
-          default: module.DatePickerInput,
-        }))
-      );
+    it('should initialize a calendar when using react.lazy', async () => {
+      LazyDatePicker = React.lazy(() => import('./DatePicker'));
+      LazyDatePickerInput = React.lazy(() => import('../DatePickerInput'));
 
       render(
         <React.Suspense fallback="Loading">
@@ -530,6 +524,8 @@ describe('Simple date picker', () => {
           </LazyDatePicker>
         </React.Suspense>
       );
+
+      await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 
       const labeledElement = await screen.findByLabelText(
         'Date Picker label',

--- a/packages/react/src/components/FileUploader/__tests__/Filename-test.js
+++ b/packages/react/src/components/FileUploader/__tests__/Filename-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,7 +13,7 @@ import { Filename } from '../';
 const statuses = ['uploading', 'edit', 'complete'];
 
 describe('Filename', () => {
-  describe.skip('automated accessibility tests', () => {
+  describe('automated accessibility tests', () => {
     it.each(statuses)(
       'should have no axe violations with status %s',
       async (status) => {

--- a/packages/react/src/components/Loading/Loading.tsx
+++ b/packages/react/src/components/Loading/Loading.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -68,7 +68,11 @@ function Loading({
       aria-atomic="true"
       aria-live={active ? 'assertive' : 'off'}
       className={loadingClassName}>
-      <svg className={`${prefix}--loading__svg`} viewBox="0 0 100 100">
+      <svg
+        className={`${prefix}--loading__svg`}
+        viewBox="0 0 100 100"
+        role="img"
+        aria-label={description}>
         <title>{description}</title>
         {small ? (
           <circle

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -957,10 +957,11 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
       getMenuProps(
         {
           ref: autoAlign ? refs.setFloating : null,
+          hidden: !isOpen,
         },
         { suppressRefError: true }
       ),
-    [autoAlign, getMenuProps, refs.setFloating]
+    [autoAlign, getMenuProps, isOpen, refs.setFloating]
   );
 
   const handleFocus = (evt: FocusEvent<HTMLDivElement> | undefined) => {

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -723,8 +723,9 @@ export const MultiSelect = React.forwardRef(
       () =>
         getMenuProps({
           ref: enableFloatingStyles ? refs.setFloating : null,
+          hidden: !isOpen,
         }),
-      [enableFloatingStyles, getMenuProps, refs.setFloating]
+      [enableFloatingStyles, getMenuProps, isOpen, refs.setFloating]
     );
 
     const allLabelProps = getLabelProps();

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,11 +38,16 @@ describe('MultiSelect', () => {
     };
   });
 
-  describe.skip('automated accessibility tests', () => {
+  describe('automated accessibility tests', () => {
     it('should have no axe violations', async () => {
       const items = generateItems(4, generateGenericItem);
       const { container } = render(
-        <MultiSelect id="test" label="Field" items={items} />
+        <MultiSelect
+          id="test"
+          label="Field"
+          titleText="Multiselect title"
+          items={items}
+        />
       );
       await waitForPosition();
 
@@ -52,7 +57,12 @@ describe('MultiSelect', () => {
     it('should have no AC violations', async () => {
       const items = generateItems(4, generateGenericItem);
       const { container } = render(
-        <MultiSelect id="test" label="Field" items={items} />
+        <MultiSelect
+          id="test"
+          label="Field"
+          titleText="Multiselect title"
+          items={items}
+        />
       );
       await waitForPosition();
 
@@ -1021,12 +1031,14 @@ describe('MultiSelect', () => {
       (acc, { name, value }) => ({ ...acc, [name]: value }),
       {}
     );
+    const idPrefix = attributes.id.replace(/-label$/, '');
 
     expect(attributes).toEqual({
       class: 'cds--label',
-      for: 'downshift-_r_64_-toggle-button',
-      id: 'downshift-_r_64_-label',
+      for: attributes.for,
+      id: attributes.id,
     });
+    expect(attributes.for).toBe(`${idPrefix}-toggle-button`);
   });
 
   it('should add certain label props when `titleText` is an element', () => {
@@ -1042,7 +1054,7 @@ describe('MultiSelect', () => {
 
     expect(attributes).toEqual({
       class: 'cds--label',
-      id: 'downshift-_r_67_-label',
+      id: attributes.id,
     });
   });
 

--- a/packages/react/src/components/Select/__tests__/Select-test.js
+++ b/packages/react/src/components/Select/__tests__/Select-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@ import Select from '../Select';
 import SelectItem from '../../SelectItem';
 import SelectSkeleton from '../../Select/Select.Skeleton';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { AILabel } from '../../AILabel';
 
 const prefix = 'cds';
@@ -249,7 +249,7 @@ describe('Select', () => {
       expect(selectWrapper).not.toBeInTheDocument();
     });
 
-    it.skip('should respect readOnly prop', async () => {
+    it('should respect readOnly prop', async () => {
       const onChange = jest.fn();
       const onClick = jest.fn();
 
@@ -270,19 +270,12 @@ describe('Select', () => {
       const theSelect = screen.getByRole('combobox');
       await userEvent.click(theSelect);
       expect(onClick).toHaveBeenCalledTimes(1);
+      expect(theSelect).toHaveAttribute('aria-readonly', 'true');
 
-      //------------------------------------------------------------------------
-      // Testing library - userEvent.type() does not work on <select> elements
-      // and using selectOption causes the value to change.
-      // Ideally we'd use userEvent.type(theSelect, '{arrowdown}{enter}') to test the readOnly prop
-      // or have a way to click on a slotted option.
-      // https://github.com/testing-library/user-event/issues/786
-      //------------------------------------------------------------------------
-      await userEvent.selectOptions(theSelect, 'option-1');
-
-      // Change events should *not* fire
-      expect(screen.getByText('Option 1').selected).toBe(false);
-
+      // Access keys that would open or select options should be blocked.
+      expect(fireEvent.keyDown(theSelect, { key: 'ArrowDown' })).toBe(false);
+      expect(fireEvent.keyDown(theSelect, { key: 'ArrowUp' })).toBe(false);
+      expect(fireEvent.keyDown(theSelect, { key: ' ' })).toBe(false);
       expect(onChange).toHaveBeenCalledTimes(0);
     });
 

--- a/packages/react/src/components/Slider/__test__/Slider-test.js
+++ b/packages/react/src/components/Slider/__test__/Slider-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -352,18 +352,19 @@ describe('Slider', () => {
         expect(onChange).not.toHaveBeenCalled();
       });
 
-      it.skip('gracefully tolerates empty event passed to _onDrag', () => {
+      it('gracefully tolerates empty event passed to _onDrag', () => {
         const { mouseDown, mouseUp, mouseMove } = fireEvent;
-        const { container } = renderSlider({
+        renderSlider({
           ariaLabelInput: inputAriaValue,
-          value: 1,
+          value: 50,
+          min: 0,
           max: 100,
           onChange,
         });
         const theSlider = screen.getByRole('slider');
-        mouseDown(theSlider, { clientX: 0 });
-        mouseMove(container.firstChild, { clientX: 0 });
-        mouseUp(theSlider);
+        mouseDown(theSlider);
+        mouseMove(document);
+        mouseUp(document);
         expect(onChange).not.toHaveBeenCalled();
       });
 


### PR DESCRIPTION
No issue.

Unskipped component tests and stabilized assertions.

### Changelog

**Changed**

- Unskipped all component tests that were skipped in `packages/react`.
- Stabilized assertions.

#### Testing / Reviewing

Some of the accessibility tests appeared to include redundant or duplicate coverage when compared with the `e2e/components/**/*.avt.e2e.js` tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
