### PR TITLE
test(react): add coverage for DatePickerSkeleton and update docs

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.Skeleton-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker.Skeleton-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DatePickerSkeleton } from './DatePicker.Skeleton';
+
+describe('DatePickerSkeleton', () => {
+  it('should support a custom `className` on the date picker element', () => {
+    render(<DatePickerSkeleton className="classy" data-testid="skeleton" />);
+
+    expect(screen.getByTestId('skeleton')).toHaveClass(
+      'cds--date-picker',
+      'cds--date-picker--short',
+      'cds--date-picker--simple',
+      'cds--skeleton',
+      'classy',
+      { exact: true }
+    );
+  });
+
+  it('should spread additional props onto the date picker element', () => {
+    render(
+      <DatePickerSkeleton
+        data-testid="skeleton"
+        aria-label="Date picker skeleton"
+      />
+    );
+
+    expect(screen.getByTestId('skeleton')).toHaveAttribute(
+      'aria-label',
+      'Date picker skeleton'
+    );
+  });
+
+  it('should render the single variant by default', () => {
+    const { container } = render(<DatePickerSkeleton id="single-label" />);
+
+    expect(
+      container.querySelector('.cds--date-picker--short')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.cds--date-picker--simple')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('.cds--date-picker-container')
+    ).toHaveLength(1);
+    expect(container.querySelector('#single-label')).toHaveClass('cds--label', {
+      exact: true,
+    });
+  });
+
+  it('should render the range variant when `range` is true', () => {
+    const { container } = render(<DatePickerSkeleton range />);
+
+    expect(
+      container.querySelector('.cds--date-picker--range')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('.cds--date-picker-container')
+    ).toHaveLength(2);
+  });
+
+  it('should hide labels when `hideLabel` is true', () => {
+    const { container } = render(<DatePickerSkeleton hideLabel />);
+
+    expect(container.querySelector('.cds--label')).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/DatePicker/DatePicker.Skeleton.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.Skeleton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,13 +12,15 @@ import { usePrefix } from '../../internal/usePrefix';
 
 export interface DatePickerSkeletonProps
   extends HTMLAttributes<HTMLDivElement> {
-  // Specify whether the skeleton should be of range date picker.
-  range?: boolean;
-
   /**
-   * Specify whether the label should be hidden, or not
+   * Specify whether to hide the label.
    */
   hideLabel?: boolean;
+
+  /**
+   * Specify whether to render the range skeleton variant.
+   */
+  range?: boolean;
 }
 
 const DatePickerSkeleton = ({
@@ -78,7 +80,7 @@ DatePickerSkeleton.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Specify whether the label should be hidden, or not
+   * Specify whether to hide the label.
    */
   hideLabel: PropTypes.bool,
 
@@ -88,7 +90,7 @@ DatePickerSkeleton.propTypes = {
   id: PropTypes.string,
 
   /**
-   * Specify whether the skeleton should be of range date picker.
+   * Specify whether to render the range skeleton variant.
    */
   range: PropTypes.bool,
 };


### PR DESCRIPTION
No issue.

Added test coverage for `DatePickerSkeleton` and updated component documentation.

### Changelog

**New**

- Added test coverage for `DatePickerSkeleton`.

**Changed**

- Updated `DatePickerSkeleton` component documentation.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/DatePicker/DatePicker.Skeleton-test.js \
  --collectCoverageFrom=packages/react/src/components/DatePicker/DatePicker.Skeleton.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
