### PR TITLE
fix(storybook): restore sass hot reloading for react

### DIFF
--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -83,6 +83,16 @@ const config = {
           },
         },
       },
+      server: {
+        watch: {
+          // Watch for changes in the styles package
+          ignored: ['!**/node_modules/@carbon/**'],
+        },
+        fs: {
+          // Allow serving files from the monorepo root
+          allow: ['../..'],
+        },
+      },
       optimizeDeps: {
         esbuildOptions: {
           loader: {


### PR DESCRIPTION
No issue

Fixes Sass hot reloading in Storybook after the migration to Vite loader https://github.com/carbon-design-system/carbon/pull/21151.

### Changelog
- Watch for changes in `@carbon` packages within node_modules
- Allow file serving from the monorepo root directory

#### Testing / Reviewing

1. Start Storybook: `yarn storybook` in `packages/react`
2. Edit a Sass file in `packages/styles/scss/components/`
3. Verify changes hot reload in the browser without manual refresh
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
