### PR TITLE
fix(content_switcher): borders fix on disabled tabs in content_switcher

### DIFF
--- a/packages/styles/scss/components/content-switcher/_content-switcher.scss
+++ b/packages/styles/scss/components/content-switcher/_content-switcher.scss
@@ -99,8 +99,9 @@
     }
 
     &:disabled {
-      border-color: $border-disabled;
       background-color: transparent;
+      border-block-color: $border-inverse;
+      border-inline-color: $border-disabled;
       color: $text-disabled;
 
       &:hover {
@@ -570,9 +571,10 @@
     }
 
     &:disabled {
-      border: convert.to-rem(1px) solid $border-disabled;
       border-radius: convert.to-rem(4px);
       background-color: $content-switcher-selected;
+      border-block: convert.to-rem(1px) solid $border-inverse;
+      border-inline: convert.to-rem(1px) solid $border-disabled;
       color: $text-disabled;
     }
 
@@ -664,7 +666,8 @@
   }
   .#{$prefix}--content-switcher--low-contrast.#{$prefix}--content-switcher--icon-only
     .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected:disabled {
-    border-color: $border-disabled;
+    border-block-color: $border-inverse;
+    border-inline-color: $border-disabled;
   }
 
   .#{$prefix}--content-switcher--low-contrast

--- a/packages/web-components/src/components/content-switcher/content-switcher.scss
+++ b/packages/web-components/src/components/content-switcher/content-switcher.scss
@@ -95,15 +95,13 @@ $css--plex: true !default;
         }
       }
 
-      border-color: $border-disabled !important; /* stylelint-disable-line declaration-no-important */
       background-color: transparent;
+      border-block-color: $border-inverse !important; /* stylelint-disable-line declaration-no-important */
+      border-inline-color: $border-disabled !important; /* stylelint-disable-line declaration-no-important */
 
       ::slotted(p) {
         color: $text-disabled !important; /* stylelint-disable-line declaration-no-important */
       }
-
-      border-block-end-color: $border-inverse;
-      border-block-start-color: $border-inverse;
     }
   }
 }


### PR DESCRIPTION
Closes #21637 

For a disabled tab in content switcher, the border on top and bottom is not following the same as active tabs. And looks in-consistent. 

### Changelog

**New**

- None

**Changed**

- Modified border styling for disabled content switcher buttons to maintain visible structural borders while greying out only the content

**Removed**

- None

#### Testing / Reviewing

For testing start the story book in web_components and go to content switcher component. Inspected in browser console and disabled one tab in content switcher. 

```
<cds-content-switcher-item disabled value="cloudFoundry" name="two">
  Second section
</cds-content-switcher-item>
```
After this borders on top and bottom remains same, as active tabs in content switcher.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
