### PR TITLE
test(react): add coverage for TableToolbarAction

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/TableToolbarAction-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableToolbarAction-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { TableToolbarAction } from '../';
+
+describe('TableToolbarAction', () => {
+  it('should render the `children` text and forward props to the menu item', () => {
+    render(
+      <TableToolbarAction
+        className="🪑"
+        closeMenu={jest.fn()}
+        data-testid="toolbar-action"
+        onClick={jest.fn()}>
+        Delete
+      </TableToolbarAction>
+    );
+
+    expect(screen.getByTestId('toolbar-action')).toHaveClass(
+      'cds--overflow-menu-options__btn',
+      '🪑',
+      { exact: true }
+    );
+    expect(screen.getByTestId('toolbar-action')).toHaveTextContent('Delete');
+    expect(screen.getByRole('menuitem')).toBe(
+      screen.getByTestId('toolbar-action')
+    );
+  });
+
+  it('should forward the `ref` and call `onClick` when activated', async () => {
+    const onClick = jest.fn();
+    const ref = React.createRef();
+
+    render(
+      <TableToolbarAction closeMenu={jest.fn()} onClick={onClick} ref={ref}>
+        Edit
+      </TableToolbarAction>
+    );
+
+    await userEvent.click(screen.getByRole('menuitem'));
+
+    expect(ref.current).toBe(screen.getByRole('menuitem'));
+    expect(onClick).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
No issue.

Added test coverage for `TableToolbarAction`.

### Changelog

**New**

- Added test coverage for `TableToolbarAction`.

#### Testing / Reviewing

```sh
yarn test --coverage \
  --runTestsByPath packages/react/src/components/DataTable/__tests__/TableToolbarAction-test.js \
  --collectCoverageFrom=packages/react/src/components/DataTable/TableToolbarAction.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
