### PR TITLE
fix(page-header): recompute fallback tag ids when prefix changes

### DIFF
--- a/packages/react/src/components/PageHeader/PageHeader-test.js
+++ b/packages/react/src/components/PageHeader/PageHeader-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,7 @@ import {
 import * as hooks from '../../internal/useMatchMedia';
 import { breakpoints } from '@carbon/layout';
 import { Breadcrumb, BreadcrumbItem } from '../Breadcrumb';
+import { IdPrefix } from '../IdPrefix';
 import { TabList, Tab, TabPanels, TabPanel } from '../Tabs/Tabs';
 import { Bee } from '@carbon/icons-react';
 
@@ -568,6 +569,44 @@ describe('PageHeader', () => {
       expect(screen.getByText('Tag 1')).toBeInTheDocument();
       expect(screen.getByText('Tag 2')).toBeInTheDocument();
       expect(screen.getByText('Tag 3')).toBeInTheDocument();
+    });
+
+    it('should regenerate fallback tag `id`s when `id` prefix changes', () => {
+      const tagsWithoutIds = [
+        { type: 'blue', text: 'Tag 1', size: 'md' },
+        { type: 'green', text: 'Tag 2', size: 'md' },
+      ];
+
+      mockUseOverflowItems.mockImplementation((items) => ({
+        visibleItems: items,
+        hiddenItems: [],
+        itemRefHandler: jest.fn(),
+      }));
+
+      const { rerender } = render(
+        <IdPrefix prefix="prefix-a">
+          <PageHeaderTabBarDirect tags={tagsWithoutIds} />
+        </IdPrefix>
+      );
+
+      const firstCallItems =
+        mockUseOverflowItems.mock.calls[
+          mockUseOverflowItems.mock.calls.length - 1
+        ][0];
+      expect(firstCallItems[0].id).toContain('prefix-a-PageHeaderTabBar');
+
+      rerender(
+        <IdPrefix prefix="prefix-b">
+          <PageHeaderTabBarDirect tags={tagsWithoutIds} />
+        </IdPrefix>
+      );
+
+      const secondCallItems =
+        mockUseOverflowItems.mock.calls[
+          mockUseOverflowItems.mock.calls.length - 1
+        ][0];
+      expect(secondCallItems[0].id).toContain('prefix-b-PageHeaderTabBar');
+      expect(secondCallItems[0].id).not.toEqual(firstCallItems[0].id);
     });
 
     describe('Overflow functionality', () => {

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -601,8 +601,7 @@ const PageHeaderTabBar = React.forwardRef<
         ...tag,
         id: tag.id || `tag-${index}-${instanceId}`,
       }));
-      // eslint-disable-next-line  react-hooks/exhaustive-deps -- https://github.com/carbon-design-system/carbon/issues/20452
-    }, [tags]);
+    }, [instanceId, tags]);
 
     // eslint-disable-next-line  react-hooks/rules-of-hooks -- https://github.com/carbon-design-system/carbon/issues/20452
     const tagsContainerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
No issue. https://github.com/carbon-design-system/carbon/pull/21497#issuecomment-3910804669

Recomputed fallback tag `id`s when prefixes changed in `PageHeader`.

### Changelog

**Changed**

- Recomputed fallback tag `id`s when prefixes changed in `PageHeader`.

#### Testing / Reviewing

Run tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
