### PR TITLE
fix(password-input): correct helperText aria-describedby logic

### DIFF
--- a/packages/react/src/components/TextInput/ControlledPasswordInput.tsx
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.tsx
@@ -137,11 +137,9 @@ const ControlledPasswordInput = forwardRef<
       hideLabel,
       invalid = false,
       invalidText = '',
-      helperText = '',
+      helperText,
       light,
-
       type = 'password',
-
       togglePasswordVisibility,
       tooltipPosition = 'bottom',
       tooltipAlignment = 'center',

--- a/packages/react/src/components/TextInput/__tests__/ControlledPasswordInput-test.js
+++ b/packages/react/src/components/TextInput/__tests__/ControlledPasswordInput-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -272,6 +272,32 @@ describe('ControlledPasswordInput Component', () => {
       />
     );
     expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('should not set `aria-describedby` when `helperText` is omitted', () => {
+    render(
+      <ControlledPasswordInput id="password-input" labelText="Password" />
+    );
+
+    expect(screen.getByLabelText('Password')).not.toHaveAttribute(
+      'aria-describedby'
+    );
+  });
+
+  it('should set `aria-describedby` when `helperText` is `0`', () => {
+    render(
+      <ControlledPasswordInput
+        id="password-input"
+        labelText="label"
+        helperText={0}
+      />
+    );
+
+    const input = screen.getByLabelText('label');
+    const helperId = input.getAttribute('aria-describedby');
+
+    expect(helperId).toMatch(/^controlled-password-helper-text-/);
+    expect(document.getElementById(helperId)).toHaveTextContent('0');
   });
 
   it('should render labelText with value 0', () => {


### PR DESCRIPTION
No issue.

Corrected `helperText` `aria-describedby` handling in `ControlledPasswordInput`.

### Changelog

**Changed**

- Corrected `helperText` `aria-describedby` handling in `ControlledPasswordInput`.

#### Testing / Reviewing

Run tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
