### PR TITLE
test(use-id): increase coverage

### DIFF
--- a/packages/react/src/internal/__tests__/useId-test.js
+++ b/packages/react/src/internal/__tests__/useId-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,8 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { useId, useFallbackId } from '../useId';
+import { useId, useFallbackId, useCompatibleId } from '../useId';
+import { IdPrefixContext } from '../useIdPrefix';
 
 describe('useId', () => {
   it('should generate a unique id that is stable across renders', () => {
@@ -38,5 +39,103 @@ describe('useId', () => {
 
     render(<Test />);
     expect(screen.getByText('test')).toHaveAttribute('id', 'idReceived');
+  });
+
+  it('should include context prefix when using useId', () => {
+    const Test = () => {
+      const id = useId('test');
+
+      return <span data-testid="react-id">{id}</span>;
+    };
+
+    render(
+      <IdPrefixContext.Provider value="beep">
+        <Test />
+      </IdPrefixContext.Provider>
+    );
+
+    expect(screen.getByTestId('react-id')).toHaveTextContent(/^beep-test-/);
+  });
+});
+
+describe('useCompatibleId', () => {
+  it('should patch from null with default prefix for both context and non-context values', () => {
+    const Test = ({ testId }) => {
+      const id = useCompatibleId();
+
+      return <span data-testid={testId}>{id ?? 'null'}</span>;
+    };
+
+    render(
+      <>
+        <Test testId="compat-default-no-context" />
+        <IdPrefixContext.Provider value="bop">
+          <Test testId="compat-default-with-context" />
+        </IdPrefixContext.Provider>
+      </>
+    );
+
+    expect(screen.getByTestId('compat-default-no-context')).toHaveTextContent(
+      /^id-\d+$/
+    );
+    expect(screen.getByTestId('compat-default-with-context')).toHaveTextContent(
+      /^bop-id-\d+$/
+    );
+  });
+
+  it('should patch an `id` on first render before handoff is completed', () => {
+    const Test = () => {
+      const id = useCompatibleId('compat');
+
+      return <span data-testid="compat-id">{id ?? 'null'}</span>;
+    };
+
+    render(<Test />);
+
+    expect(screen.getByTestId('compat-id')).toHaveTextContent(/^compat-\d+$/);
+  });
+
+  it('should initialize synchronously after handoff and include context prefix', () => {
+    const Test = () => {
+      const id = useCompatibleId('compat');
+
+      return <span data-testid="compat-id">{id ?? 'null'}</span>;
+    };
+
+    const { unmount } = render(<Test />);
+
+    expect(screen.getByTestId('compat-id')).toHaveTextContent(/^compat-\d+$/);
+
+    unmount();
+    render(
+      <IdPrefixContext.Provider value="boop">
+        <Test />
+      </IdPrefixContext.Provider>
+    );
+
+    expect(screen.getByTestId('compat-id')).toHaveTextContent(
+      /^boop-compat-\d+$/
+    );
+  });
+
+  it('should select `useCompatibleId` when `React.useId` is unavailable', () => {
+    jest.isolateModules(() => {
+      jest.doMock('react', () => {
+        const actual = jest.requireActual('react');
+
+        return {
+          __esModule: true,
+          ...actual,
+          default: { ...actual, useId: undefined },
+          useId: undefined,
+        };
+      });
+
+      const useIdModule = require('../useId');
+
+      expect(useIdModule.useId).toBe(useIdModule.useCompatibleId);
+
+      jest.dontMock('react');
+    });
   });
 });

--- a/packages/react/src/internal/useId.js
+++ b/packages/react/src/internal/useId.js
@@ -52,8 +52,6 @@ const defaultId = 'id';
 /**
  * Generate a unique ID for React <=17 with an optional prefix prepended to it.
  * This is an internal utility, not intended for public usage.
- * @param {string} [prefix]
- * @returns {string}
  */
 export function useCompatibleId(prefix = defaultId) {
   const contextPrefix = useIdPrefix();
@@ -61,7 +59,7 @@ export function useCompatibleId(prefix = defaultId) {
   const [id, setId] = useState(() => {
     if (serverHandoffCompleted) {
       return `${
-        contextPrefix ? `${contextPrefix}-` : ``
+        contextPrefix ? `${contextPrefix}-` : ''
       }${prefix}-${instanceId()}`;
     }
     return null;
@@ -70,7 +68,7 @@ export function useCompatibleId(prefix = defaultId) {
   useIsomorphicEffect(() => {
     if (id === null) {
       setId(
-        `${contextPrefix ? `${contextPrefix}-` : ``}${prefix}-${instanceId()}`
+        `${contextPrefix ? `${contextPrefix}-` : ''}${prefix}-${instanceId()}`
       );
     }
   }, [instanceId]);
@@ -87,13 +85,11 @@ export function useCompatibleId(prefix = defaultId) {
 /**
  * Generate a unique ID for React >=18 with an optional prefix prepended to it.
  * This is an internal utility, not intended for public usage.
- * @param {string} [prefix]
- * @returns {string}
  */
 function useReactId(prefix = defaultId) {
   const contextPrefix = useIdPrefix();
   return `${
-    contextPrefix ? `${contextPrefix}-` : ``
+    contextPrefix ? `${contextPrefix}-` : ''
   }${prefix}-${_React.useId()}`;
 }
 
@@ -107,8 +103,7 @@ export const useId = _React.useId ? useReactId : useCompatibleId;
 /**
  * Generate a unique id if a given `id` is not provided
  * This is an internal utility, not intended for public usage.
- * @param {string|undefined} id
- * @returns {string}
+ * @param {string} [id]
  */
 export function useFallbackId(id) {
   const fallback = useId();

--- a/packages/react/src/internal/useId.js
+++ b/packages/react/src/internal/useId.js
@@ -52,6 +52,8 @@ const defaultId = 'id';
 /**
  * Generate a unique ID for React <=17 with an optional prefix prepended to it.
  * This is an internal utility, not intended for public usage.
+ * @param {string} [prefix]
+ * @returns {string}
  */
 export function useCompatibleId(prefix = defaultId) {
   const contextPrefix = useIdPrefix();
@@ -59,7 +61,7 @@ export function useCompatibleId(prefix = defaultId) {
   const [id, setId] = useState(() => {
     if (serverHandoffCompleted) {
       return `${
-        contextPrefix ? `${contextPrefix}-` : ''
+        contextPrefix ? `${contextPrefix}-` : ``
       }${prefix}-${instanceId()}`;
     }
     return null;
@@ -68,7 +70,7 @@ export function useCompatibleId(prefix = defaultId) {
   useIsomorphicEffect(() => {
     if (id === null) {
       setId(
-        `${contextPrefix ? `${contextPrefix}-` : ''}${prefix}-${instanceId()}`
+        `${contextPrefix ? `${contextPrefix}-` : ``}${prefix}-${instanceId()}`
       );
     }
   }, [instanceId]);
@@ -85,11 +87,13 @@ export function useCompatibleId(prefix = defaultId) {
 /**
  * Generate a unique ID for React >=18 with an optional prefix prepended to it.
  * This is an internal utility, not intended for public usage.
+ * @param {string} [prefix]
+ * @returns {string}
  */
 function useReactId(prefix = defaultId) {
   const contextPrefix = useIdPrefix();
   return `${
-    contextPrefix ? `${contextPrefix}-` : ''
+    contextPrefix ? `${contextPrefix}-` : ``
   }${prefix}-${_React.useId()}`;
 }
 
@@ -103,7 +107,8 @@ export const useId = _React.useId ? useReactId : useCompatibleId;
 /**
  * Generate a unique id if a given `id` is not provided
  * This is an internal utility, not intended for public usage.
- * @param {string} [id]
+ * @param {string|undefined} id
+ * @returns {string}
  */
 export function useFallbackId(id) {
   const fallback = useId();


### PR DESCRIPTION
No issue.

Increased test coverage for `useId` hooks and fixed types.

### Changelog

**Changed**

- Increased test coverage for `useId` hooks.
- Fixed types for `useId` hooks.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath \
  packages/react/src/internal/__tests__/useId-test.js \
  packages/react/src/internal/__tests__/useId.server-test.js \
  --collectCoverageFrom=packages/react/src/internal/useId.js \
  --coverageReporters=text-summary
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
