### PR TITLE
fix(pagination): call onchange on page size change

### DIFF
--- a/packages/react/src/components/Pagination/experimental/Pagination.js
+++ b/packages/react/src/components/Pagination/experimental/Pagination.js
@@ -81,9 +81,14 @@ function Pagination({
               hideLabel
               noLabel
               inline
-              onChange={(event) =>
-                setCurrentPageSize(Number(event.target.value))
-              }
+              onChange={(event) => {
+                const pageSize = Number(event.target.value);
+                setCurrentPageSize(pageSize);
+
+                if (onChange) {
+                  onChange({ page: currentPage, pageSize });
+                }
+              }}
               value={currentPageSize}>
               {pageSizes.map((size) => (
                 <SelectItem key={size} value={size} text={String(size)} />

--- a/packages/react/src/components/Pagination/experimental/Pagination.js
+++ b/packages/react/src/components/Pagination/experimental/Pagination.js
@@ -83,10 +83,12 @@ function Pagination({
               inline
               onChange={(event) => {
                 const pageSize = Number(event.target.value);
+                const page = 1;
+                setCurrentPage(page);
                 setCurrentPageSize(pageSize);
 
                 if (onChange) {
-                  onChange({ page: currentPage, pageSize });
+                  onChange({ page, pageSize });
                 }
               }}
               value={currentPageSize}>

--- a/packages/react/src/components/Pagination/experimental/__tests__/Pagination-test.js
+++ b/packages/react/src/components/Pagination/experimental/__tests__/Pagination-test.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import Pagination from '../Pagination';
+
+describe('Preview Pagination', () => {
+  describe('renders as expected - Component API', () => {
+    it('should spread extra props onto outermost element', () => {
+      const { container } = render(
+        <Pagination
+          data-testid="test-id"
+          pageSizes={[10]}
+          onChange={() => {}}
+        />
+      );
+
+      expect(container.firstChild).toHaveAttribute('data-testid', 'test-id');
+    });
+
+    it('should label icon with backwardText', () => {
+      render(
+        <Pagination
+          backwardText="Move backwards"
+          pageSizes={[10]}
+          onChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('Move backwards')).toBeInTheDocument();
+    });
+
+    it('should support a custom `className` prop on the outermost element', () => {
+      const { container } = render(
+        <Pagination
+          className="custom-class"
+          pageSizes={[10]}
+          onChange={() => {}}
+        />
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+
+    it('should disable controls with disabled', () => {
+      render(<Pagination disabled pageSizes={[10]} onChange={() => {}} />);
+
+      expect(
+        screen.getByLabelText('Next page', { hidden: true })
+      ).toBeDisabled();
+
+      expect(
+        screen.getByLabelText('Previous page', { hidden: true })
+      ).toBeDisabled();
+    });
+
+    it('should call onChange when changing page size using the dropdown', async () => {
+      const onChange = jest.fn();
+      render(
+        <Pagination
+          totalItems={20}
+          pageSizes={[10, 20]}
+          pageSize={10}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.selectOptions(screen.getByLabelText('Items per page:'), [
+        '20',
+      ]);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, pageSize: 20 })
+      );
+    });
+  });
+});

--- a/packages/react/src/components/Pagination/experimental/__tests__/Pagination-test.js
+++ b/packages/react/src/components/Pagination/experimental/__tests__/Pagination-test.js
@@ -80,5 +80,25 @@ describe('Preview Pagination', () => {
         expect.objectContaining({ page: 1, pageSize: 20 })
       );
     });
+
+    it('should reset to page 1 when changing page size using the dropdown', async () => {
+      render(
+        <Pagination
+          totalItems={40}
+          pageSizes={[10, 20]}
+          pageSize={10}
+          initialPage={2}
+          onChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('11–20 of 40 items')).toBeInTheDocument();
+
+      await userEvent.selectOptions(screen.getByLabelText('Items per page:'), [
+        '20',
+      ]);
+
+      expect(screen.getByText('1–20 of 40 items')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes #21661

Update experimental pagination to call onChange and reset the current page to page 1 when the page size changes. This matches how the non-experimental pagination works. 

### Changelog

**New**

- Add experimental pagination test file

**Changed**

- Update experimental pagination to call onChange and reset to page 1 when page size changes

#### Testing / Reviewing

- Visit the story, go to the second page, change the page size, validate onChange was called and page resets to page 1

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
