### PR TITLE
test(react): increase coverage for CodeSnippet

### DIFF
--- a/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js
+++ b/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import CodeSnippet from '../';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import copy from 'copy-to-clipboard';
 
-jest.mock('copy-to-clipboard', () => {
-  return jest.fn();
-});
+const mockUseResizeObserver = jest.fn();
+
+jest.mock('copy-to-clipboard', () => jest.fn());
+
+jest.mock('../../../internal/useResizeObserver', () => ({
+  useResizeObserver: (args) => mockUseResizeObserver(args),
+}));
 
 const inline = `node -v`;
 
@@ -66,6 +71,22 @@ const multi15 = `  "scripts": {
   "resolutions": {
     "react": "~16.9.0",`;
 
+const triggerResizeObserver = () => {
+  const latestCall =
+    mockUseResizeObserver.mock.calls[
+      mockUseResizeObserver.mock.calls.length - 1
+    ];
+
+  act(() => {
+    latestCall[0].onResize();
+  });
+};
+
+beforeEach(() => {
+  copy.mockClear();
+  mockUseResizeObserver.mockClear();
+});
+
 describe('CodeSnippet', () => {
   it('should use the appropriate snippet class when it is type single', () => {
     render(
@@ -74,6 +95,16 @@ describe('CodeSnippet', () => {
       </CodeSnippet>
     );
     expect(screen.getByTestId('code-1')).toHaveClass('cds--snippet--single');
+  });
+
+  it('should default to the single snippet type when `type` is not provided', () => {
+    render(<CodeSnippet>{single}</CodeSnippet>);
+
+    triggerResizeObserver();
+
+    expect(screen.getByRole('textbox')).toHaveClass('cds--snippet-container', {
+      exact: true,
+    });
   });
 
   it('should use the appropriate snippet class when it is type multi', () => {
@@ -126,6 +157,17 @@ describe('CodeSnippet', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it('should allow hiding the copy button for inline snippets', () => {
+    render(
+      <CodeSnippet type="inline" hideCopyButton>
+        {inline}
+      </CodeSnippet>
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText(inline).tagName).toBe('CODE');
+  });
+
   it('should set disabled on copy button if it is passed via props', () => {
     render(
       <CodeSnippet type="single" disabled>
@@ -134,6 +176,38 @@ describe('CodeSnippet', () => {
     );
 
     expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should use fallback container attributes when `type` is not recognized', () => {
+    const { container } = render(
+      <CodeSnippet aria-label={null} type="other">
+        {single}
+      </CodeSnippet>
+    );
+
+    triggerResizeObserver();
+
+    const snippetContainer = container.querySelector('.cds--snippet-container');
+
+    expect(snippetContainer).not.toHaveAttribute('role');
+    expect(snippetContainer).toHaveAttribute('aria-label', 'code-snippet');
+    expect(snippetContainer).not.toHaveAttribute('aria-readonly');
+  });
+
+  it('should omit collapsed inline styles when collapsed row limits are zero', () => {
+    render(
+      <CodeSnippet
+        type="multi"
+        maxCollapsedNumberOfRows={0}
+        minCollapsedNumberOfRows={0}>
+        {multiLong}
+      </CodeSnippet>
+    );
+
+    const textBox = screen.getByRole('textbox');
+
+    expect(textBox.style.maxHeight).toBe('');
+    expect(textBox.style.minHeight).toBe('');
   });
 });
 
@@ -148,6 +222,18 @@ describe('CodeSnippet events', () => {
 
     await userEvent.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should copy text when the copy button is clicked without an `onClick` handler', async () => {
+    render(
+      <CodeSnippet copyText="copied value" type="single">
+        {single}
+      </CodeSnippet>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(copy).toHaveBeenCalledWith('copied value');
   });
 
   it('should call the click handler with type inline', async () => {
@@ -175,5 +261,70 @@ describe('Show more button', () => {
     render(<CodeSnippet type="multi">{multi15}</CodeSnippet>);
 
     expect(screen.queryByText('Show more')).not.toBeInTheDocument();
+  });
+
+  it('should show, expand, collapse, and hide the multi-line toggle based on measured height', async () => {
+    render(
+      <CodeSnippet
+        type="multi"
+        maxCollapsedNumberOfRows={3}
+        maxExpandedNumberOfRows={5}
+        minExpandedNumberOfRows={4}>
+        {multiLong}
+      </CodeSnippet>
+    );
+
+    const textBox = screen.getByRole('textbox');
+    const code = textBox.querySelector('code');
+    const getBoundingClientRectSpy = jest
+      .spyOn(code, 'getBoundingClientRect')
+      .mockReturnValue({ height: 80 });
+
+    triggerResizeObserver();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show more' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Show less' })
+    ).toBeInTheDocument();
+    expect(textBox).toHaveStyle({ maxHeight: '80px', minHeight: '64px' });
+
+    getBoundingClientRectSpy.mockReturnValue({ height: 50 });
+    triggerResizeObserver();
+
+    expect(
+      screen.getByRole('button', { name: 'Show more' })
+    ).toBeInTheDocument();
+
+    getBoundingClientRectSpy.mockReturnValue({ height: 32 });
+    triggerResizeObserver();
+
+    expect(
+      screen.queryByRole('button', { name: 'Show more' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should omit expanded inline styles when expanded row limits are zero', async () => {
+    render(
+      <CodeSnippet
+        type="multi"
+        maxCollapsedNumberOfRows={3}
+        maxExpandedNumberOfRows={0}
+        minExpandedNumberOfRows={0}>
+        {multiLong}
+      </CodeSnippet>
+    );
+
+    const textBox = screen.getByRole('textbox');
+    const code = textBox.querySelector('code');
+
+    jest.spyOn(code, 'getBoundingClientRect').mockReturnValue({ height: 80 });
+
+    triggerResizeObserver();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show more' }));
+
+    expect(textBox.style.maxHeight).toBe('');
+    expect(textBox.style.minHeight).toBe('');
   });
 });


### PR DESCRIPTION
No issue.

Increased test coverage for `CodeSnippet`.

### Changelog

**Changed**

- Increased test coverage for `CodeSnippet`.

#### Testing / Reviewing

There is one uncovered line in `handleCopyClick` and I'm not sure how to cover it.

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js \
  --collectCoverageFrom=packages/react/src/components/CodeSnippet/CodeSnippet.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
