### PR TITLE
feat(react): add tooltipLabel to ComboButton

### DIFF
--- a/packages/react/src/components/ComboButton/ComboButton-test.js
+++ b/packages/react/src/components/ComboButton/ComboButton-test.js
@@ -156,6 +156,22 @@ describe('ComboButton', () => {
 
       expect(tooltip).toHaveTextContent(t());
     });
+
+    it('supports props.tooltipLabel', () => {
+      const tooltipLabel = 'More actions';
+
+      render(
+        <ComboButton label="Primary action" tooltipLabel={tooltipLabel}>
+          <MenuItem label="Additional action" />
+        </ComboButton>
+      );
+
+      const triggerButton = screen.getAllByRole('button')[1];
+      const tooltipId = triggerButton.getAttribute('aria-labelledby');
+      const tooltip = document.getElementById(tooltipId);
+
+      expect(tooltip).toHaveTextContent(tooltipLabel);
+    });
   });
 
   describe('behaves as expected', () => {

--- a/packages/react/src/components/ComboButton/ComboButton.mdx
+++ b/packages/react/src/components/ComboButton/ComboButton.mdx
@@ -27,7 +27,8 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 A `ComboButton` can be used to offer additional, secondary actions in a
 disclosed list next to the primary action. These additional actions must be
 `MenuItem`s passed as `children`. The primary action's label is passed as
-`props.label`.
+`props.label`. Use `tooltipLabel` to override the tooltip text for the trigger
+button and the menu label used for accessibility.
 
 ```jsx
 <ComboButton label="Primary action">

--- a/packages/react/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/react/src/components/ComboButton/ComboButton.stories.js
@@ -87,6 +87,19 @@ export const WithIcons = (args) => {
   );
 };
 
+export const WithCustomTooltipLabel = (args) => {
+  return (
+    <ComboButton
+      label="Primary action"
+      tooltipLabel="More actions"
+      {...args}>
+      <MenuItem label="Second action" />
+      <MenuItem label="Third action" />
+      <MenuItem label="Fourth action" disabled />
+    </ComboButton>
+  );
+};
+
 export const WithMenuAlignment = () => {
   return (
     <>

--- a/packages/react/src/components/ComboButton/index.tsx
+++ b/packages/react/src/components/ComboButton/index.tsx
@@ -86,6 +86,11 @@ interface ComboButtonProps extends TranslateWithId<TranslationKey> {
    * Specify how the trigger tooltip should be aligned.
    */
   tooltipAlignment?: React.ComponentProps<typeof IconButton>['align'];
+
+  /**
+   * Provide a custom label for the trigger tooltip and menu.
+   */
+  tooltipLabel?: string;
 }
 
 const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(
@@ -99,6 +104,7 @@ const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(
       size = 'lg',
       menuAlignment = 'bottom',
       tooltipAlignment,
+      tooltipLabel,
       translateWithId: t = defaultTranslateWithId,
       ...rest
     },
@@ -190,6 +196,8 @@ const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(
       `${prefix}--combo-button__primary-action`
     );
     const triggerClasses = classNames(`${prefix}--combo-button__trigger`);
+    const triggerLabel =
+      tooltipLabel ?? t('carbon.combo-button.additional-actions');
 
     return (
       <div
@@ -209,7 +217,7 @@ const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(
         <IconButton
           ref={refs.setReference}
           className={triggerClasses}
-          label={t('carbon.combo-button.additional-actions')}
+          label={triggerLabel}
           size={size}
           disabled={disabled}
           align={tooltipAlignment}
@@ -226,7 +234,7 @@ const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(
           className={menuClasses}
           ref={refs.setFloating}
           id={id}
-          label={t('carbon.combo-button.additional-actions')}
+          label={triggerLabel}
           size={size}
           open={open}
           onClose={handleClose}>
@@ -327,6 +335,11 @@ ComboButton.propTypes = {
     ],
     mapPopoverAlign
   ),
+
+  /**
+   * Provide a custom label for the trigger tooltip and menu.
+   */
+  tooltipLabel: PropTypes.string,
 
   /**
    * Translates component strings using your i18n tool.


### PR DESCRIPTION
Closes N.A

Add prop to ComboButton to customize the trigger tooltip/menu label

### Changelog

**New**
- Add tooltipLabel prop on ComboButton to override trigger tooltip text and menu label

**Changed**
- Update ComboButton docs and Storybook to showcase tooltipLabel

**Removed**
- N.A

#### Testing / Reviewing
- Review: verify tooltip text and menu label update when tooltipLabel is provided
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
