### PR TITLE
test(react): increase coverage for ModalFooter

### DIFF
--- a/packages/react/src/components/ComposedModal/ModalFooter-test.js
+++ b/packages/react/src/components/ComposedModal/ModalFooter-test.js
@@ -149,4 +149,43 @@ describe('ModalFooter', () => {
     expect(screen.getByText('Keep both')).toBeInTheDocument();
     expect(screen.getByText('Rename')).toBeInTheDocument();
   });
+
+  it('should call close handlers for secondary buttons without `onClick`', async () => {
+    const closeModal = jest.fn();
+    const onRequestClose = jest.fn();
+
+    render(
+      <ModalFooter
+        closeModal={closeModal}
+        onRequestClose={onRequestClose}
+        secondaryButtons={[
+          { buttonText: 'Cancel' },
+          { buttonText: 'Rename', onClick: jest.fn() },
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Cancel'));
+
+    expect(closeModal).toHaveBeenCalled();
+    expect(onRequestClose).toHaveBeenCalled();
+  });
+
+  it('should render active loading state for primary button', () => {
+    const { container } = render(
+      <ModalFooter
+        loadingStatus="active"
+        primaryClassName="custom-class"
+        primaryButtonText="Submit"
+        secondaryButtonText="Cancel"
+      />
+    );
+
+    const primaryButton = container.querySelector('button.custom-class');
+
+    expect(primaryButton).toBeTruthy();
+    expect(primaryButton).toHaveClass('cds--btn--loading');
+    expect(screen.getByText('Cancel')).toBeDisabled();
+    expect(container.querySelector('.cds--inline-loading--btn')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
No issue.

Increase test coverage for `ModalFooter`.

### Changelog

**Changed**

- Increase test coverage for `ModalFooter`.

#### Testing / Reviewing

The remaining uncovered code relates to prop-types. I didn't think that was worth testing given prop-types may be removed in v12. If anyone thinks tests should be added for them regardless, let me know.

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/ComposedModal/ModalFooter-test.js \
  --collectCoverageFrom=packages/react/src/components/ComposedModal/ModalFooter.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
