### PR TITLE
fix(search): treat 0 as content in search components

### DIFF
--- a/packages/react/src/components/ExpandableSearch/ExpandableSearch-test.js
+++ b/packages/react/src/components/ExpandableSearch/ExpandableSearch-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ describe('ExpandableSearch', () => {
       expect(container.firstChild).toHaveClass(`${prefix}--search--expanded`);
     });
 
-    it('is renders a defaultValue', () => {
+    it('renders a defaultValue', () => {
       render(
         <ExpandableSearch
           defaultValue="This is default text"
@@ -149,6 +149,36 @@ describe('ExpandableSearch', () => {
 
       expect(container.firstChild).toHaveClass(`${prefix}--search--expanded`);
     });
+
+    it.each([
+      { label: 'empty string', value: '', shouldRemainExpanded: false },
+      { label: 'zero', value: 0, shouldRemainExpanded: true },
+      { label: 'non-empty string', value: 'hmm', shouldRemainExpanded: true },
+      { label: 'undefined', value: undefined, shouldRemainExpanded: false },
+    ])(
+      'should handle blur when defaultValue is $label',
+      async ({ value, shouldRemainExpanded }) => {
+        const { container } = render(
+          <>
+            <ExpandableSearch defaultValue={value} labelText="test-search" />
+            <button type="button">second-element</button>
+          </>
+        );
+
+        await userEvent.click(screen.getAllByRole('button')[0]);
+        await userEvent.click(screen.getByText('second-element'));
+
+        if (shouldRemainExpanded) {
+          expect(container.firstChild).toHaveClass(
+            `${prefix}--search--expanded`
+          );
+        } else {
+          expect(container.firstChild).not.toHaveClass(
+            `${prefix}--search--expanded`
+          );
+        }
+      }
+    );
 
     it('closes and clears value on escape', async () => {
       const { container } = render(

--- a/packages/react/src/components/ExpandableSearch/ExpandableSearch.tsx
+++ b/packages/react/src/components/ExpandableSearch/ExpandableSearch.tsx
@@ -12,6 +12,7 @@ import { usePrefix } from '../../internal/usePrefix';
 import { composeEventHandlers } from '../../tools/events';
 import { match, keys } from '../../internal/keyboard';
 import { mergeRefs } from '../../tools/mergeRefs';
+import { isSearchValuePresent } from '../Search/utils';
 
 const frFn = forwardRef<HTMLInputElement, SearchProps>;
 
@@ -27,7 +28,9 @@ const ExpandableSearch = frFn((props, forwardedRef) => {
   } = props;
 
   const [expanded, setExpanded] = useState(isExpanded || false);
-  const [hasContent, setHasContent] = useState(Boolean(defaultValue));
+  const [hasContent, setHasContent] = useState(
+    isSearchValuePresent(defaultValue)
+  );
   const searchRef = useRef<HTMLInputElement>(null);
   const prefix = usePrefix();
 

--- a/packages/react/src/components/Search/Search-test.js
+++ b/packages/react/src/components/Search/Search-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,6 +11,12 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
 const prefix = 'cds';
+const contentScenarios = [
+  { label: 'empty string', value: '', hasContent: false },
+  { label: 'zero', value: 0, hasContent: true },
+  { label: 'non-empty string', value: 'hmm', hasContent: true },
+  { label: 'undefined', value: undefined, hasContent: false },
+];
 
 describe('Search', () => {
   describe('renders as expected - Component API', () => {
@@ -51,6 +57,23 @@ describe('Search', () => {
 
       expect(screen.getByRole('searchbox')).toHaveValue('test-value');
     });
+
+    it.each(contentScenarios)(
+      'should treat a defaultValue of $label as content',
+      ({ value, hasContent }) => {
+        render(<Search labelText="test-search" defaultValue={value} />);
+
+        if (hasContent) {
+          expect(screen.getByLabelText('Clear search input')).not.toHaveClass(
+            `${prefix}--search-close--hidden`
+          );
+        } else {
+          expect(screen.getByLabelText('Clear search input')).toHaveClass(
+            `${prefix}--search-close--hidden`
+          );
+        }
+      }
+    );
 
     it('should respect disabled prop', () => {
       render(<Search labelText="test-search" disabled />);
@@ -204,5 +227,22 @@ describe('Search', () => {
 
       expect(screen.getByRole('searchbox')).toHaveValue('test-value');
     });
+
+    it.each(contentScenarios)(
+      'should treat a value of $label as content',
+      ({ value, hasContent }) => {
+        render(<Search labelText="test-search" value={value} />);
+
+        if (hasContent) {
+          expect(screen.getByLabelText('Clear search input')).not.toHaveClass(
+            `${prefix}--search-close--hidden`
+          );
+        } else {
+          expect(screen.getByLabelText('Clear search input')).toHaveClass(
+            `${prefix}--search-close--hidden`
+          );
+        }
+      }
+    );
   });
 });

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -28,6 +28,7 @@ import { deprecate } from '../../prop-types/deprecate';
 import { FormContext } from '../FluidForm';
 import { noopFn } from '../../internal/noopFn';
 import { Tooltip } from '../Tooltip';
+import { isSearchValuePresent } from './utils';
 
 type InputPropsBase = Omit<HTMLAttributes<HTMLInputElement>, 'onChange'>;
 export interface SearchProps extends InputPropsBase {
@@ -151,7 +152,8 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
     },
     forwardRef
   ) => {
-    const hasPropValue = Boolean(value || defaultValue);
+    const hasPropValue =
+      isSearchValuePresent(value) || isSearchValuePresent(defaultValue);
     const prefix = usePrefix();
     const { isFluid } = useContext(FormContext);
     const inputRef = useRef<HTMLInputElement>(null);
@@ -181,7 +183,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
     });
 
     if (value !== prevValue) {
-      setHasContent(!!value);
+      setHasContent(isSearchValuePresent(value));
       setPrevValue(value);
     }
 

--- a/packages/react/src/components/Search/utils.ts
+++ b/packages/react/src/components/Search/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const isSearchValuePresent = (value: string | number | undefined) =>
+  value !== '' && typeof value !== 'undefined';


### PR DESCRIPTION
No issue.

Treated `0` as content in `Search` components.

### Changelog

**Changed**

- Treated `0` as content in `Search` components.

#### Testing / Reviewing

Run tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
