### PR TITLE
feat(FileUploaderButton): add xs size support

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploader.stories.js
+++ b/packages/react/src/components/FileUploader/FileUploader.stories.js
@@ -69,7 +69,7 @@ _FileUploaderItem.argTypes = {
   },
   name: { control: 'text', description: 'Name of the uploaded file' },
   onDelete: { action: 'onDelete' },
-  size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  size: { control: 'select', options: ['xs', 'sm', 'md', 'lg'] },
   status: {
     control: 'inline-radio',
     options: ['uploading', 'edit', 'complete'],
@@ -193,7 +193,7 @@ Default.argTypes = {
   },
   size: {
     control: { type: 'select' },
-    options: ['sm', 'md', 'lg'],
+    options: ['xs', 'sm', 'md', 'lg'],
   },
 };
 

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -150,7 +150,7 @@ export interface FileUploaderProps extends HTMLAttributes<HTMLSpanElement> {
    * Specify the size of the FileUploaderButton, from a list of available
    * sizes.
    */
-  size?: 'sm' | 'small' | 'md' | 'field' | 'lg';
+  size?: 'xs' | 'sm' | 'small' | 'md' | 'field' | 'lg';
 }
 
 export interface FileUploaderHandle {
@@ -432,6 +432,7 @@ const FileUploader = forwardRef<FileUploaderHandle, FileUploaderProps>(
       });
 
     const selectedFileClasses = classNames(`${prefix}--file__selected-file`, {
+      [`${prefix}--file__selected-file--xs`]: size === 'xs',
       [`${prefix}--file__selected-file--md`]: size === 'field' || size === 'md',
       [`${prefix}--file__selected-file--sm`]: size === 'small' || size === 'sm',
     });
@@ -617,7 +618,7 @@ FileUploader.propTypes = {
    * Specify the size of the FileUploaderButton, from a list of available
    * sizes.
    */
-  size: PropTypes.oneOf(['sm', 'small', 'md', 'field', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'small', 'md', 'field', 'lg']),
 } as PropTypes.ValidationMap<FileUploaderProps>;
 
 export default FileUploader;

--- a/packages/react/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.tsx
@@ -93,7 +93,7 @@ export interface FileUploaderButtonProps
    * Specify the size of the FileUploaderButton, from a list of available
    * sizes.
    */
-  size?: 'sm' | 'small' | 'field' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'small' | 'field' | 'md' | 'lg';
 
   /**
    * @deprecated The `tabIndex` prop for `FileUploaderButton` has been deprecated since it now renders a button element by default.
@@ -128,6 +128,7 @@ function FileUploaderButton({
     [`${prefix}--btn--${buttonKind}`]: buttonKind,
     [`${prefix}--btn--disabled`]: disabled,
     // V11: remove field, small
+    [`${prefix}--btn--xs`]: size === 'xs',
     [`${prefix}--btn--md`]: size === 'field' || size === 'md',
     [`${prefix}--btn--sm`]: size === 'small' || size === 'sm',
     [`${prefix}--layout--size-${size}`]: size,
@@ -275,7 +276,7 @@ FileUploaderButton.propTypes = {
    * Specify the size of the FileUploaderButton, from a list of available
    * sizes.
    */
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * Provide a custom tabIndex value for the `<FileUploaderButton>`

--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -61,7 +61,7 @@ export interface FileUploaderItemProps extends HTMLAttributes<HTMLSpanElement> {
    * Specify the size of the FileUploaderButton, from a list of available
    * sizes.
    */
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 
   /**
    * Status of the file upload
@@ -93,6 +93,7 @@ function FileUploaderItem({
   const { current: id } = useRef(uuid || generatedId);
   const classes = cx(`${prefix}--file__selected-file`, className, {
     [`${prefix}--file__selected-file--invalid`]: invalid,
+    [`${prefix}--file__selected-file--xs`]: size === 'xs',
     [`${prefix}--file__selected-file--md`]: size === 'md',
     [`${prefix}--file__selected-file--sm`]: size === 'sm',
   });
@@ -232,7 +233,7 @@ FileUploaderItem.propTypes = {
    * Specify the size of the FileUploaderButton, from a list of available
    * sizes.
    */
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * Status of the file upload

--- a/packages/styles/scss/components/file-uploader/_file-uploader.scss
+++ b/packages/styles/scss/components/file-uploader/_file-uploader.scss
@@ -237,6 +237,36 @@
     }
   }
 
