### PR TITLE
test(data-table): add coverage for TableSlugRow

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/TableSlugRow-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableSlugRow-test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Table, TableBody, TableRow } from '../';
+import TableSlugRow from '../TableSlugRow';
+
+jest.mock('../../../prop-types/deprecateComponent', () => ({
+  deprecateComponent: jest.fn(),
+}));
+
+const Slug = ({ size }) => <span data-testid="slug" data-size={size} />;
+
+describe('TableSlugRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should add base and custom classes', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableSlugRow className="pew-pew" />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    const cell = screen.getByRole('cell');
+
+    expect(cell).toHaveClass('pew-pew', 'cds--table-column-slug', {
+      exact: true,
+    });
+  });
+
+  it('should normalize the slug `size` to `mini` and add active class when slug is present', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableSlugRow slug={<Slug size="xl" />} />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    const cell = screen.getByRole('cell');
+
+    expect(cell).toHaveClass(
+      'cds--table-column-slug',
+      'cds--table-column-slug--active',
+      { exact: true }
+    );
+    expect(screen.getByTestId('slug')).toHaveAttribute('data-size', 'mini');
+  });
+});


### PR DESCRIPTION
No issue.

Added test coverage for `TableSlugRow`.

### Changelog

**New**

- Added test coverage for `TableSlugRow`.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/DataTable/__tests__/TableSlugRow-test.js \
  --collectCoverageFrom=packages/react/src/components/DataTable/TableSlugRow.tsx \
  --coverageReporters=text-summary
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
