### PR TITLE
fix(react): stabilize useOverflowItems hook order

### DIFF
--- a/packages/react/src/internal/__tests__/useOverflowItems-test.js
+++ b/packages/react/src/internal/__tests__/useOverflowItems-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -202,5 +202,27 @@ describe('useOverflowItems', () => {
     // Should return all items as visible when no container
     expect(result.current.visibleItems).toEqual(mockItems);
     expect(result.current.hiddenItems).toEqual([]);
+  });
+
+  it('should keep hook order when items changes between array and non-array', () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => useOverflowItems(items, containerRef, offsetRef),
+      { initialProps: { items: mockItems } }
+    );
+
+    expect(Array.isArray(result.current.visibleItems)).toBe(true);
+    expect(Array.isArray(result.current.hiddenItems)).toBe(true);
+
+    expect(() => {
+      rerender({ items: 'not an array' });
+    }).not.toThrow();
+    expect(result.current.visibleItems).toEqual([]);
+    expect(result.current.hiddenItems).toEqual([]);
+
+    expect(() => {
+      rerender({ items: mockItems });
+    }).not.toThrow();
+    expect(Array.isArray(result.current.visibleItems)).toBe(true);
+    expect(Array.isArray(result.current.hiddenItems)).toBe(true);
   });
 });


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Stabilized `useOverflowItems` hook order.

### Changelog

**Changed**

- Stabilized `useOverflowItems` hook order.

#### Testing / Reviewing

Run tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
