### PR TITLE
fix : add label truncation with ellipsis for status indicators when labels exceed available space

### DIFF
--- a/packages/react/src/components/IconIndicator/index.tsx
+++ b/packages/react/src/components/IconIndicator/index.tsx
@@ -106,7 +106,7 @@ export const IconIndicator = React.forwardRef(
           size={size}
           className={`${prefix}--icon-indicator--${kind}`}
         />
-        {label}
+        <span className={`${prefix}--icon-indicator__label`}>{label}</span>
       </div>
     );
   }

--- a/packages/react/src/components/ShapeIndicator/index.tsx
+++ b/packages/react/src/components/ShapeIndicator/index.tsx
@@ -123,7 +123,7 @@ export const ShapeIndicator = React.forwardRef(
           size={16}
           className={`${prefix}--shape-indicator--${kind}`}
         />
-        {label}
+        <span className={`${prefix}--shape-indicator__label`}>{label}</span>
       </div>
     );
   }

--- a/packages/styles/scss/components/icon-indicator/_icon-indicator.scss
+++ b/packages/styles/scss/components/icon-indicator/_icon-indicator.scss
@@ -20,12 +20,22 @@
     @include type-style('body-compact-01');
 
     display: flex;
+    align-items: center;
     color: $text-secondary;
+    min-inline-size: 0;
   }
 
   .#{$prefix}--icon-indicator svg {
     align-self: center;
+    flex-shrink: 0;
     margin-inline-end: $spacing-03;
+  }
+
+  .#{$prefix}--icon-indicator__label {
+    min-inline-size: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .#{$prefix}--icon-indicator--20 {

--- a/packages/styles/scss/components/shape-indicator/_shape-indicator.scss
+++ b/packages/styles/scss/components/shape-indicator/_shape-indicator.scss
@@ -20,12 +20,22 @@
     @include type-style('helper-text-01');
 
     display: flex;
+    align-items: center;
     color: $text-secondary;
+    min-inline-size: 0;
   }
 
   .#{$prefix}--shape-indicator svg {
     align-self: center;
+    flex-shrink: 0;
     margin-inline-end: $spacing-03;
+  }
+
+  .#{$prefix}--shape-indicator__label {
+    min-inline-size: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .#{$prefix}--shape-indicator--14 {

--- a/packages/web-components/src/components/icon-indicator/icon-indicator.ts
+++ b/packages/web-components/src/components/icon-indicator/icon-indicator.ts
@@ -117,7 +117,7 @@ class CDSIconIndicator extends LitElement {
 
   render() {
     const IconComponent = iconMap[this.kind]?.[this.size];
-    return html`${iconLoader(IconComponent, { size: this.size })}${this.label}`;
+    return html`${iconLoader(IconComponent, { size: this.size })}<span class="${prefix}--icon-indicator__label">${this.label}</span>`;
   }
 
   static styles = styles;

--- a/packages/web-components/src/components/shape-indicator/shape-indicator.ts
+++ b/packages/web-components/src/components/shape-indicator/shape-indicator.ts
@@ -89,12 +89,13 @@ class CDSShapeIndicator extends LitElement {
       return null;
     }
 
-    // Handle custom SVG string vs Carbon icon descriptor
+    const labelEl = html`<span class="${prefix}--shape-indicator__label">${this.label}</span>`;
+
     if (typeof shape === 'string') {
-      return html` ${iconLoader(null, {}, shape)} ${this.label} `;
+      return html`${iconLoader(null, {}, shape)}${labelEl}`;
     }
 
-    return html` ${iconLoader(shape)} ${this.label} `;
+    return html`${iconLoader(shape)}${labelEl}`;
   }
 
   /**


### PR DESCRIPTION
Closes #21747

 Changelog

### New

 Design spec for status indicator label truncation

### Changed

Labels truncate with ellipsis when space is limited
Icons no longer shrink (flex-shrink: 0)

### Removed
(none)

### Testing / Reviewing
[ ] Long label in narrow container shows ellipsis
[ ] Icon size stays fixed
[ ] Check React and Web Components


