### PR TITLE
fix(eslint): disable jsx-no-undef in figma files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,6 +217,7 @@ export default defineConfig(
     files: ['packages/react/code-connect/**/*.figma.tsx'],
     rules: {
       '@typescript-eslint/ban-ts-comment': ['error', { 'ts-nocheck': false }],
+      'react/jsx-no-undef': 'off',
     },
   },
   {

--- a/packages/react/code-connect/ComboButton/ComboButton.figma.tsx
+++ b/packages/react/code-connect/ComboButton/ComboButton.figma.tsx
@@ -33,7 +33,6 @@ figma.connect(
     props: sharedComboButtonProps,
     example: ({ size, position }) => (
       <ComboButton size={size} position={position} label="Primary action">
-        {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
         Open Combo button to view <MenuItem /> props and code
       </ComboButton>
     ),

--- a/packages/react/code-connect/ComposedModal/ComposedModal.figma.tsx
+++ b/packages/react/code-connect/ComposedModal/ComposedModal.figma.tsx
@@ -50,9 +50,7 @@ figma.connect(
       const [open, setOpen] = useState(true);
       return (
         <ComposedModal open onClose={() => setOpen(false)}>
-          {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
           <ModalHeader label={label} title={title} />
-          {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
           <ModalBody>
             {progress}
             {descriptionText}

--- a/packages/react/code-connect/DatePicker/FluidDatePicker.figma.tsx
+++ b/packages/react/code-connect/DatePicker/FluidDatePicker.figma.tsx
@@ -47,7 +47,6 @@ figma.connect(
   'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=17544-267399&t=hgJuU7m9Y6EM076g-4',
   {
     variant: { State: 'Skeleton' },
-    /* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */
     example: () => <DatePickerSkeleton type="simple" />,
   }
 );
@@ -88,7 +87,6 @@ figma.connect(
   'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=17544-267989&t=hgJuU7m9Y6EM076g-4',
   {
     variant: { State: 'Skeleton' },
-    /* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */
     example: () => <DatePickerSkeleton type="single" />,
   }
 );
@@ -152,7 +150,6 @@ figma.connect(
   'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=17544-268235&t=hgJuU7m9Y6EM076g-4',
   {
     variant: { State: 'Skeleton' },
-    /* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */
     example: () => <DatePickerSkeleton type="range" />,
   }
 );

--- a/packages/react/code-connect/FileUploader/FileUploader.figma.tsx
+++ b/packages/react/code-connect/FileUploader/FileUploader.figma.tsx
@@ -53,7 +53,6 @@ figma.connect(
       <FormItem>
         <p className="cds--file--label">{labelTitle}</p>
         <p className="cds--label-description">{labelDescription}</p>
-        {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
         <FileUploaderDropContainer
           accept={['image/jpeg', 'image/png']}
           innerRef={{

--- a/packages/react/code-connect/MenuButton/MenuButton.figma.tsx
+++ b/packages/react/code-connect/MenuButton/MenuButton.figma.tsx
@@ -49,7 +49,6 @@ figma.connect(
         label="Actions"
         kind={button.kind}
         disabled={button.disabled}>
-        {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
         Open Menu button to view <MenuItem /> props and code
       </MenuButton>
     ),

--- a/packages/react/code-connect/TextArea/TextArea.figma.tsx
+++ b/packages/react/code-connect/TextArea/TextArea.figma.tsx
@@ -43,7 +43,6 @@ figma.connect(
         'Read-only': true,
       }),
     },
-    /* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */
     example: ({ ...props }) => <TextAreaDefault {...props} />,
   }
 );

--- a/packages/react/code-connect/Toggletip/Toggletip.figma.tsx
+++ b/packages/react/code-connect/Toggletip/Toggletip.figma.tsx
@@ -46,10 +46,8 @@ figma.connect(
           <ToggletipButton label="Show information">
             <Information />
           </ToggletipButton>
-          {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
           <ToggletipContent>
             <p>{toggletip.content}</p>
-            {/* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */}
             <ToggletipActions>
               {toggletip.link}
               {toggletip.button}

--- a/packages/react/code-connect/UIShell/HeaderMenuItem.figma.tsx
+++ b/packages/react/code-connect/UIShell/HeaderMenuItem.figma.tsx
@@ -66,7 +66,6 @@ figma.connect(
   {
     props: { children: figma.children(['UI shell - Header sub-menu item']) },
     example: ({ children }) => (
-      /* eslint-disable-next-line react/jsx-no-undef -- https://github.com/carbon-design-system/carbon/issues/20452 */
       <UIShellHeaderSubMenu>{children}</UIShellHeaderSubMenu>
     ),
   }


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Disabled `react/jsx-no-undef` in Figma files.

### Changelog

**Changed**

- Disabled `react/jsx-no-undef` in Figma files.

#### Testing / Reviewing

Run `yarn lint`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
