### PR TITLE
feat(theme): add `color-scheme` token and property

### DIFF
--- a/packages/elements/src/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/elements/src/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -95,6 +95,7 @@ exports[`Public API should only change with a semver change 1`] = `
   "chatShellBackground",
   "code01",
   "code02",
+  "colorScheme",
   "colors",
   "container",
   "container01",

--- a/packages/styles/scss/__tests__/theme-test.js
+++ b/packages/styles/scss/__tests__/theme-test.js
@@ -261,6 +261,7 @@ describe('@carbon/styles/scss/theme', () => {
         "chat-button-text-selected",
         "highlight",
         "overlay",
+        "color-scheme",
         "toggle-off",
         "shadow",
         "focus",

--- a/packages/styles/scss/_reset.scss
+++ b/packages/styles/scss/_reset.scss
@@ -113,6 +113,10 @@
     font-family: inherit;
   }
 
+  :root {
+    color-scheme: custom-property.get-var('color-scheme', light);
+  }
+
   /* HTML5 display-role reset for older browsers */
   article,
   aside,

--- a/packages/styles/scss/_theme.scss
+++ b/packages/styles/scss/_theme.scss
@@ -15,6 +15,8 @@
 @mixin theme($args...) {
   @include theme.theme($args...);
 
+  color-scheme: custom-property.get-var('color-scheme', light);
+
   // If the system is in high-contrast mode, use the system defined colors.  This mostly happens automatically, but
   // we need to do it manually for icons and selected backgrounds.  Importantly, the custom properties we set here
   // need to override the CSS custom properties set above.  See:

--- a/packages/styles/scss/_zone.scss
+++ b/packages/styles/scss/_zone.scss
@@ -44,7 +44,11 @@ $-components: (
     color: custom-property.get-var('text-primary');
 
     @each $key, $value in $theme {
-      @if meta.type-of($value) == color {
+      @if $key == 'color-scheme' {
+        @include custom-property.declaration($key, $value);
+
+        color-scheme: custom-property.get-var($key, $value);
+      } @else if meta.type-of($value) == color {
         @include custom-property.declaration($key, $value);
       }
     }

--- a/packages/themes/__tests__/scss-test.js
+++ b/packages/themes/__tests__/scss-test.js
@@ -56,6 +56,7 @@ describe('@carbon/themes/scss', () => {
 
   test('scss/_themes.scss', async () => {
     const { unwrap } = await render(`
+      @use 'sass:map';
       @use '../scss/themes';
 
       // Themes
