### PR TITLE
test(react): add coverage for ColumnHang

### DIFF
--- a/packages/react/src/components/Grid/__tests__/ColumnHang-test.js
+++ b/packages/react/src/components/Grid/__tests__/ColumnHang-test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ColumnHang } from '../';
+
+describe('ColumnHang', () => {
+  it('should render a `div` by default with the column hang class', () => {
+    const { container } = render(<ColumnHang />);
+
+    expect(container.firstChild.tagName).toBe('DIV');
+    expect(container.firstChild).toHaveClass('cds--grid-column-hang', {
+      exact: true,
+    });
+  });
+
+  it('should support a custom element as the root node', () => {
+    const { container } = render(<ColumnHang as="section" />);
+
+    expect(container.firstChild.tagName).toBe('SECTION');
+  });
+
+  it('should include a custom `className` and pass through unused props', () => {
+    const { container } = render(
+      <ColumnHang className="🧇" id="column-hang" />
+    );
+
+    expect(container.firstChild).toHaveAttribute('id', 'column-hang');
+    expect(container.firstChild).toHaveClass('🧇', 'cds--grid-column-hang', {
+      exact: true,
+    });
+  });
+
+  it('should render `children`', () => {
+    const { container } = render(
+      <ColumnHang>
+        <span id="test">Test</span>
+      </ColumnHang>
+    );
+
+    const testNode = container.querySelector('#test');
+
+    expect(testNode).toBeInstanceOf(HTMLElement);
+  });
+});


### PR DESCRIPTION
No issue.

Added test coverage for `ColumnHang`.

### Changelog

**New**

- Added test coverage for `ColumnHang`.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/Grid/__tests__/ColumnHang-test.js \
  --collectCoverageFrom=packages/react/src/components/Grid/ColumnHang.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
