### PR TITLE
test(react): increase coverage for TableBatchAction

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/TableBatchAction-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableBatchAction-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,5 +30,29 @@ describe('TableBatchAction', () => {
   it('should support labeling the button with `iconDescription`', () => {
     render(<TableBatchAction iconDescription="test" />);
     expect(screen.getByLabelText('test')).toBeInTheDocument();
+  });
+
+  it('should return an error when `renderIcon` is provided without `iconDescription` or children', () => {
+    const renderIcon = () => null;
+
+    const result = TableBatchAction.propTypes.iconDescription({
+      renderIcon,
+    });
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe(
+      'renderIcon property specified without also providing an iconDescription property.'
+    );
+  });
+
+  it('should not return an error when `renderIcon` is provided with children', () => {
+    const renderIcon = () => null;
+
+    const result = TableBatchAction.propTypes.iconDescription({
+      children: 'Archive',
+      renderIcon,
+    });
+
+    expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
No issue.

Increased test coverage for `TableBatchAction`.

### Changelog

**Changed**

- Increased test coverage for `TableBatchAction`.

#### Testing / Reviewing

I haven't added testing for prop-types in other pull requests. However, in this component, test coverage is low without it.

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/DataTable/__tests__/TableBatchAction-test.js \
  --collectCoverageFrom=packages/react/src/components/DataTable/TableBatchAction.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
