### PR TITLE
test(data-table): add coverage for TableDecoratorRow

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/TableDecoratorRow-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableDecoratorRow-test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Table, TableBody, TableDecoratorRow, TableRow } from '../';
+import { AILabel } from '../../AILabel';
+
+const prefix = 'cds';
+
+const renderDecoratorRow = (props = {}) =>
+  render(
+    <Table>
+      <TableBody>
+        <TableRow>
+          <TableDecoratorRow {...props} />
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+
+describe('TableDecoratorRow', () => {
+  it('should render default classes when no decorator is provided', () => {
+    renderDecoratorRow();
+
+    const cell = screen.getByRole('cell');
+
+    expect(cell).toHaveClass(`${prefix}--table-column-decorator`, {
+      exact: true,
+    });
+  });
+
+  it('should support custom `className` and not render non-`AILabel` decorators', () => {
+    renderDecoratorRow({
+      className: 'custom-class',
+      decorator: <span>Non-AI decorator</span>,
+    });
+
+    const cell = screen.getByRole('cell');
+
+    expect(cell).toHaveClass(
+      'custom-class',
+      `${prefix}--table-column-decorator`,
+      `${prefix}--table-column-decorator--active`,
+      { exact: true }
+    );
+    expect(screen.queryByText('Non-AI decorator')).not.toBeInTheDocument();
+  });
+
+  it('should render `AILabel` decorators with `mini` sizing', () => {
+    renderDecoratorRow({
+      decorator: <AILabel size="xl" />,
+    });
+
+    const cell = screen.getByRole('cell');
+    const aiLabelButton = screen.getByRole('button', {
+      name: 'AI Show information',
+    });
+
+    expect(cell).toHaveClass(
+      `${prefix}--table-column-decorator`,
+      `${prefix}--table-column-decorator--active`,
+      { exact: true }
+    );
+    expect(aiLabelButton).toHaveClass(
+      `${prefix}--toggletip-button`,
+      `${prefix}--ai-label__button`,
+      `${prefix}--ai-label__button--mini`,
+      `${prefix}--ai-label__button--default`,
+      { exact: true }
+    );
+  });
+});


### PR DESCRIPTION
No issue.

Added test coverage for `TableDecoratorRow`.

### Changelog

**New**

- Added test coverage for `TableDecoratorRow`.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/DataTable/__tests__/TableDecoratorRow-test.js \
  --collectCoverageFrom=packages/react/src/components/DataTable/TableDecoratorRow.tsx \
  --coverageReporters=text-summary
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
