### PR TITLE
fix(content-switcher): align props and docs for required usage

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -48,6 +48,10 @@ describe('ContentSwitcher - RTL', () => {
 
       expect(screen.getAllByRole('tab')[0]).toHaveAttribute('tabindex', '0');
       expect(screen.getAllByRole('tab')[0]).toHaveClass(
+        'cds--content-switcher--selected'
+      );
+      expect(screen.getAllByRole('tab')[1]).toHaveAttribute('tabindex', '-1');
+      expect(screen.getAllByRole('tab')[1]).not.toHaveClass(
         'cds--content-switcher--selected'
       );
     });
@@ -117,6 +121,46 @@ describe('ContentSwitcher - RTL', () => {
 
       expect(screen.getAllByRole('tab')[2]).toHaveAttribute('tabindex', '0');
       expect(screen.getAllByRole('tab')[2]).toHaveClass(
+        'cds--content-switcher--selected'
+      );
+      expect(screen.getAllByRole('tab')[1]).toHaveAttribute('tabindex', '-1');
+      expect(screen.getAllByRole('tab')[1]).not.toHaveClass(
+        'cds--content-switcher--selected'
+      );
+    });
+
+    it('should update selected index when `selectedIndex` prop changes', () => {
+      const { rerender } = render(
+        <ContentSwitcher onChange={() => {}} selectedIndex={0}>
+          <Switch name="one" text="First section" />
+          <Switch name="two" text="Second section" />
+          <Switch name="three" text="Third section" />
+        </ContentSwitcher>
+      );
+
+      expect(screen.getAllByRole('tab')[0]).toHaveAttribute('tabindex', '0');
+      expect(screen.getAllByRole('tab')[0]).toHaveClass(
+        'cds--content-switcher--selected'
+      );
+      expect(screen.getAllByRole('tab')[2]).toHaveAttribute('tabindex', '-1');
+      expect(screen.getAllByRole('tab')[2]).not.toHaveClass(
+        'cds--content-switcher--selected'
+      );
+
+      rerender(
+        <ContentSwitcher onChange={() => {}} selectedIndex={2}>
+          <Switch name="one" text="First section" />
+          <Switch name="two" text="Second section" />
+          <Switch name="three" text="Third section" />
+        </ContentSwitcher>
+      );
+
+      expect(screen.getAllByRole('tab')[2]).toHaveAttribute('tabindex', '0');
+      expect(screen.getAllByRole('tab')[2]).toHaveClass(
+        'cds--content-switcher--selected'
+      );
+      expect(screen.getAllByRole('tab')[0]).toHaveAttribute('tabindex', '-1');
+      expect(screen.getAllByRole('tab')[0]).not.toHaveClass(
         'cds--content-switcher--selected'
       );
     });

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
@@ -90,17 +90,19 @@ specifying a custom class name for layout.
 ### ContentSwitcher `light`
 
 In certain circumstances, a `ContentSwitcher` will exist on a container element
-with the same background color. To improve contrast, you can use the `light`
-property to toggle the light variant of the `ContentSwitcher`.
+with the same background color. To improve contrast, set the `light` property to
+toggle the light variant of the `ContentSwitcher`.
 
 ```jsx
-<ContentSwitcher light>...</ContentSwitcher>
+<ContentSwitcher light onChange={() => {}}>
+  ...
+</ContentSwitcher>
 ```
 
 ### ContentSwitcher `onChange`
 
