### PR TITLE
fix(combo-box): normalize empty blur custom selection

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -341,6 +341,34 @@ describe('ComboBox', () => {
     expect(findInputNode()).toHaveDisplayValue('Apple');
   });
 
+  it('should not call `onChange` on blur when `allowCustomValue` input is empty with no selection', async () => {
+    render(<ComboBox {...mockProps} allowCustomValue />);
+
+    await userEvent.click(findInputNode());
+    fireEvent.blur(findInputNode());
+
+    expect(mockProps.onChange).not.toHaveBeenCalled();
+  });
+
+  it('should never pass empty string `selectedItem` on `allowCustomValue` blur', async () => {
+    const user = userEvent.setup();
+
+    render(<ComboBox {...mockProps} allowCustomValue />);
+
+    await openMenu();
+    await user.click(screen.getByRole('option', { name: 'Item 0' }));
+    mockProps.onChange.mockClear();
+
+    await user.clear(findInputNode());
+    fireEvent.blur(findInputNode());
+
+    const calls = mockProps.onChange.mock.calls.map(([payload]) => payload);
+
+    expect(calls).not.toContainEqual(
+      expect.objectContaining({ selectedItem: '' })
+    );
+  });
+
   it('should apply onChange value if custom value is entered and `allowCustomValue` is set', async () => {
     render(<ComboBox {...mockProps} allowCustomValue />);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -603,10 +603,13 @@ const ComboBox = forwardRef(
                 return changes;
               }
               const nextSelectedItem =
-                items.find((item) => itemToString(item) === inputValue) ??
-                inputValue;
+                inputValue === ''
+                  ? null
+                  : (items.find((item) => itemToString(item) === inputValue) ??
+                    inputValue);
               const isCustomSelection =
                 typeof nextSelectedItem === 'string' &&
+                nextSelectedItem !== '' &&
                 !items.some((item) => isEqual(item, nextSelectedItem));
 
               if (!isEqual(currentSelectedItem, nextSelectedItem) && onChange) {


### PR DESCRIPTION
No issue.

Normalize empty blur custom selection in `ComboBox`.

### Changelog

**Changed**

- Normalize empty blur custom selection in `ComboBox`.

#### Testing / Reviewing

In `ComboBox`, the `allowCustomValue` blur path emitted an invalid selection payload when the input was empty. Instead of treating an empty input as a cleared selection, the reducer could fall back to `selectedItem: ''` and call `onChange` with `{ selectedItem: '', inputValue: '' }`.

That's inconsistent with the component's selection model, where a cleared value is represented as `null`.

```tsx
export const Emission = () => {
  const items = [
    { id: 'id-0', label: 'Item 0', value: 0 },
    { id: 'id-1', label: 'Item 1', value: 1 },
  ];

  return (
    <ComboBox
      id="items"
      titleText="Items"
      items={items}
      itemToString={(item) => (item ? item.label : '')}
      allowCustomValue
      onChange={(data) => {
        console.log('onChange', data);
      }}
    />
  );
};
```

Steps to reproduce:

1. Select `Item 0`.
2. Clear the input.
3. Blur the input (click outside).
4. See `onChange` payload.

Before: `{ selectedItem: '', inputValue: '' }` would be emitted.  
After: Cleared state should use `selectedItem: null`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
