### PR TITLE
test(react): increase coverage for SassRenderer

### DIFF
--- a/packages/test-utils/src/__tests__/renderer-test.js
+++ b/packages/test-utils/src/__tests__/renderer-test.js
@@ -1,10 +1,13 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+const fs = require('fs');
+const path = require('path');
+const sass = require('sass');
 const { SassRenderer } = require('../renderer');
 
 const { render } = SassRenderer.create(__dirname);
@@ -25,5 +28,69 @@ describe('SassRenderer', () => {
       $_: get-value(1);
     `);
     expect(getValue(0)).toEqual(1);
+  });
+
+  it('should convert and retrieve keyed Sass values', async () => {
+    const { get, unwrap } = await render(`
+      @use 'sass:math';
+
+      $_: get(list, (1, "two", false));
+      $_: get(map, (alpha: 1, beta: true));
+      $_: get(unitless, 2);
+      $_: get(units, 2px);
+      $_: get(rate, math.div(1px, 2s));
+      $_: get(string, "abc");
+      $_: get(color, #0f62fe);
+      $_: get(nullish, null);
+    `);
+
+    expect(unwrap('list')).toEqual([1, 'two', false]);
+    expect(unwrap('map')).toEqual({ alpha: 1, beta: true });
+    expect(unwrap('unitless')).toEqual(2);
+    expect(unwrap('units')).toEqual('2px');
+    expect(unwrap('rate')).toEqual('0.5px/s');
+    expect(unwrap('string')).toEqual('abc');
+    expect(unwrap('color')).toEqual('#0f62fe');
+    expect(unwrap('nullish')).toBeNull();
+    expect(get('color').nativeValue).toBeInstanceOf(sass.SassColor);
+    expect(() => get('missing')).toThrow(
+      'Unabled to find value with key: missing'
+    );
+    expect(() => unwrap('missing')).toThrow(
+      'Unabled to find value with key: missing'
+    );
+  });
+
+  it('should include discovered `node_modules` folders in Sass load paths', async () => {
+    const cwd = path.join(path.sep, 'tmp', 'project', 'src');
+    const currentNodeModules = path.join(cwd, 'node_modules');
+    const parentNodeModules = path.join(path.dirname(cwd), 'node_modules');
+    const compileStringSpy = jest
+      .spyOn(sass, 'compileString')
+      .mockReturnValue({ css: '' });
+    const existsSyncSpy = jest
+      .spyOn(fs, 'existsSync')
+      .mockImplementation(
+        (folder) =>
+          folder === currentNodeModules || folder === parentNodeModules
+      );
+
+    try {
+      const { render } = SassRenderer.create(cwd, '$color: red;');
+
+      await render('body { color: $color; }');
+
+      expect(compileStringSpy).toHaveBeenCalledWith(
+        '$color: red;\nbody { color: $color; }',
+        expect.objectContaining({
+          loadPaths: [cwd, currentNodeModules, parentNodeModules],
+          quietDeps: true,
+          functions: expect.any(Object),
+        })
+      );
+    } finally {
+      compileStringSpy.mockRestore();
+      existsSyncSpy.mockRestore();
+    }
   });
 });

--- a/packages/test-utils/src/renderer.js
+++ b/packages/test-utils/src/renderer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -41,7 +41,6 @@ const SassRenderer = {
 
       return {
         result,
-        values,
         getValue(index) {
           return convertValue(values[index]);
         },
@@ -61,7 +60,6 @@ const SassRenderer = {
     }
 
     return {
-      convert: convertValue,
       render,
     };
   },


### PR DESCRIPTION
No issue.

Increased test coverage for `SassRenderer` and deleted unused code.

### Changelog

**Changed**

- Increased test coverage for `SassRenderer`.

**Removed**

- Deleted unused code.

#### Testing / Reviewing

I deleted unused code in the module. It came down to either removing it or adding tests for code that is no longer used.

There is one uncovered line in `convertValue`. It is no longer exercised since the `convert` property was removed. Since it serves as the fallback for the entire function, I left it in.

```sh
yarn test --coverage \
  --runTestsByPath packages/test-utils/src/__tests__/renderer-test.js \
  --collectCoverageFrom=packages/test-utils/src/renderer.js
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