+  .#{$prefix}--file__selected-file--xs {
+    gap: $spacing-02 $spacing-05;
+    min-block-size: convert.to-rem(24px);
+    margin-block-end: $spacing-02;
+
+    .#{$prefix}--file__state-container {
+      padding-inline-end: $spacing-05;
+      min-inline-size: $spacing-05;
+    }
+
+    .#{$prefix}--file__state-container .#{$prefix}--file-loading {
+      block-size: $spacing-05;
+      inline-size: $spacing-05;
+    }
+
+    .#{$prefix}--file__state-container .#{$prefix}--file-complete {
+      inline-size: $spacing-05;
+    }
+
+    .#{$prefix}--file__state-container .#{$prefix}--file-invalid {
+      block-size: $spacing-05;
+      inline-size: $spacing-05;
+    }
+
+    .#{$prefix}--file__state-container .#{$prefix}--file-close {
+      block-size: $spacing-05;
+      inline-size: $spacing-05;
+    }
+  }
+
   .#{$prefix}--file__selected-file--md {
     gap: $spacing-03 0;
     min-block-size: convert.to-rem(40px);
@@ -263,6 +293,10 @@
     padding: convert.to-rem(12px) 0;
   }
 
+  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--xs {
+    padding: $spacing-02 0;
+  }
+
   .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--sm {
     padding: $spacing-02 0;
   }
@@ -274,6 +308,11 @@
   .#{$prefix}--file__selected-file--invalid .#{$prefix}--form-requirement {
     border-block-start: 1px solid $border-subtle;
     padding-block-start: $spacing-05;
+  }
+
+  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--xs
+    .#{$prefix}--form-requirement {
+    padding-block-start: $spacing-02;
   }
 
   .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--sm

--- a/packages/web-components/src/components/file-uploader/defs.ts
+++ b/packages/web-components/src/components/file-uploader/defs.ts
@@ -30,6 +30,11 @@ export enum FILE_UPLOADER_ITEM_STATE {
  */
 export enum FILE_UPLOADER_ITEM_SIZE {
   /**
+   * Extra small size.
+   */
+  EXTRA_SMALL = 'xs',
+
+  /**
    * Small size.
    */
   SMALL = 'sm',

--- a/packages/web-components/src/components/file-uploader/demo-file-uploader.ts
+++ b/packages/web-components/src/components/file-uploader/demo-file-uploader.ts
@@ -233,6 +233,7 @@ export default class CDSCEDemoFileUploader extends LitElement {
             <cds-file-uploader-item
               data-file-id="${id}"
               ?invalid="${invalid}"
+              size="${ifDefined(size)}"
               state="${inputState || ifDefined(state)}"
               icon-description="${ifDefined(iconDescription)}"
               error-subject="${ifDefined(errorSubject)}"

--- a/packages/web-components/src/components/file-uploader/file-uploader.scss
+++ b/packages/web-components/src/components/file-uploader/file-uploader.scss
@@ -45,6 +45,10 @@
   }
 }
 
+:host(#{$prefix}-file-uploader-item[size='xs']) {
+  @extend .#{$prefix}--file__selected-file--xs;
+}
+
 :host(#{$prefix}-file-uploader-item[size='md']) {
   @extend .#{$prefix}--file__selected-file--md;
 }

--- a/packages/web-components/src/components/file-uploader/file-uploader.stories.ts
+++ b/packages/web-components/src/components/file-uploader/file-uploader.stories.ts
@@ -32,6 +32,7 @@ const states = {
 };
 
 const sizes = {
+  [`xs (${BUTTON_SIZE.EXTRA_SMALL})`]: BUTTON_SIZE.EXTRA_SMALL,
   [`sm (${BUTTON_SIZE.SMALL})`]: BUTTON_SIZE.SMALL,
   [`md (${BUTTON_SIZE.MEDIUM})`]: BUTTON_SIZE.MEDIUM,
   [`lg (${BUTTON_SIZE.LARGE})`]: BUTTON_SIZE.LARGE,


### PR DESCRIPTION
Closes : #21807

- Adds extra small (xs) size variant to the File uploader in React and Web Components.

### Changelog
New
- xs size option for File uploader button and file items (24px height, 16px icons)

### Changed

- File uploader styles to support xs spacing (16px button–list, 8px between items, 16px filename–icon gap)

### Removed

- (none)

### Testing / Reviewing

[ ] In Storybook, set File uploader size to xs and verify layout
[ ] Check default, invalid, loading, and complete states for xs
[ ] Verify xs in both React and Web Components stories

### PR Checklist

- As the author of this PR, before marking ready for review, confirm you:

[ ] Reviewed every line of the diff
[ ] Updated documentation and storybook examples
[ ] Wrote passing tests that cover this change
[ ] Addressed any impact on accessibility (a11y)
[ ] Tested for cross-browser consistency
[ ] Validated that this code is ready for review and status checks should pass