### PR TITLE
test(react): add coverage for FluidFilterableMultiSelect

### DIFF
--- a/packages/react/src/components/FluidMultiSelect/__tests__/FluidFilterableMultiSelect-test.js
+++ b/packages/react/src/components/FluidMultiSelect/__tests__/FluidFilterableMultiSelect-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { generateItems, generateGenericItem } from '../../ListBox/test-helpers';
+import FluidFilterableMultiSelect from '../FluidFilterableMultiSelect';
+
+describe('FluidFilterableMultiSelect', () => {
+  it('should render with fluid classes', () => {
+    const items = generateItems(4, generateGenericItem);
+    const { container } = render(
+      <FluidFilterableMultiSelect
+        id="test"
+        label="Field"
+        items={items}
+        className="test"
+      />
+    );
+
+    expect(container.firstChild).toHaveClass(
+      'cds--multi-select__wrapper',
+      'cds--multi-select--filterable__wrapper',
+      'cds--list-box__wrapper',
+      'cds--list-box__wrapper--fluid',
+      'test',
+      { exact: true }
+    );
+  });
+
+  it('should render condensed fluid classes when `isCondensed` is `true`', () => {
+    const items = generateItems(4, generateGenericItem);
+    const { container } = render(
+      <FluidFilterableMultiSelect
+        id="test"
+        label="Field"
+        items={items}
+        isCondensed
+      />
+    );
+
+    expect(container.firstChild).toHaveClass(
+      'cds--multi-select__wrapper',
+      'cds--multi-select--filterable__wrapper',
+      'cds--list-box__wrapper',
+      'cds--list-box__wrapper--fluid',
+      'cds--list-box__wrapper--fluid--condensed',
+      { exact: true }
+    );
+  });
+});


### PR DESCRIPTION
No issue.

Added test coverage for `FluidFilterableMultiSelect`.

### Changelog

**New**

- Added test coverage for `FluidFilterableMultiSelect`.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/FluidMultiSelect/__tests__/FluidFilterableMultiSelect-test.js \
  --collectCoverageFrom=packages/react/src/components/FluidMultiSelect/FluidFilterableMultiSelect.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
