### PR TITLE
fix(eslint): disable rules-of-hooks in figma files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,6 +217,7 @@ export default defineConfig(
     files: ['packages/react/code-connect/**/*.figma.tsx'],
     rules: {
       '@typescript-eslint/ban-ts-comment': ['error', { 'ts-nocheck': false }],
+      'react-hooks/rules-of-hooks': 'off',
       'react/jsx-no-undef': 'off',
     },
   },

--- a/packages/react/code-connect/ComposedModal/ComposedModal.figma.tsx
+++ b/packages/react/code-connect/ComposedModal/ComposedModal.figma.tsx
@@ -46,7 +46,7 @@ figma.connect(
       descriptionText,
       progress,
     }) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars , react-hooks/rules-of-hooks -- https://github.com/carbon-design-system/carbon/issues/20452
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- https://github.com/carbon-design-system/carbon/issues/20452
       const [open, setOpen] = useState(true);
       return (
         <ComposedModal open onClose={() => setOpen(false)}>

--- a/packages/react/code-connect/Popover/Popover.figma.tsx
+++ b/packages/react/code-connect/Popover/Popover.figma.tsx
@@ -38,7 +38,6 @@ figma.connect(
       }),
     },
     example: ({ align, open, popoverItem }) => {
-      // eslint-disable-next-line  react-hooks/rules-of-hooks -- https://github.com/carbon-design-system/carbon/issues/20452
       const [open, setOpen] = React.useState(false);
       return (
         <Popover
@@ -77,7 +76,6 @@ figma.connect(
       }),
     },
     example: ({ align, open, dropShadow, popoverItem }) => {
-      // eslint-disable-next-line  react-hooks/rules-of-hooks -- https://github.com/carbon-design-system/carbon/issues/20452
       const [open, setOpen] = React.useState(false);
       return (
         <Popover isTabTip align={align} open={open} dropShadow={dropShadow}>


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Disabled `react-hooks/rules-of-hooks` in Figma files.

### Changelog

**Changed**

- Disabled `react-hooks/rules-of-hooks` in Figma files.

#### Testing / Reviewing

Run `yarn lint`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
