### PR TITLE
fix: add part to cds-button-set

### DIFF
--- a/packages/web-components/src/components/button/button-set.ts
+++ b/packages/web-components/src/components/button/button-set.ts
@@ -97,7 +97,7 @@ class CDSButtonSet extends CDSButtonSetBase {
     };
     const classes = classMap(defaultClasses);
 
-    return html`<slot class="${classes} @slotchange="${this._handleSlotChange}"></slot>`;
+    return html`<slot class="${classes} part="button-set" @slotchange="${this._handleSlotChange}"></slot>`;
   }
   /**
    * A selector that will return the child items.


### PR DESCRIPTION
Closes #21578

add part to cds-button-set.

The cds-button-set component applies display: flex directly to its internal , which makes the slot itself the flex container. Because of this, the slotted cds-button elements are constrained by the slot’s layout, and their inline size does not stretch to the full available width when controlled from outside the component.

To improve flexibility and allow external layout control, the slot should expose a part attribute. This would enable consumers to style the slot container from outside the shadow DOM and manage width and flex behavior more effectively.

### Changelog



**Changed**

- packages/web-components/src/components/button/button-set.ts



#### Testing / Reviewing

locally

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
