### PR TITLE
chore: fix version listings for @carbon/feature-flags

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.27.3",
-    "@carbon/feature-flags": "workspace:1.0.0",
+    "@carbon/feature-flags": "^1.0.0",
     "@carbon/icons-react": "^11.75.0",
     "@carbon/layout": "^11.48.0",
     "@carbon/styles": "^1.100.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@carbon/colors": "^11.47.0",
-    "@carbon/feature-flags": "workspace:1.0.0",
+    "@carbon/feature-flags": "^1.0.0",
     "@carbon/grid": "^11.50.0",
     "@carbon/layout": "^11.48.0",
     "@carbon/motion": "^11.41.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/feature-flags@workspace:1.0.0, @carbon/feature-flags@workspace:packages/feature-flags":
+"@carbon/feature-flags@npm:^1.0.0, @carbon/feature-flags@workspace:packages/feature-flags":
   version: 0.0.0-use.local
   resolution: "@carbon/feature-flags@workspace:packages/feature-flags"
   dependencies:
@@ -1885,7 +1885,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.27.1"
     "@babel/preset-typescript": "npm:^7.27.1"
     "@babel/runtime": "npm:^7.27.3"
-    "@carbon/feature-flags": "workspace:1.0.0"
+    "@carbon/feature-flags": "npm:^1.0.0"
     "@carbon/icons-react": "npm:^11.75.0"
     "@carbon/layout": "npm:^11.48.0"
     "@carbon/styles": "npm:^1.100.0"
@@ -1962,7 +1962,7 @@ __metadata:
   resolution: "@carbon/styles@workspace:packages/styles"
   dependencies:
     "@carbon/colors": "npm:^11.47.0"
-    "@carbon/feature-flags": "workspace:1.0.0"
+    "@carbon/feature-flags": "npm:^1.0.0"
     "@carbon/grid": "npm:^11.50.0"
     "@carbon/layout": "npm:^11.48.0"
     "@carbon/motion": "npm:^11.41.0"


### PR DESCRIPTION
Refs #21019.

Starting with carbon-design-system#20794, package.json has a weird workspace: prefix for the @carbon/feature-flags version, rather than using the caret.

This commit switches to the standard syntax.  Perhaps the old syntax was useful when @carbon/feature-flags had a 0.* version, but I think now it's counterproductive.

### Changelog

**Changed**

- Update package.json files to use caret syntax for @carbon/feature-flags,


#### Testing / Reviewing

Just running unit tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