@@ -63,12 +64,22 @@ describe('@carbon/themes/scss', () => {
       $_: get('themes.$g10', themes.$g10);
       $_: get('themes.$g90', themes.$g90);
       $_: get('themes.$g100', themes.$g100);
+
+      $_: get('color-scheme.white', map.get(themes.$white, 'color-scheme'));
+      $_: get('color-scheme.g10', map.get(themes.$g10, 'color-scheme'));
+      $_: get('color-scheme.g90', map.get(themes.$g90, 'color-scheme'));
+      $_: get('color-scheme.g100', map.get(themes.$g100, 'color-scheme'));
     `);
 
     // Themes should be available
     for (const theme of Object.keys(themes)) {
       expect(unwrap(`themes.$${theme}`)).toBeDefined();
     }
+
+    expect(unwrap('color-scheme.white')).toBe('light');
+    expect(unwrap('color-scheme.g10')).toBe('light');
+    expect(unwrap('color-scheme.g90')).toBe('dark');
+    expect(unwrap('color-scheme.g100')).toBe('dark');
   });
 
   describe('configuration', () => {

--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -55,6 +55,9 @@ import {
 } from '@carbon/colors';
 import { adjustAlpha } from './tools';
 
+// Color scheme
+export const colorScheme = 'light';
+
 // Background
 export const background = gray10;
 export const backgroundInverse = gray80;

--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -56,6 +56,9 @@ import {
 } from '@carbon/colors';
 import { adjustLightness, adjustAlpha } from './tools';
 
+// Color scheme
+export const colorScheme = 'dark';
+
 // Background
 export const background = gray100;
 export const backgroundInverse = gray10;

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -58,6 +58,9 @@ import {
 } from '@carbon/colors';
 import { adjustAlpha } from './tools';
 
+// Color scheme
+export const colorScheme = 'dark';
+
 // Background
 export const background = gray90;
 export const backgroundInverse = gray10;

--- a/packages/themes/src/tokens/__tests__/__snapshots__/v11-test.js.snap
+++ b/packages/themes/src/tokens/__tests__/__snapshots__/v11-test.js.snap
@@ -376,6 +376,7 @@ exports[`v11 v11 token group 1`] = `
   "chat-button-text-selected",
   "highlight",
   "overlay",
+  "color-scheme",
   "toggle-off",
   "shadow",
   "focus",

--- a/packages/themes/src/tokens/__tests__/metadata-test.js
+++ b/packages/themes/src/tokens/__tests__/metadata-test.js
@@ -1462,6 +1462,10 @@ test('metadata', () => {
           "type": "color",
         },
         {
+          "name": "color-scheme",
+          "type": "color",
+        },
+        {
           "name": "toggle-off",
           "type": "color",
         },

--- a/packages/themes/src/tokens/v11TokenGroup.js
+++ b/packages/themes/src/tokens/v11TokenGroup.js
@@ -528,6 +528,10 @@ export const group = TokenGroup.create({
       properties: ['background'],
     },
     {
+      name: 'color-scheme',
+      properties: ['color-scheme'],
+    },
+    {
       name: 'toggle-off',
     },
     {

--- a/packages/themes/src/white.js
+++ b/packages/themes/src/white.js
@@ -55,6 +55,9 @@ import {
 } from '@carbon/colors';
 import { adjustAlpha } from './tools';
 
+// Color scheme
+export const colorScheme = 'light';
+
 // Background
 export const background = white;
 export const backgroundInverse = gray80;

--- a/packages/themes/tasks/builders/compat/themes.js
+++ b/packages/themes/tasks/builders/compat/themes.js
@@ -20,6 +20,7 @@ function buildCompatFile() {
     g90,
     g100,
   };
+  const imports = [t.SassModule('sass:string')];
   const variables = Object.entries(themes).flatMap(([key, theme]) => {
     return [
       t.Newline(),
@@ -47,6 +48,7 @@ function buildCompatFile() {
   return t.StyleSheet([
     // Preamble
     FILE_BANNER,
+    ...imports,
     ...variables,
   ]);
 }

--- a/packages/themes/tasks/builders/modules-button-tokens.js
+++ b/packages/themes/tasks/builders/modules-button-tokens.js
@@ -14,7 +14,7 @@ const { FILE_BANNER, primitive } = require('./shared');
 const { paramCase } = require('change-case-all');
 
 function buildThemesFile() {
-  const imports = [t.SassModule('sass:map')];
+  const imports = [t.SassModule('sass:map'), t.SassModule('sass:string')];
 
   const variables = Object.entries(buttonTokens).flatMap(
     ([key, buttonToken]) => {

--- a/packages/themes/tasks/builders/modules-content-switcher-tokens.js
+++ b/packages/themes/tasks/builders/modules-content-switcher-tokens.js
@@ -16,7 +16,7 @@ const { FILE_BANNER, primitive } = require('./shared');
 const { paramCase } = require('change-case-all');
 
 function buildThemesFile() {
-  const imports = [t.SassModule('sass:map')];
+  const imports = [t.SassModule('sass:map'), t.SassModule('sass:string')];
 
   const variables = Object.entries(contentSwitcherTokens).flatMap(
     ([key, contentSwitcherToken]) => {

--- a/packages/themes/tasks/builders/modules-notification-tokens.js
+++ b/packages/themes/tasks/builders/modules-notification-tokens.js
@@ -16,7 +16,7 @@ const { FILE_BANNER, primitive } = require('./shared');
 const { paramCase } = require('change-case-all');
 
 function buildThemesFile() {
-  const imports = [t.SassModule('sass:map')];
+  const imports = [t.SassModule('sass:map'), t.SassModule('sass:string')];
 
   const variables = Object.entries(notificationTokens).flatMap(
     ([key, notificationToken]) => {

--- a/packages/themes/tasks/builders/modules-status-tokens.js
+++ b/packages/themes/tasks/builders/modules-status-tokens.js
@@ -14,7 +14,7 @@ const { FILE_BANNER, primitive } = require('./shared');
 const { paramCase } = require('change-case-all');
 
 function buildThemesFile() {
-  const imports = [t.SassModule('sass:map')];
+  const imports = [t.SassModule('sass:map'), t.SassModule('sass:string')];
 
   const variables = Object.entries(statusTokens).flatMap(
     ([key, statusToken]) => {

--- a/packages/themes/tasks/builders/modules-tag-tokens.js
+++ b/packages/themes/tasks/builders/modules-tag-tokens.js
@@ -14,7 +14,7 @@ const { FILE_BANNER, primitive } = require('./shared');
 const { paramCase } = require('change-case-all');
 
 function buildThemesFile() {
-  const imports = [t.SassModule('sass:map')];
+  const imports = [t.SassModule('sass:map'), t.SassModule('sass:string')];
 
   const variables = Object.entries(tagTokens).flatMap(([key, tagToken]) => {
     return [

--- a/packages/themes/tasks/builders/modules-themes.js
+++ b/packages/themes/tasks/builders/modules-themes.js
@@ -15,6 +15,7 @@ const { FILE_BANNER, primitive } = require('./shared');
 function buildThemesFile() {
   const imports = [
     t.SassModule('sass:map'),
+    t.SassModule('sass:string'),
     t.SassModule('@carbon/layout'),
     t.SassModule('@carbon/type'),
     t.SassModule('../utilities'),

--- a/packages/themes/tasks/builders/shared.js
+++ b/packages/themes/tasks/builders/shared.js
@@ -32,7 +32,7 @@ function primitive(value) {
     ) {
       return t.SassValue(value);
     }
-    return t.SassValue(`unquote("${value}")`);
+    return t.SassValue(`string.unquote("${value}")`);
   }
   if (typeof value === 'number') {
     return t.SassNumber(value);


### PR DESCRIPTION
Closes #21411 

This improves theming to apply system-level styling that appropriately matches each theme via the [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme) property.

### Changelog

**New**

- Add color-scheme token to each theme
- Use color-scheme property in scss to apply this by default moving forward

**Changed**

- Update tests to cover the new token and output
- Fix some places we were getting sass deprecation warnings about built-in globals going away.
  - Did this by importing sass' string module to use `string.unquote()` instead of `unquote()`, the built in global

#### Testing / Reviewing

- Storybook styles should show:
  - The css custom property defined in the inspector on `:root`
  - The actual color-scheme property being set on `:root` as well

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
