### PR TITLE
fix(accordion-item): avoid state updates during render

### DIFF
--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,8 @@ import React, {
   ReactElement,
   ReactNode,
   useContext,
+  useEffect,
+  useRef,
   useState,
 } from 'react';
 import { Text } from '../Text';
@@ -127,7 +129,7 @@ function AccordionItem({
   ...rest
 }: PropsWithChildren<AccordionItemProps>) {
   const [isOpen, setIsOpen] = useState(open);
-  const [prevIsOpen, setPrevIsOpen] = useState(open);
+  const prevOpenRef = useRef(open);
   const accordionState = useContext(AccordionContext);
 
   const disabledIsControlled = typeof controlledDisabled === 'boolean';
@@ -159,10 +161,12 @@ function AccordionItem({
     [isOpen]
   );
 
-  if (open !== prevIsOpen) {
-    setIsOpen(open);
-    setPrevIsOpen(open);
-  }
+  useEffect(() => {
+    if (open !== prevOpenRef.current) {
+      setIsOpen(open);
+      prevOpenRef.current = open;
+    }
+  }, [open]);
 
   // When the AccordionItem heading is clicked, toggle the open state of the
   // panel

--- a/packages/react/src/components/Accordion/__tests__/AccordionItem-test.js
+++ b/packages/react/src/components/Accordion/__tests__/AccordionItem-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -66,6 +66,31 @@ describe('AccordionItem', () => {
       expect(screen.getByRole('button')).toHaveAttribute(
         'aria-expanded',
         'true'
+      );
+    });
+
+    it('should update open state when open prop changes', () => {
+      const { rerender } = render(
+        <AccordionItem title="Test title" open={false} />
+      );
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+
+      rerender(<AccordionItem title="Test title" open />);
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+
+      rerender(<AccordionItem title="Test title" open={false} />);
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-expanded',
+        'false'
       );
     });
 


### PR DESCRIPTION
No issue.

Avoided state updates during render in `AccordionItem`.

### Changelog

**Changed**

- Avoided state updates during render in `AccordionItem`.

#### Testing / Reviewing

`AccordionItem` was setting state during render which is an anti-pattern.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
