### PR TITLE
fix(ci): add checkout to flag-agents-md-changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,9 @@ jobs:
   flag-agents-md-changes:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - name: Detect AGENTS.md changes
         id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2


### PR DESCRIPTION
Closes N/A

Fixes the `flag-agents-md-changes` CI job by checking out the repository before running `dorny/paths-filter`, preventing `fatal: not a git repository` failures.

I found this in theses PR's:
https://github.com/carbon-design-system/carbon/pull/21745
https://github.com/carbon-design-system/carbon/pull/21739
<img width="770" height="374" alt="image" src="https://github.com/user-attachments/assets/4bc32a56-7c76-47fb-a71e-1e8a2bbba39c" />

I checked the details: 
<img width="999" height="430" alt="image" src="https://github.com/user-attachments/assets/ac1e3696-ba01-4dae-a573-5a415579bd5c" />

### Changelog

**New**

- Added `actions/checkout` to the `flag-agents-md-changes` job in `.github/workflows/ci.yml`.

**Changed**

- Updated the `AGENTS.md` change detection job to run with a checked-out git workspace (`fetch-depth: 0`), based on the workflow file, this could be the fix.

**Removed**

- ~None~

#### Testing / Reviewing

CI should pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
