### PR TITLE
fix(ProgressIndicator): keep steps tabbable and use spans in buttons

### DIFF
--- a/e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js
+++ b/e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js
@@ -106,6 +106,12 @@ test.describe('@avt ProgressIndicator', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.press('Escape');
 
+    // Testing the second element interaction (current step is now focusable)
+    await page.keyboard.press('Tab');
+    await expect(
+      page.getByRole('button', { name: 'Really long label' })
+    ).toBeFocused();
+
     // Testing the third element interaction
     await page.keyboard.press('Tab');
     await expect(

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -327,7 +327,7 @@ function ProgressStep({
         })}
         disabled={disabled}
         aria-disabled={disabled}
-        tabIndex={!current && onClick && !disabled ? 0 : -1}
+        tabIndex={disabled ? -1 : 0}
         onClick={!current ? onClick : undefined}
         onKeyDown={handleKeyDown}
         title={label}
@@ -340,11 +340,11 @@ function ProgressStep({
           prefix={prefix}
         />
         <div className={`${prefix}--progress-text`}>
-          <Text as="p" className={`${prefix}--progress-label`}>
+          <Text as="span" className={`${prefix}--progress-label`}>
             {label}
           </Text>
           {secondaryLabel !== null && secondaryLabel !== undefined ? (
-            <Text as="p" className={`${prefix}--progress-optional`}>
+            <Text as="span" className={`${prefix}--progress-optional`}>
               {secondaryLabel}
             </Text>
           ) : null}

--- a/packages/react/src/components/ProgressIndicator/__tests__/ProgressIndicator-test.js
+++ b/packages/react/src/components/ProgressIndicator/__tests__/ProgressIndicator-test.js
@@ -275,5 +275,33 @@ describe('ProgressStep', () => {
       expect(screen.getByText('Non valide')).toBeInTheDocument();
       expect(screen.getByText('Partiel')).toBeInTheDocument();
     });
+
+    it('sets tabindex to 0 for enabled steps and -1 for disabled steps', () => {
+      render(
+        <ProgressIndicator>
+          <ProgressStep label="First step" />
+          <ProgressStep label="Second step" disabled />
+        </ProgressIndicator>
+      );
+
+      expect(screen.getByTitle('First step')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTitle('Second step')).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
+    });
+
+    it('renders labels and secondary labels as spans for valid button content', () => {
+      const { container } = render(
+        <ProgressStep label="First step" secondaryLabel="Optional label" />
+      );
+
+      expect(container.querySelector('.cds--progress-label')?.tagName).toBe(
+        'SPAN'
+      );
+      expect(container.querySelector('.cds--progress-optional')?.tagName).toBe(
+        'SPAN'
+      );
+    });
   });
 });

--- a/packages/styles/scss/components/progress-indicator/_progress-indicator.scss
+++ b/packages/styles/scss/components/progress-indicator/_progress-indicator.scss
@@ -87,6 +87,7 @@ $progress-indicator-bar-width: 1px inset transparent !default;
   .#{$prefix}--progress-label {
     @include type-style('body-compact-01');
 
+    display: block;
     overflow: hidden;
     margin: $spacing-03 0 0 0;
     color: $text-primary;
@@ -115,9 +116,7 @@ $progress-indicator-bar-width: 1px inset transparent !default;
     max-inline-size: 100%;
   }
 
-  .#{$prefix}--progress-step-button:not(
-      .#{$prefix}--progress-step-button--unclickable
-    ) {
+  .#{$prefix}--progress-step-button {
     &:focus {
       outline: none;
     }
@@ -125,10 +124,14 @@ $progress-indicator-bar-width: 1px inset transparent !default;
       color: $focus;
       outline: convert.to-rem(1px) solid $focus;
     }
+  }
+
+  .#{$prefix}--progress-step-button:not(
+      .#{$prefix}--progress-step-button--unclickable
+    )
     .#{$prefix}--progress-label:active {
-      box-shadow: 0 convert.to-rem(1px) 0 0 $text-primary;
-      color: $text-primary;
-    }
+    box-shadow: 0 convert.to-rem(1px) 0 0 $text-primary;
+    color: $text-primary;
   }
 
   //OVERFLOW STYLING
@@ -178,6 +181,7 @@ $progress-indicator-bar-width: 1px inset transparent !default;
     @include type-style('label-01');
 
     position: absolute;
+    display: block;
     color: $text-secondary;
     inset-inline-start: 0;
     margin-block-start: convert.to-rem(28px);


### PR DESCRIPTION
Closes #20762 

Fix `ProgressIndicator` a11y warning reported by `IBM Equal Access Accessibility Checker`: enabled steps were not tabbable and buttons contained `<p>` descendants

<img width="1676" height="464" alt="image" src="https://github.com/user-attachments/assets/cc2fc5ca-14c6-4040-99d0-e8014b76069c" />

### Changelog

**New**

- Added regression tests to ensure enabled steps render tabindex="0"/disabled -1 and labels render as spans inside buttons and update avt tests

**Changed**

- `ProgressStep` buttons now set `tabIndex={disabled ? -1 : 0}`, keeping all non-disabled steps in the tab order and skipping disabled ones
- `ProgressStep` label and secondary label render as `<span>` (with `display: block`) to avoid block elements inside `<button>`
- Focus styling applies to all progress step buttons so keyboard focus is visible on stories

**Removed**

- ~None~

#### Testing / Reviewing

-Go to `WC Deploy Preview `> `ProgressIndicator` > `Default`
-Tab through steps: focus ring appears on each enabled step, disabled step is skipped.
- Run`IBM Equal Access Accessibility Checker` on the `ProgressIndicator` story (https://deploy-preview-21574--v11-carbon-react.netlify.app/iframe.html?globals=&args=&id=components-progressindicator--default&viewMode=story):

Confirm “Component with "button" role does not have a tabbable element” and “The element with role "button" contains descendants with implicit roles "paragraph" which are ignored by browsers” no longer appear

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