-This is a required prop. You will need to specify a function to run when the
-selection of the `ContentSwitcher` is changed.
+This required prop specifies a function to run when the selection of the
+`ContentSwitcher` changes.
 
 ```jsx
 <ContentSwitcher
@@ -113,8 +115,9 @@ selection of the `ContentSwitcher` is changed.
 
 ### ContentSwitcher `selectedIndex`
 
-This prop allows you to specify which `ContentSwitcher` index you would like to
-be selected on initial render. This number defaults to `0`.
+This prop specifies which `ContentSwitcher` index should be selected. This
+number defaults to `0`, and updates to this prop will update the selected
+switch.
 
 <ContentSwitcher selectedIndex={2} onChange={() => {}}>
   <Switch name="one" text="First section" />
@@ -133,10 +136,10 @@ be selected on initial render. This number defaults to `0`.
 ### ContentSwitcher `selectionMode`
 
 By default, when a `ContentSwitcher` is focused and an arrow key is pressed, the
-selection is updated immediately and the `onChange` is fired. However, sometimes
-you may want to only change the `selectedIndex` once a selection has been made.
-To do this, you can set the `selectionMode` to `manual`, and the `onChange` will
-only fire when a selection is made.
+selection is updated immediately and the `onChange` is fired. In some cases, it
+is preferable to change `selectedIndex` only once a selection has been made. To
+do this, set `selectionMode` to `manual`, and the `onChange` will only fire when
+a selection is made.
 
 <ContentSwitcher
   selectionMode="manual"
@@ -166,7 +169,7 @@ The className prop passed into `Switch` will be forwarded along to the
 underlying wrapper `button` element.
 
 ```jsx
-<ContentSwitcher>
+<ContentSwitcher onChange={() => {}}>
   <Switch className="switch-one" />
   <Switch className="switch-two " />
 </ContentSwitcher>
@@ -174,17 +177,17 @@ underlying wrapper `button` element.
 
 ### Switch `disabled`
 
-You can disable the `ContentSwitcher` by passing in `disabled` to the `Switch`
+The `ContentSwitcher` can be disabled by passing `disabled` to the `Switch`
 elements directly.
 
-<ContentSwitcher>
+<ContentSwitcher onChange={() => {}}>
   <Switch disabled name="one" text="First section" />
   <Switch disabled name="two" text="Second section" />
   <Switch disabled name="three" text="Third section" />
 </ContentSwitcher>
 
 ```jsx
-<ContentSwitcher>
+<ContentSwitcher onChange={() => {}}>
   <Switch disabled name="one" text="First section" />
   <Switch disabled name="two" text="Second section" />
   <Switch disabled name="three" text="Third section" />

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.stories.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,12 +11,7 @@ import { WithLayer } from '../../../.storybook/templates/WithLayer';
 import { ContentSwitcher } from './ContentSwitcher';
 import { Switch, IconSwitch } from '../Switch';
 import mdx from './ContentSwitcher.mdx';
-import {
-  TableOfContents,
-  Workspace,
-  ViewMode_2,
-  Icon,
-} from '@carbon/icons-react';
+import { TableOfContents, Workspace, ViewMode_2 } from '@carbon/icons-react';
 
 export default {
   title: 'Components/ContentSwitcher',

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -25,7 +25,6 @@ import { LayoutConstraint } from '../Layout';
 import { composeEventHandlers } from '../../tools/events';
 import { getNextIndex, matches, keys } from '../../internal/keyboard';
 import { PrefixContext } from '../../internal/usePrefix';
-import { noopFn } from '../../internal/noopFn';
 import { IconSwitch } from '../Switch';
 import type { SwitchEventHandlersParams } from '../Switch/Switch';
 
@@ -64,7 +63,7 @@ export interface ContentSwitcherProps
   /**
    * Specify a selected index for the initially selected content
    */
-  selectedIndex: number;
+  selectedIndex?: number;
 
   /**
    * Choose whether or not to automatically change selection on focus when left/right arrow pressed. Defaults to 'automatic'
@@ -74,7 +73,7 @@ export interface ContentSwitcherProps
   /**
    * Specify the size of the Content Switcher. Currently supports either `sm`, `md` (default) or `lg` as an option.
    */
-  size: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg';
 }
 
 export const ContentSwitcher = ({
@@ -85,7 +84,7 @@ export const ContentSwitcher = ({
   selectedIndex: selectedIndexProp = 0,
   selectionMode = 'automatic',
   size,
-  onChange = noopFn,
+  onChange,
   ...other
 }: ContentSwitcherProps) => {
   const prefix = useContext(PrefixContext);


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18276

Aligned `ContentSwitcher` props and documentation for required usage.

### Changelog

**Changed**

- Aligned `ContentSwitcher` props and documentation for required usage.

#### Testing / Reviewing

Run tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
