### PR TITLE
ci: needs build to promote package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
             })
 
   packages:
+    needs: build
     runs-on: ubuntu-latest
     # only promote the packages to latest if the version is not a release candidate
     if: contains(github.ref_name, '-rc') == false


### PR DESCRIPTION
Closes N/A

Waits for build to promote package, so we dont have to do it manually during release
edit: since it fails on first run as lerna haven't published the package yet.

### Changelog

**New**

- adds `needs: build`

#### Testing / Reviewing

must be tested in the next release steps

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
