### PR TITLE
test(react): increase coverage for Button

### DIFF
--- a/packages/react/src/components/Button/__tests__/Button-test.js
+++ b/packages/react/src/components/Button/__tests__/Button-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -193,6 +193,42 @@ describe('Button', () => {
       );
       expect(screen.getByTestId('custom-component')).toBeInTheDocument();
       expect(screen.getByLabelText('test')).toHaveClass('cds--btn--icon-only');
+    });
+
+    it.each([
+      ['bottom', 'end', 'bottom-end'],
+      ['top', 'start', 'top-start'],
+      ['right', 'center', 'right'],
+    ])(
+      'should map tooltipPosition=%s and tooltipAlignment=%s to IconButton align=%s',
+      (tooltipPosition, tooltipAlignment, expectedAlign) => {
+        const result = Button.render(
+          {
+            hasIconOnly: true,
+            iconDescription: 'test',
+            renderIcon: Add,
+            tooltipAlignment,
+            tooltipPosition,
+          },
+          null
+        );
+
+        expect(result.props.align).toBe(expectedAlign);
+      }
+    );
+
+    it('should pass children through to IconButton when `hasIconOnly` is true without `renderIcon`', () => {
+      const result = Button.render(
+        {
+          children: '🧪',
+          hasIconOnly: true,
+          iconDescription: 'test',
+        },
+        null
+      );
+
+      expect(result.props.renderIcon).toBeUndefined();
+      expect(result.props.children).toBe('🧪');
     });
   });
 });


### PR DESCRIPTION
No issue.

Increased test coverage for `Button`.

### Changelog

**Changed**

- Increased test coverage for `Button`.

#### Testing / Reviewing

The remaining uncovered code relates to prop-types. I didn't think that was worth testing given prop-types may be removed in v12. If anyone thinks tests should be added for them regardless, let me know.

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/Button/__tests__/Button-test.js \
  --collectCoverageFrom=packages/react/src/components/Button/Button.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
