### PR TITLE
fix(data-table): document legacy search sentinel and fix types

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -10,7 +10,6 @@ import React, { // eslint-disable-line @typescript-eslint/no-unused-vars -- http
   useEffect,
   useMemo,
   useState,
-  type ChangeEvent,
   type MouseEvent,
   type ReactElement,
   type ReactNode,
@@ -44,7 +43,9 @@ import TableSlugRow from './TableSlugRow';
 import TableToolbar from './TableToolbar';
 import TableToolbarAction from './TableToolbarAction';
 import TableToolbarContent from './TableToolbarContent';
-import TableToolbarSearch from './TableToolbarSearch';
+import TableToolbarSearch, {
+  type TableToolbarSearchOnChangeEvent,
+} from './TableToolbarSearch';
 import TableToolbarMenu from './TableToolbarMenu';
 import type { TranslateWithId, TFunc } from '../../types/common';
 import { deprecate } from '../../prop-types/deprecate';
@@ -242,9 +243,12 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
 
   /**
    * Handles input value changes.
+   *
+   * Note: the `''` event sentinel is supported for compatibility with
+   * `TableToolbarSearch` and should be removed in the next major release.
    */
   onInputChange: (
-    event: ChangeEvent<HTMLInputElement>,
+    event: TableToolbarSearchOnChangeEvent,
     defaultValue?: string
   ) => void;
 
@@ -811,10 +815,12 @@ export const DataTable = <RowType, ColTypes extends any[]>(
    * Event handler for table filter input changes.
    */
   const handleOnInputValueChange = (
-    event: ChangeEvent<HTMLInputElement>,
+    event: TableToolbarSearchOnChangeEvent,
     defaultValue?: string
   ) => {
-    const value = defaultValue || event.target?.value;
+    // TODO: Remove `''` sentinel support once `TableToolbarSearch` no
+    // longer emits it on mount.
+    const value = defaultValue ?? (event === '' ? event : event.target.value);
 
     setState((prev) => ({ ...prev, filterInputValue: value }));
   };

--- a/packages/react/src/components/DataTable/TableToolbarSearch.tsx
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -53,6 +53,15 @@ export type TableToolbarSearchHandleExpand = (
   newValue?: boolean
 ) => void;
 
+/**
+ * @deprecated Passing `''` as the event sentinel is legacy compatibility
+ * behavior for `DataTable` filtering. In the next major release, this type
+ * should become an optional `ChangeEvent<HTMLInputElement>` instead.
+ */
+export type TableToolbarSearchOnChangeEvent =
+  | ''
+  | ChangeEvent<HTMLInputElement>;
+
 export interface TableToolbarSearchProps
   extends Omit<SearchProps, ExcludedInheritedProps>,
     TranslateWithId<TranslationKey> {
@@ -88,11 +97,11 @@ export interface TableToolbarSearchProps
 
   /**
    * Provide an optional hook that is called each time the input is updated
+   *
+   * Note: the `''` event sentinel is legacy compatibility behavior and will be
+   * removed in the next major release.
    */
-  onChange?: (
-    event: '' | ChangeEvent<HTMLInputElement>,
-    value?: string
-  ) => void;
+  onChange?: (event: TableToolbarSearchOnChangeEvent, value?: string) => void;
 
   /**
    * Provide an optional hook that is called each time the input is expanded
@@ -166,6 +175,8 @@ const TableToolbarSearch = ({
   useEffect(
     () => {
       if (defaultValue) {
+        // TODO: Remove the `''` event sentinel and pass `undefined` for
+        // value initialization in the next major release.
         onChangeProp?.('', defaultValue);
       }
     },

--- a/packages/react/src/components/DataTable/__tests__/TableToolbarSearch-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableToolbarSearch-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -113,6 +113,15 @@ describe('TableToolbarSearch', () => {
       );
       await userEvent.tab();
       expect(onChange).toHaveBeenCalled();
+    });
+
+    it('should call onChange on mount with empty string event sentinel when defaultValue is provided', () => {
+      const onChange = jest.fn();
+
+      render(<TableToolbarSearch onChange={onChange} defaultValue="preset" />);
+
+      expect(onChange).toHaveBeenCalledWith('', 'preset');
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
 
     it('should expand/contract as normal when no onBlur/onFocus provided', async () => {

--- a/packages/react/src/components/DataTable/stories/examples/TableToolbarFilter.tsx
+++ b/packages/react/src/components/DataTable/stories/examples/TableToolbarFilter.tsx
@@ -37,6 +37,9 @@ interface TableToolbarFilterProps {
 
   /**
    * Provide an optional hook that is called each time the input is updated
+   *
+   * Note: the `''` event sentinel exists for `DataTable` compatibility and
+   * should be removed in the next major release.
    */
   onChange?: (event: '' | ChangeEvent<HTMLInputElement>) => void;
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18177

Documented legacy `DataTable` search sentinel and fixed types.

### Changelog

**Changed**

- Documented legacy `DataTable` search sentinel.
- Fixed `DataTable` types.

#### Testing / Reviewing

I deprecated the search sentinel functionality. If it needs to be retained, let me know. During my testing, it didn't appear to be necessary. However, removing it now would be a breaking change.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
