### PR TITLE
fix: icon & shape indicator overflow

### DIFF
--- a/packages/react/src/components/IconIndicator/index.tsx
+++ b/packages/react/src/components/IconIndicator/index.tsx
@@ -106,7 +106,7 @@ export const IconIndicator = React.forwardRef(
           size={size}
           className={`${prefix}--icon-indicator--${kind}`}
         />
-        {label}
+        <span className={`${prefix}--icon-indicator__label`}>{label}</span>
       </div>
     );
   }

--- a/packages/react/src/components/ShapeIndicator/index.tsx
+++ b/packages/react/src/components/ShapeIndicator/index.tsx
@@ -123,7 +123,7 @@ export const ShapeIndicator = React.forwardRef(
           size={16}
           className={`${prefix}--shape-indicator--${kind}`}
         />
-        {label}
+        <span className={`${prefix}--shape-indicator__label`}>{label}</span>
       </div>
     );
   }

--- a/packages/styles/scss/components/icon-indicator/_icon-indicator.scss
+++ b/packages/styles/scss/components/icon-indicator/_icon-indicator.scss
@@ -23,6 +23,13 @@
     color: $text-secondary;
   }
 
+  .#{$prefix}--icon-indicator__label {
+    overflow: hidden;
+    flex: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .#{$prefix}--icon-indicator svg {
     align-self: center;
     margin-inline-end: $spacing-03;

--- a/packages/styles/scss/components/shape-indicator/_shape-indicator.scss
+++ b/packages/styles/scss/components/shape-indicator/_shape-indicator.scss
@@ -23,6 +23,13 @@
     color: $text-secondary;
   }
 
+  .#{$prefix}--shape-indicator__label {
+    overflow: hidden;
+    flex: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .#{$prefix}--shape-indicator svg {
     align-self: center;
     margin-inline-end: $spacing-03;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21700

In case you want to go through with a fix for the issue above. - This prevents both labels from overflowing but to properly truncate with an ellipsis. 

Note: Previously multi word labels did wrap, now they won't anymore. In case this is not expected, I suggest to remove the CSS to prevent overflow again, but keep the span and class name for users to be able to apply it themselves, if necessary. Currently the label is not accessible via CSS. 

### Changelog

**Changed**

- Wraps labels with a span
- Applies CSS to achieve the outcome described above

#### Testing / Reviewing

- Storybook

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
