### PR TITLE
fix(overflow-menu): floating menu stays attached in scroll containers

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2170,6 +2170,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "krasnoff",
+      "name": "Kobi Krasnoff",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3822883?v=4",
+      "profile": "https://krasnoff-personal-web-app.vercel.app/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/Pradumn11"><img src="https://avatars.githubusercontent.com/u/99590317?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Pradumnya Zendphale</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Pradumn11" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/suniltc-ibm"><img src="https://avatars.githubusercontent.com/u/186133269?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sunil TC</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=suniltc-ibm" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/baadhira"><img src="https://avatars.githubusercontent.com/u/69342013?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Badira P P</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=baadhira" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/harishjanardhanan"><img src="https://avatars.githubusercontent.com/u/32760275?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Harish</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=harishjanardhanan" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://krasnoff-personal-web-app.vercel.app/"><img src="https://avatars.githubusercontent.com/u/3822883?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kobi Krasnoff</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=krasnoff" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import { Filter } from '@carbon/icons-react';
 import OverflowMenu from './OverflowMenu';
@@ -19,8 +25,8 @@ describe('OverflowMenu', () => {
     it('should support a custom `className` prop on the button element', () => {
       render(
         <OverflowMenu open aria-label="Overflow menu" className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
       expect(screen.getByRole('button')).toHaveClass('extra-class');
@@ -30,8 +36,8 @@ describe('OverflowMenu', () => {
       const ref = React.createRef();
       render(
         <OverflowMenu open ref={ref} aria-label="Overflow menu">
-          <OverflowMenuItem itemText="one" />
-          <OverflowMenuItem itemText="two" />
+          <OverflowMenuItem itemText="one" href="#" />
+          <OverflowMenuItem itemText="two" href="#" />
         </OverflowMenu>
       );
       expect(ref.current).toBeInstanceOf(HTMLButtonElement);
@@ -43,8 +49,8 @@ describe('OverflowMenu', () => {
           data-testid="test"
           aria-label="Overflow menu"
           className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
       expect(screen.getByRole('button')).toHaveAttribute('data-testid', 'test');
@@ -56,8 +62,8 @@ describe('OverflowMenu', () => {
           data-testid="test"
           aria-label="Overflow menu"
           className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -71,8 +77,8 @@ describe('OverflowMenu', () => {
           flipped={true}
           aria-label="Overflow menu"
           className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -91,8 +97,8 @@ describe('OverflowMenu', () => {
           aria-label="Overflow menu"
           className="extra-class"
           onClick={onClick}>
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -107,8 +113,8 @@ describe('OverflowMenu', () => {
           aria-label="Overflow menu"
           className="extra-class"
           onClose={onClose}>
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -124,8 +130,8 @@ describe('OverflowMenu', () => {
           aria-label="Overflow menu"
           className="extra-class"
           onClose={onClose}>
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -143,8 +149,8 @@ describe('OverflowMenu', () => {
           aria-label="Overflow menu"
           className="extra-class"
           onFocus={onFocus}>
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -155,8 +161,8 @@ describe('OverflowMenu', () => {
     it('should render open if open is true', () => {
       render(
         <OverflowMenu open aria-label="Overflow menu" className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -172,8 +178,8 @@ describe('OverflowMenu', () => {
           aria-label="Overflow menu"
           className="extra-class"
           renderIcon={() => <Filter aria-label="filter icon" />}>
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -194,8 +200,16 @@ describe('OverflowMenu', () => {
               aria-label="Overflow menu"
               className="extra-class"
               size={size}>
-              <OverflowMenuItem className="test-child" itemText="one" />
-              <OverflowMenuItem className="test-child" itemText="two" />
+              <OverflowMenuItem
+                className="test-child"
+                itemText="one"
+                href="#"
+              />
+              <OverflowMenuItem
+                className="test-child"
+                itemText="two"
+                href="#"
+              />
             </OverflowMenu>
           );
 
@@ -209,8 +223,8 @@ describe('OverflowMenu', () => {
     it('should open on click', async () => {
       render(
         <OverflowMenu aria-label="Overflow menu" className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -236,8 +250,8 @@ describe('OverflowMenu', () => {
           aria-label="Overflow menu"
           className="extra-class"
           onClick={handleClick}>
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
       );
 
@@ -254,8 +268,8 @@ describe('OverflowMenu', () => {
   it('should not open menu when disabled', async () => {
     render(
       <OverflowMenu aria-label="Overflow menu" className="extra-class" disabled>
-        <OverflowMenuItem className="test-child" itemText="one" />
-        <OverflowMenuItem className="test-child" itemText="two" />
+        <OverflowMenuItem className="test-child" itemText="one" href="#" />
+        <OverflowMenuItem className="test-child" itemText="two" href="#" />
       </OverflowMenu>
     );
 
@@ -267,8 +281,8 @@ describe('OverflowMenu', () => {
     render(
       <div>
         <OverflowMenu aria-label="Overflow menu" className="extra-class">
-          <OverflowMenuItem className="test-child" itemText="one" />
-          <OverflowMenuItem className="test-child" itemText="two" />
+          <OverflowMenuItem className="test-child" itemText="one" href="#" />
+          <OverflowMenuItem className="test-child" itemText="two" href="#" />
         </OverflowMenu>
         <div data-testid="outside-element">Outside Element</div>
       </div>
@@ -287,8 +301,8 @@ describe('OverflowMenu', () => {
         aria-label="Overflow menu"
         className="extra-class"
         iconDescription={iconDescription}>
-        <OverflowMenuItem className="test-child" itemText="one" />
-        <OverflowMenuItem className="test-child" itemText="two" />
+        <OverflowMenuItem className="test-child" itemText="one" href="#" />
+        <OverflowMenuItem className="test-child" itemText="two" href="#" />
       </OverflowMenu>
     );
     const button = screen.getByRole('button', { name: iconDescription });
@@ -301,8 +315,8 @@ describe('OverflowMenu', () => {
         direction="top"
         iconDescription="custom-icon"
         className="extra-class">
-        <OverflowMenuItem className="test-child" itemText="one" />
-        <OverflowMenuItem className="test-child" itemText="two" />
+        <OverflowMenuItem className="test-child" itemText="one" href="#" />
+        <OverflowMenuItem className="test-child" itemText="two" href="#" />
       </OverflowMenu>
     );
     const button = screen.getByRole('button', { name: 'custom-icon' });
@@ -317,8 +331,8 @@ describe('OverflowMenu', () => {
         direction="bottom"
         iconDescription="custom-icon"
         className="extra-class">
-        <OverflowMenuItem className="test-child" itemText="one" />
-        <OverflowMenuItem className="test-child" itemText="two" />
+        <OverflowMenuItem className="test-child" itemText="one" href="#" />
+        <OverflowMenuItem className="test-child" itemText="two" href="#" />
       </OverflowMenu>
     );
     const newMenu = await waitFor(() =>
@@ -329,42 +343,66 @@ describe('OverflowMenu', () => {
   it('focuses the next enabled menu item when pressing ArrowDown', async () => {
     render(
       <OverflowMenu iconDescription="custom-icon" className="extra-class">
-        <OverflowMenuItem itemText="Item 1" data-testid="menu-item-1" />
+        <OverflowMenuItem
+          itemText="Item 1"
+          data-testid="menu-item-1"
+          href="#"
+        />
         <OverflowMenuItem
           itemText="Item 2"
           disabled
           data-testid="menu-item-2"
+          href="#"
         />
-        <OverflowMenuItem itemText="Item 3" data-testid="menu-item-3" />
+        <OverflowMenuItem
+          itemText="Item 3"
+          data-testid="menu-item-3"
+          href="#"
+        />
       </OverflowMenu>
     );
     const button = screen.getByRole('button', { name: 'custom-icon' });
-    fireEvent.click(button);
+    act(() => {
+      fireEvent.click(button);
+    });
 
-    const menuItem1 = screen.getByText('Item 1').closest('button');
-    const menuItem3 = screen.getByText('Item 3').closest('button');
+    const menuItem1 = screen.getByText('Item 1').closest('a');
+    const menuItem3 = screen.getByText('Item 3').closest('a');
 
-    menuItem1.focus();
-    fireEvent.keyDown(menuItem1, { key: 'ArrowDown', code: 'ArrowDown' });
+    act(() => {
+      menuItem1.focus();
+    });
+    act(() => {
+      fireEvent.keyDown(menuItem1, { key: 'ArrowDown', code: 'ArrowDown' });
+    });
     expect(menuItem3).toHaveFocus();
   });
   it('focuses the next enabled menu item when pressing ArrowUp', async () => {
     render(
       <OverflowMenu iconDescription="custom-icon" className="extra-class">
-        <OverflowMenuItem itemText="Item 1" data-testid="menu-item-1" />
+        <OverflowMenuItem
+          itemText="Item 1"
+          data-testid="menu-item-1"
+          href="#"
+        />
         <OverflowMenuItem
           itemText="Item 2"
           disabled
           data-testid="menu-item-2"
+          href="#"
         />
-        <OverflowMenuItem itemText="Item 3" data-testid="menu-item-3" />
+        <OverflowMenuItem
+          itemText="Item 3"
+          data-testid="menu-item-3"
+          href="#"
+        />
       </OverflowMenu>
     );
     const button = screen.getByRole('button', { name: 'custom-icon' });
     fireEvent.click(button);
 
-    const menuItem1 = screen.getByText('Item 1').closest('button');
-    const menuItem3 = screen.getByText('Item 3').closest('button');
+    const menuItem1 = screen.getByText('Item 1').closest('a');
+    const menuItem3 = screen.getByText('Item 3').closest('a');
 
     menuItem3.focus();
     expect(menuItem3).toHaveFocus();
@@ -374,21 +412,30 @@ describe('OverflowMenu', () => {
   it('focuses the last enabled item when moving backwards from the first enabled item (case -1)', () => {
     render(
       <OverflowMenu iconDescription="custom-icon" className="extra-class">
-        <OverflowMenuItem itemText="Item 1" data-testid="menu-item-1" />
+        <OverflowMenuItem
+          itemText="Item 1"
+          data-testid="menu-item-1"
+          href="#"
+        />
         <OverflowMenuItem
           itemText="Item 2"
           disabled
           data-testid="menu-item-2"
+          href="#"
         />
-        <OverflowMenuItem itemText="Item 3" data-testid="menu-item-3" />
+        <OverflowMenuItem
+          itemText="Item 3"
+          data-testid="menu-item-3"
+          href="#"
+        />
       </OverflowMenu>
     );
 
     const button = screen.getByRole('button', { name: 'custom-icon' });
     fireEvent.click(button);
 
-    const menuItem1 = screen.getByText('Item 1').closest('button');
-    const menuItem3 = screen.getByText('Item 3').closest('button');
+    const menuItem1 = screen.getByText('Item 1').closest('a');
+    const menuItem3 = screen.getByText('Item 3').closest('a');
     menuItem1.focus();
     expect(menuItem1).toHaveFocus();
     fireEvent.keyDown(menuItem1, { key: 'ArrowUp', code: 'ArrowUp' });
@@ -398,21 +445,30 @@ describe('OverflowMenu', () => {
   it('focuses the first enabled item when moving forward from the last enabled item (case enabledIndices.length)', () => {
     render(
       <OverflowMenu iconDescription="custom-icon" className="extra-class">
-        <OverflowMenuItem itemText="Item 1" data-testid="menu-item-1" />
+        <OverflowMenuItem
+          itemText="Item 1"
+          data-testid="menu-item-1"
+          href="#"
+        />
         <OverflowMenuItem
           itemText="Item 2"
           disabled
           data-testid="menu-item-2"
+          href="#"
         />
-        <OverflowMenuItem itemText="Item 3" data-testid="menu-item-3" />
+        <OverflowMenuItem
+          itemText="Item 3"
+          data-testid="menu-item-3"
+          href="#"
+        />
       </OverflowMenu>
     );
 
     const button = screen.getByRole('button', { name: 'custom-icon' });
     fireEvent.click(button);
 
-    const menuItem1 = screen.getByText('Item 1').closest('button');
-    const menuItem3 = screen.getByText('Item 3').closest('button');
+    const menuItem1 = screen.getByText('Item 1').closest('a');
+    const menuItem3 = screen.getByText('Item 3').closest('a');
     menuItem3.focus();
     expect(menuItem3).toHaveFocus();
     fireEvent.keyDown(menuItem3, { key: 'ArrowDown', code: 'ArrowDown' });
@@ -421,13 +477,22 @@ describe('OverflowMenu', () => {
   it('closes the menu on Escape key press', async () => {
     render(
       <OverflowMenu open iconDescription="custom-icon" className="extra-class">
-        <OverflowMenuItem itemText="Item 1" data-testid="menu-item-1" />
+        <OverflowMenuItem
+          itemText="Item 1"
+          data-testid="menu-item-1"
+          href="#"
+        />
         <OverflowMenuItem
           itemText="Item 2"
           disabled
           data-testid="menu-item-2"
+          href="#"
         />
-        <OverflowMenuItem itemText="Item 3" data-testid="menu-item-3" />
+        <OverflowMenuItem
+          itemText="Item 3"
+          data-testid="menu-item-3"
+          href="#"
+        />
       </OverflowMenu>
     );
     const button = screen.getByRole('button', { name: 'custom-icon' });
@@ -451,8 +516,8 @@ describe('OverflowMenu', () => {
           innerRef={innerRef}
           aria-label="Overflow menu"
           data-testid="overflow-menu">
-          <OverflowMenuItem itemText="Option 1" />
-          <OverflowMenuItem itemText="Option 2" />
+          <OverflowMenuItem itemText="Option 1" href="#" />
+          <OverflowMenuItem itemText="Option 2" href="#" />
         </OverflowMenu>
       );
       const buttonElement = screen.getByRole('button');
@@ -472,8 +537,8 @@ describe('OverflowMenu', () => {
         aria-label="Overflow menu"
         className="extra-class"
         onOpen={onOpen}>
-        <OverflowMenuItem className="test-child" itemText="one" />
-        <OverflowMenuItem className="test-child" itemText="two" />
+        <OverflowMenuItem className="test-child" itemText="one" href="#" />
+        <OverflowMenuItem className="test-child" itemText="two" href="#" />
       </OverflowMenu>
     );
 

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -43,6 +43,27 @@ export const Default = (args) => (
   </OverflowMenu>
 );
 
+export const InsideScrollableContainer = (args) => (
+  <div
+    style={{
+      maxHeight: '300px',
+      overflow: 'auto',
+      border: '1px solid #e0e0e0',
+      width: '300px',
+    }}>
+    <div style={{ height: '10000px', backgroundColor: 'lightblue' }}>
+      <OverflowMenu aria-label="overflow-menu" {...args}>
+        <OverflowMenuItem itemText="Stop app" />
+        <OverflowMenuItem itemText="Restart app" />
+        <OverflowMenuItem itemText="Rename app" />
+        <OverflowMenuItem itemText="Clone and move app" disabled requireTitle />
+        <OverflowMenuItem itemText="Edit routes and access" requireTitle />
+        <OverflowMenuItem hasDivider isDelete itemText="Delete app" />
+      </OverflowMenu>
+    </div>
+  </div>
+);
+
 Default.args = {
   flipped: document?.dir === 'rtl',
   focusTrap: false,

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -495,9 +495,7 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
     const getTarget = () => {
       const triggerEl = triggerRef.current;
       if (triggerEl instanceof Element) {
-        return (
-          triggerEl.closest('[data-floating-menu-container]') || document.body
-        );
+        return triggerEl || document.body;
       }
       return document.body;
     };


### PR DESCRIPTION
Closes #21406

Fix `OverflowMenu` component

### Changelog

**New**

- Fix bug in the component `OverflowMenu` when it is in scrollable parent. 

**Changed**

- getTarget function now recieves the parent compoent as its `target` and not document.body by default

#### Testing / Reviewing

See the story: "Inside Scrollable Container" of the component `OverflowMenu` in the storybook.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
