### PR TITLE
fix(react): fix FeatureFlags scope sync and types

### DIFF
--- a/packages/react/src/components/FeatureFlags/__tests__/FeatureFlags-test.js
+++ b/packages/react/src/components/FeatureFlags/__tests__/FeatureFlags-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2015, 2023
+ * Copyright IBM Corp. 2015, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,7 +33,7 @@ describe('FeatureFlags', () => {
     expect(checkFlag).toHaveBeenLastCalledWith(true);
   });
   it('should provide access to the feature flags for a scope through deprecated flags prop', () => {
-    consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const checkFlags = jest.fn();
     const checkFlag = jest.fn();
 
@@ -55,21 +55,24 @@ describe('FeatureFlags', () => {
       return null;
     }
 
-    render(
-      <FeatureFlags flags={{ a: true, b: false }}>
-        <TestComponent />
-      </FeatureFlags>
-    );
+    try {
+      render(
+        <FeatureFlags flags={{ a: true, b: false }}>
+          <TestComponent />
+        </FeatureFlags>
+      );
 
-    expect(checkFlags).toHaveBeenLastCalledWith({
-      a: true,
-      b: false,
-    });
-    expect(checkFlag).toHaveBeenLastCalledWith({
-      a: true,
-      b: false,
-    });
-    consoleSpy.mockRestore();
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        a: true,
+        b: false,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        a: true,
+        b: false,
+      });
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('should provide access to the feature flags for a scope', () => {
@@ -225,6 +228,46 @@ describe('FeatureFlags', () => {
       enableV12Overflowmenu: false,
       enableTreeviewControllable: false,
     });
+  });
+
+  it('should update nested scope when parent scope changes', () => {
+    const checkFlag = jest.fn();
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const TestComponent = () => {
+      const a = useFeatureFlag('a');
+
+      checkFlag(a);
+
+      return null;
+    };
+
+    try {
+      const { rerender } = render(
+        <FeatureFlags flags={{ a: false }}>
+          <FeatureFlags>
+            <TestComponent />
+          </FeatureFlags>
+        </FeatureFlags>
+      );
+
+      expect(checkFlag).toHaveBeenLastCalledWith(false);
+      checkFlag.mockClear();
+
+      rerender(
+        <FeatureFlags flags={{ a: true }}>
+          <FeatureFlags>
+            <TestComponent />
+          </FeatureFlags>
+        </FeatureFlags>
+      );
+
+      expect(checkFlag).toHaveBeenCalled();
+      expect(checkFlag.mock.calls).toEqual([[true]]);
+      expect(checkFlag).toHaveBeenLastCalledWith(true);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('should handle boolean props and flags object with no overlapping keys', () => {

--- a/packages/react/src/components/FeatureFlags/index.tsx
+++ b/packages/react/src/components/FeatureFlags/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2015, 2025
+ * Copyright IBM Corp. 2015, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,11 +13,8 @@ import PropTypes from 'prop-types';
 import React, {
   createContext,
   useContext,
-  useEffect,
-  useRef,
-  useState,
-  ReactNode,
-  type JSX,
+  useMemo,
+  type ReactNode,
 } from 'react';
 import { deprecate } from '../../prop-types/deprecate';
 
@@ -36,19 +33,25 @@ export interface FeatureFlagsProps {
   enablePresence?: boolean;
 }
 
-// TODO: Can this variable be deleted now? It isn't used anywhere.
+// TODO: Migrate `packages/feature-flags` to TypeScript and delete this
+// interface.
+interface FeatureFlagScope {
+  enabled: (name: string) => boolean;
+  mergeWithScope: (scope: FeatureFlagScope) => void;
+}
+
 /**
  * Our FeatureFlagContext is used alongside the FeatureFlags component to enable
  * or disable feature flags in a given React tree
  */
-const FeatureFlagContext = createContext(GlobalFeatureFlags);
+const FeatureFlagContext = createContext<FeatureFlagScope>(GlobalFeatureFlags);
 
 /**
  * Supports an object of feature flag values with the `flags` prop, merging them
  * along with the current `FeatureFlagContext` to provide consumers to check if
  * a feature flag is enabled or disabled in a given React tree
  */
-function FeatureFlags({
+export const FeatureFlags = ({
   children,
   flags = {},
   enableV12TileDefaultIcons = false,
@@ -61,56 +64,52 @@ function FeatureFlags({
   enableV12DynamicFloatingStyles = false,
   enableEnhancedFileUploader = false,
   enablePresence = false,
-}: FeatureFlagsProps): JSX.Element {
+}: FeatureFlagsProps) => {
   const parentScope = useContext(FeatureFlagContext);
-  const [prevParentScope, setPrevParentScope] = useState(parentScope);
 
-  const combinedFlags = {
-    'enable-v12-tile-default-icons': enableV12TileDefaultIcons,
-    'enable-v12-tile-radio-icons': enableV12TileRadioIcons,
-    'enable-v12-overflowmenu': enableV12Overflowmenu,
-    'enable-treeview-controllable': enableTreeviewControllable,
-    'enable-experimental-focus-wrap-without-sentinels':
-      enableExperimentalFocusWrapWithoutSentinels,
-    'enable-focus-wrap-without-sentinels': enableFocusWrapWithoutSentinels,
-    'enable-dialog-element': enableDialogElement,
-    'enable-v12-dynamic-floating-styles': enableV12DynamicFloatingStyles,
-    'enable-enhanced-file-uploader': enableEnhancedFileUploader,
-    'enable-presence': enablePresence,
-    ...flags,
-  };
-  const [scope, updateScope] = useState(() => {
-    const scope = createScope(combinedFlags);
+  const scope = useMemo(() => {
+    const combinedFlags = {
+      'enable-v12-tile-default-icons': enableV12TileDefaultIcons,
+      'enable-v12-tile-radio-icons': enableV12TileRadioIcons,
+      'enable-v12-overflowmenu': enableV12Overflowmenu,
+      'enable-treeview-controllable': enableTreeviewControllable,
+      'enable-experimental-focus-wrap-without-sentinels':
+        enableExperimentalFocusWrapWithoutSentinels,
+      'enable-focus-wrap-without-sentinels': enableFocusWrapWithoutSentinels,
+      'enable-dialog-element': enableDialogElement,
+      'enable-v12-dynamic-floating-styles': enableV12DynamicFloatingStyles,
+      'enable-enhanced-file-uploader': enableEnhancedFileUploader,
+      'enable-presence': enablePresence,
+      ...flags,
+    };
+
+    const scope = createScope(combinedFlags) as FeatureFlagScope;
     scope.mergeWithScope(parentScope);
     return scope;
-  });
-
-  if (parentScope !== prevParentScope) {
-    const scope = createScope(combinedFlags);
-    scope.mergeWithScope(parentScope);
-    updateScope(scope);
-    setPrevParentScope(parentScope);
-  }
-
-  // We use a custom hook to detect if any of the keys or their values change
-  // for flags that are passed in. If they have changed, then we re-create the
-  // FeatureFlagScope using the new flags
-  useChangedValue(combinedFlags, isEqual, (changedFlags) => {
-    const scope = createScope(changedFlags);
-    scope.mergeWithScope(parentScope);
-    updateScope(scope);
-  });
+  }, [
+    enableV12TileDefaultIcons,
+    enableV12TileRadioIcons,
+    enableV12Overflowmenu,
+    enableTreeviewControllable,
+    enableExperimentalFocusWrapWithoutSentinels,
+    enableFocusWrapWithoutSentinels,
+    enableDialogElement,
+    enableV12DynamicFloatingStyles,
+    enableEnhancedFileUploader,
+    enablePresence,
+    flags,
+    parentScope,
+  ]);
 
   return (
     <FeatureFlagContext.Provider value={scope}>
       {children}
     </FeatureFlagContext.Provider>
   );
-}
+};
 
 FeatureFlags.propTypes = {
   children: PropTypes.node,
-
   /**
    * Provide the feature flags to enabled or disabled in the current Rea,ct tree
    */
@@ -133,94 +132,15 @@ FeatureFlags.propTypes = {
 };
 
 /**
- * This hook will store previous versions of the given `value` and compare the
- * current value to the previous one using the `compare` function. If the
- * compare function returns true, then the given `callback` is invoked in an
- * effect.
- *
- * @param {any} value
- * @param {Function} compare
- * @param {Function} callback
- */
-function useChangedValue<T>(
-  value: T,
-  compare: (a: T, b: T) => boolean,
-  callback: (value: T) => void
-) {
-  const initialRender = useRef(false);
-  const savedCallback = useRef(callback);
-  const [prevValue, setPrevValue] = useState(value);
-
-  if (!compare(prevValue, value)) {
-    setPrevValue(value);
-  }
-
-  useEffect(() => {
-    savedCallback.current = callback;
-  });
-
-  useEffect(() => {
-    // We only want the callback triggered after the first render
-    if (initialRender.current) {
-      savedCallback.current(prevValue);
-    }
-  }, [prevValue]);
-
-  useEffect(() => {
-    initialRender.current = true;
-  }, []);
-}
-
-/**
  * Access whether a given flag is enabled or disabled in a given
  * FeatureFlagContext
- *
- * @returns {boolean}
  */
-function useFeatureFlag(flag) {
+export const useFeatureFlag = (flag: string) => {
   const scope = useContext(FeatureFlagContext);
   return scope.enabled(flag);
-}
+};
 
 /**
  * Access all feature flag information for the given FeatureFlagContext
- *
- * @returns {FeatureFlagScope}
  */
-function useFeatureFlags() {
-  return useContext(FeatureFlagContext);
-}
-
-/**
- * Compare two objects and determine if they are equal. This is a shallow
- * comparison since the objects we are comparing are objects with boolean flags
- * from the flags prop in the `FeatureFlags` component
- *
- * @param {object} a
- * @param {object} b
- * @returns {boolean}
- */
-function isEqual(
-  a: Record<string, boolean>,
-  b: Record<string, boolean>
-): boolean {
-  if (a === b) {
-    return true;
-  }
-
-  for (const key of Object.keys(a)) {
-    if (a[key] !== b[key]) {
-      return false;
-    }
-  }
-
-  for (const key of Object.keys(b)) {
-    if (b[key] !== a[key]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-export { FeatureFlags, FeatureFlagContext, useFeatureFlags, useFeatureFlag };
+export const useFeatureFlags = () => useContext(FeatureFlagContext);


### PR DESCRIPTION
No issue.

Fixed `FeatureFlags` scope syncing and types.

### Changelog

**Changed**

- Fixed `FeatureFlags` scope syncing.
- Fixed `FeatureFlags` types.

**Removed**

- Removed unecessary hooks and utils.

#### Testing / Reviewing

`FeatureFlags` was setting state during render which is an anti-pattern. I refactored it so scope is derived from the current parent scope and flags instead of being synced through state and effects. I also removed the old change detection helpers since they appeared unnecessary.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
