### PR TITLE
build(lint-staged): run via yarn and enable stylelint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ css
 # Caches
 .cache
 .eslintcache
+.stylelintcache
 
 # Logs
 logs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install lint-staged
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -134,20 +134,17 @@
   },
   "lint-staged": {
     "**/*.{cjs,js,jsx,mjs,ts,tsx}": [
-      "yarn prettier --cache --write",
+      "prettier --cache --write",
       "eslint --cache --fix --max-warnings 0 --no-warn-ignored"
     ],
     "**/*.scss": [
-      "yarn prettier --cache --write",
-      "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
+      "prettier --cache --write",
+      "stylelint --cache --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
     ],
     "!(*sass).md": [
-      "yarn prettier --cache --write"
+      "prettier --cache --write"
     ],
-    "README.md": [
-      "all-contributors generate"
-    ],
-    ".all-contributorsrc": [
+    "{README.md,.all-contributorsrc}": [
       "all-contributors generate"
     ]
   },


### PR DESCRIPTION
No issue.

Ran `lint-staged` via `yarn` and enabled `stylelint` caching.

### Changelog

**New**

- Enabled `stylelint` caching.

**Changed**

- Ran `lint-staged` via `yarn`.

#### Testing / Reviewing

My goal was to speed up `lint-staged`. Performance could likely be improved further by updating `husky`.

I considered https://github.com/carbon-design-system/carbon/pull/18112 while making these changes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
