### PR TITLE
fix(hooks): stabilize useNoInteractiveChildren hook order

### DIFF
--- a/packages/react/src/internal/__tests__/useNoInteractiveChildren-test.js
+++ b/packages/react/src/internal/__tests__/useNoInteractiveChildren-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,10 @@
 
 import { render } from '@testing-library/react';
 import React, { useRef } from 'react';
-import { useNoInteractiveChildren } from '../useNoInteractiveChildren';
+import {
+  useInteractiveChildrenNeedDescription,
+  useNoInteractiveChildren,
+} from '../useNoInteractiveChildren';
 
 describe('useNoInteractiveChildren', () => {
   it('should render without errors if no interactive content is found', () => {
@@ -41,5 +44,92 @@ describe('useNoInteractiveChildren', () => {
 
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe('useInteractiveChildrenNeedDescription', () => {
+  it('should render without errors if interactive content has `aria-describedby`', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useInteractiveChildrenNeedDescription(ref);
+
+      return (
+        <div ref={ref}>
+          <button aria-describedby="helper-text">Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).not.toThrow();
+  });
+
+  it('should throw an error if interactive content is missing `aria-describedby`', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useInteractiveChildrenNeedDescription(ref);
+
+      return (
+        <div ref={ref}>
+          <button>Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow();
+  });
+});
+
+describe('noInteractiveChildren hooks in production', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('should not throw in production when `useNoInteractiveChildren` finds interactive content', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useNoInteractiveChildren(ref);
+
+      return (
+        <div ref={ref}>
+          <button>Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).not.toThrow();
+  });
+
+  it('should not throw in production when `useInteractiveChildrenNeedDescription` finds missing `aria-describedby`', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useInteractiveChildrenNeedDescription(ref);
+
+      return (
+        <div ref={ref}>
+          <button>Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).not.toThrow();
   });
 });

--- a/packages/react/src/internal/useNoInteractiveChildren.ts
+++ b/packages/react/src/internal/useNoInteractiveChildren.ts
@@ -11,46 +11,35 @@ export const useNoInteractiveChildren = (
   ref: RefObject<HTMLElement | null>,
   message = 'component should have no interactive child nodes'
 ) => {
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is intentionally called conditionally because it is
-    // stripped from production builds. In development it runs once
-    // to enforce accessibility constraints.
-    //
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      const node = ref.current ? getInteractiveContent(ref.current) : false;
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
 
-      if (node) {
-        const errorMessage = `Error: ${message}.\n\nInstead found: ${node.outerHTML}`;
-        // eslint-disable-next-line no-console -- https://github.com/carbon-design-system/carbon/issues/20452
-        console.error(errorMessage);
-        throw new Error(errorMessage);
-      }
-      // eslint-disable-next-line  react-hooks/exhaustive-deps -- https://github.com/carbon-design-system/carbon/issues/20452
-    }, []);
-  }
+    const { current } = ref;
+    const node = current ? getInteractiveContent(current) : null;
+
+    if (node) {
+      const errorMessage = `Error: ${message}.\n\nInstead found: ${node.outerHTML}`;
+      // eslint-disable-next-line no-console -- https://github.com/carbon-design-system/carbon/issues/20452
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }, [message, ref]);
 };
 
 export const useInteractiveChildrenNeedDescription = (
   ref: RefObject<HTMLElement | null>,
   message = `interactive child node(s) should have an \`aria-describedby\` property`
 ) => {
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is intentionally called conditionally because it is
-    // stripped from production builds. In development it runs once
-    // to enforce accessibility constraints.
-    //
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      const node = ref.current ? getInteractiveContent(ref.current) : false;
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
 
-      if (node && !node.hasAttribute('aria-describedby')) {
-        throw new Error(
-          `Error: ${message}.\n\nInstead found: ${node.outerHTML}`
-        );
-      }
-    });
-  }
+    const { current } = ref;
+    const node = current ? getInteractiveContent(current) : null;
+
+    if (node && !node.hasAttribute('aria-describedby')) {
+      throw new Error(`Error: ${message}.\n\nInstead found: ${node.outerHTML}`);
+    }
+  }, [message, ref]);
 };
 
 /**
@@ -63,6 +52,7 @@ export const useInteractiveChildrenNeedDescription = (
 export const getInteractiveContent = (
   node: HTMLElement
 ): HTMLElement | null => {
+  // TODO: This check shouldn't be necessary. Investigate deleting it.
   if (!node || !node.childNodes) {
     return null;
   }
@@ -91,6 +81,7 @@ export const getInteractiveContent = (
  * @returns The node with a `role`, or `null` if none is found.
  */
 export const getRoleContent = (node: HTMLElement): HTMLElement | null => {
+  // TODO: This check shouldn't be necessary. Investigate deleting it.
   if (!node || !node.childNodes) {
     return null;
   }

--- a/packages/utilities-react/src/useNoInteractiveChildren/index-test.js
+++ b/packages/utilities-react/src/useNoInteractiveChildren/index-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,10 @@
 
 import { render } from '@testing-library/react';
 import React, { useRef } from 'react';
-import { useNoInteractiveChildren } from './index.jsx';
+import {
+  useInteractiveChildrenNeedDescription,
+  useNoInteractiveChildren,
+} from './index.jsx';
 
 describe('useNoInteractiveChildren', () => {
   it('should render without errors if no interactive content is found', () => {
@@ -41,5 +44,92 @@ describe('useNoInteractiveChildren', () => {
 
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe('useInteractiveChildrenNeedDescription', () => {
+  it('should render without errors if interactive content has `aria-describedby`', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useInteractiveChildrenNeedDescription(ref);
+
+      return (
+        <div ref={ref}>
+          <button aria-describedby="helper-text">Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).not.toThrow();
+  });
+
+  it('should throw an error if interactive content is missing `aria-describedby`', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useInteractiveChildrenNeedDescription(ref);
+
+      return (
+        <div ref={ref}>
+          <button>Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow();
+  });
+});
+
+describe('noInteractiveChildren hooks in production', () => {
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('should not throw in production when `useNoInteractiveChildren` finds interactive content', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useNoInteractiveChildren(ref);
+
+      return (
+        <div ref={ref}>
+          <button>Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).not.toThrow();
+  });
+
+  it('should not throw in production when `useInteractiveChildrenNeedDescription` finds missing `aria-describedby`', () => {
+    const TestComponent = () => {
+      const ref = useRef(null);
+
+      useInteractiveChildrenNeedDescription(ref);
+
+      return (
+        <div ref={ref}>
+          <button>Interactive</button>
+        </div>
+      );
+    };
+
+    expect(() => {
+      render(<TestComponent />);
+    }).not.toThrow();
   });
 });

--- a/packages/utilities-react/src/useNoInteractiveChildren/index.jsx
+++ b/packages/utilities-react/src/useNoInteractiveChildren/index.jsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,37 +15,35 @@ export function useNoInteractiveChildren(
   ref,
   message = 'component should have no interactive child nodes'
 ) {
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      const node = ref.current ? getInteractiveContent(ref.current) : false;
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
 
-      if (node) {
-        const errorMessage = `Error: ${message}.\n\nInstead found: ${node.outerHTML}`;
-        // eslint-disable-next-line no-console
-        console.error(errorMessage);
-        throw new Error(errorMessage);
-      }
-    });
-  }
+    const { current } = ref;
+    const node = current ? getInteractiveContent(current) : null;
+
+    if (node) {
+      const errorMessage = `Error: ${message}.\n\nInstead found: ${node.outerHTML}`;
+      // eslint-disable-next-line no-console
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }, [message, ref]);
 }
 
 export function useInteractiveChildrenNeedDescription(
   ref,
   message = `interactive child node(s) should have an \`aria-describedby\` property`
 ) {
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      const node = ref.current ? getInteractiveContent(ref.current) : false;
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
 
-      if (node && !node.hasAttribute('aria-describedby')) {
-        throw new Error(
-          `Error: ${message}.\n\nInstead found: ${node.outerHTML}`
-        );
-      }
-    });
-  }
+    const { current } = ref;
+    const node = current ? getInteractiveContent(current) : null;
+
+    if (node && !node.hasAttribute('aria-describedby')) {
+      throw new Error(`Error: ${message}.\n\nInstead found: ${node.outerHTML}`);
+    }
+  }, [message, ref]);
 }
 
 /**


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Stabilized `useNoInteractiveChildren` hook order.

### Changelog

**New**

- Added test coverage for `useInteractiveChildrenNeedDescription`.

**Changed**

- Stabilized `useNoInteractiveChildren` hook order.

#### Testing / Reviewing

I confirmed that the tests passed with and without the code changes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
