### PR TITLE
fix(pagination): data type in selection event detail

### DIFF
--- a/packages/web-components/src/components/pagination/pagination.stories.ts
+++ b/packages/web-components/src/components/pagination/pagination.stories.ts
@@ -10,6 +10,7 @@ import '../select/index';
 
 import { PAGINATION_SIZE } from './defs';
 import { html } from 'lit';
+import { action } from 'storybook/actions';
 
 const sizes = {
   [`Small size (${PAGINATION_SIZE.SMALL})`]: PAGINATION_SIZE.SMALL,
@@ -119,7 +120,13 @@ export const Default = {
         ?page-size-input-disabled=${pageSizeInputDisabled}
         size=${size}
         ?pages-unknown=${pagesUnknown}
-        total-items=${totalItems}>
+        total-items=${totalItems}
+        @cds-page-sizes-select-changed=${(event: CustomEvent) => {
+          action('cds-page-sizes-select-changed')(event.detail);
+        }}
+        @cds-pagination-changed-current=${(event: CustomEvent) => {
+          action('cds-pagination-changed-current')(event.detail);
+        }}>
         <cds-select-item value="10">10</cds-select-item>
         <cds-select-item value="20">20</cds-select-item>
         <cds-select-item value="30">30</cds-select-item>
@@ -159,7 +166,13 @@ export const MultiplePaginationComponents = {
         ?page-size-input-disabled=${pageSizeInputDisabled}
         size=${size}
         ?pages-unknown=${pagesUnknown}
-        total-items=${totalItems}>
+        total-items=${totalItems}
+        @cds-page-sizes-select-changed=${(event: CustomEvent) => {
+          action('cds-page-sizes-select-changed')(event.detail);
+        }}
+        @cds-pagination-changed-current=${(event: CustomEvent) => {
+          action('cds-pagination-changed-current')(event.detail);
+        }}>
         <cds-select-item value="10">10</cds-select-item>
         <cds-select-item value="20">20</cds-select-item>
         <cds-select-item value="30">30</cds-select-item>
@@ -178,7 +191,13 @@ export const MultiplePaginationComponents = {
         ?page-size-input-disabled=${pageSizeInputDisabled}
         size=${size}
         ?pages-unknown=${pagesUnknown}
-        total-items=${totalItems}>
+        total-items=${totalItems}
+        @cds-page-sizes-select-changed=${(event: CustomEvent) => {
+          action('cds-page-sizes-select-changed')(event.detail);
+        }}
+        @cds-pagination-changed-current=${(event: CustomEvent) => {
+          action('cds-pagination-changed-current')(event.detail);
+        }}>
         <cds-select-item value="10">10</cds-select-item>
         <cds-select-item value="20">20</cds-select-item>
         <cds-select-item value="30">30</cds-select-item>
@@ -224,7 +243,13 @@ export const PaginationUnknownPages = {
         ?page-size-input-disabled=${pageSizeInputDisabled}
         size=${size}
         ?pages-unknown=${pagesUnknown}
-        total-items=${totalItems}>
+        total-items=${totalItems}
+        @cds-page-sizes-select-changed=${(event: CustomEvent) => {
+          action('cds-page-sizes-select-changed')(event.detail);
+        }}
+        @cds-pagination-changed-current=${(event: CustomEvent) => {
+          action('cds-pagination-changed-current')(event.detail);
+        }}>
         <cds-select-item value="10">10</cds-select-item>
         <cds-select-item value="20">20</cds-select-item>
         <cds-select-item value="30">30</cds-select-item>
@@ -264,7 +289,13 @@ export const PaginationWithCustomPageSizesLabel = {
         ?page-size-input-disabled=${pageSizeInputDisabled}
         size=${size}
         ?pages-unknown=${pagesUnknown}
-        total-items=${totalItems}>
+        total-items=${totalItems}
+        @cds-page-sizes-select-changed=${(event: CustomEvent) => {
+          action('cds-page-sizes-select-changed')(event.detail);
+        }}
+        @cds-pagination-changed-current=${(event: CustomEvent) => {
+          action('cds-pagination-changed-current')(event.detail);
+        }}>
         <cds-select-item value="10">Ten</cds-select-item>
         <cds-select-item value="20">Twenty</cds-select-item>
         <cds-select-item value="30">Thirty</cds-select-item>

--- a/packages/web-components/src/components/pagination/pagination.ts
+++ b/packages/web-components/src/components/pagination/pagination.ts
@@ -221,7 +221,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
       this.start = 0;
       this._handleUserInitiatedPageSizeChange();
     } else {
-      this.page = value;
+      this.page = Number(value);
       const newStart = this._calculateStart(
         value,
         pageSize,


### PR DESCRIPTION
Closes N/A

noticed an inconsistency while checking web components pagination

reproduction - https://stackblitz.com/edit/github-tytssssd?file=index.html

https://github.com/user-attachments/assets/10108713-99ad-4f86-b85f-af1fac005448

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

added action for pagination events, which must populate on actions tab in storybook.

https://github.com/user-attachments/assets/78a94eee-f9dd-447a-b011-3f2cf3dfac1a

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
