### PR TITLE
fix: remove story defaultWidth from component props

### DIFF
--- a/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
+++ b/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -108,8 +108,8 @@ const sharedArgTypes = {
   },
 };
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
+export const Default = ({ defaultWidth, ...comboBoxArgs }) => (
+  <div style={{ width: defaultWidth }}>
     <FluidComboBox
       onChange={() => {}}
       id="default"
@@ -117,7 +117,7 @@ export const Default = (args) => (
       label="Choose an option"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
-      {...args}
+      {...comboBoxArgs}
     />
   </div>
 );

--- a/packages/react/src/components/FluidDropdown/FluidDropdown.stories.js
+++ b/packages/react/src/components/FluidDropdown/FluidDropdown.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -108,15 +108,15 @@ const sharedArgTypes = {
   },
 };
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
+export const Default = ({ defaultWidth, ...dropdownArgs }) => (
+  <div style={{ width: defaultWidth }}>
     <FluidDropdown
       id="default"
       titleText="Label"
       label="Choose an option"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
-      {...args}
+      {...dropdownArgs}
     />
   </div>
 );

--- a/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.stories.js
+++ b/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -65,8 +65,8 @@ const items = [
   },
 ];
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
+export const Default = ({ defaultWidth, ...multiSelectArgs }) => (
+  <div style={{ width: defaultWidth }}>
     <FluidMultiSelect
       onChange={() => {}}
       id="default"
@@ -74,7 +74,7 @@ export const Default = (args) => (
       label="Choose an option"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
-      {...args}
+      {...multiSelectArgs}
     />
   </div>
 );

--- a/packages/react/src/components/FluidNumberInput/FluidNumberInput.stories.js
+++ b/packages/react/src/components/FluidNumberInput/FluidNumberInput.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -43,9 +43,9 @@ const ToggleTip = (
   </>
 );
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
-    <FluidNumberInput {...args} />
+export const Default = ({ defaultWidth, ...numberInputArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <FluidNumberInput {...numberInputArgs} />
   </div>
 );
 

--- a/packages/react/src/components/FluidSearch/FluidSearch.stories.js
+++ b/packages/react/src/components/FluidSearch/FluidSearch.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,9 +31,9 @@ export const Skeleton = () => (
   </div>
 );
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
-    <FluidSearch {...args} />
+export const Default = ({ defaultWidth, ...searchArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <FluidSearch {...searchArgs} />
   </div>
 );
 

--- a/packages/react/src/components/FluidSelect/FluidSelect.stories.js
+++ b/packages/react/src/components/FluidSelect/FluidSelect.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -95,9 +95,9 @@ const ToggleTip = (
   </>
 );
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
-    <FluidSelect {...args} id="select-1">
+export const Default = ({ defaultWidth, ...selectArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <FluidSelect {...selectArgs} id="select-1">
       <SelectItem value="" text="" />
       <SelectItem value="option-1" text="Option 1" />
       <SelectItem value="option-2" text="Option 2" />

--- a/packages/react/src/components/FluidTextArea/FluidTextArea.stories.js
+++ b/packages/react/src/components/FluidTextArea/FluidTextArea.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -106,9 +106,9 @@ const sharedArgTypes = {
   },
 };
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
-    <FluidTextArea {...args} />
+export const Default = ({ defaultWidth, ...textAreaArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <FluidTextArea {...textAreaArgs} />
   </div>
 );
 

--- a/packages/react/src/components/FluidTextInput/FluidPasswordInput.stories.js
+++ b/packages/react/src/components/FluidTextInput/FluidPasswordInput.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,10 +24,10 @@ export default {
   },
 };
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
+export const Default = ({ defaultWidth, ...passwordInputArgs }) => (
+  <div style={{ width: defaultWidth }}>
     <FluidPasswordInput
-      {...args}
+      {...passwordInputArgs}
       id="input-1"
       labelText="Label"
       placeholder="Placeholder text"

--- a/packages/react/src/components/FluidTextInput/FluidTextInput.stories.js
+++ b/packages/react/src/components/FluidTextInput/FluidTextInput.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -48,9 +48,9 @@ const ToggleTip = (
   </>
 );
 
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
-    <FluidTextInput {...args} />
+export const Default = ({ defaultWidth, ...textInputArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <FluidTextInput {...textInputArgs} />
   </div>
 );
 

--- a/packages/react/src/components/Search/Search.stories.js
+++ b/packages/react/src/components/Search/Search.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -102,13 +102,11 @@ export const ExpandableWithLayer = () => {
   );
 };
 
-export const Default = (args) => {
-  return (
-    <div style={{ width: args.defaultWidth }}>
-      <Search id="search-default-1" {...args} />
-    </div>
-  );
-};
+export const Default = ({ defaultWidth, ...searchArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <Search id="search-default-1" {...searchArgs} />
+  </div>
+);
 
 Default.args = {
   closeButtonLabelText: 'Clear search input',

--- a/packages/react/src/components/TextInput/PasswordInput.stories.js
+++ b/packages/react/src/components/TextInput/PasswordInput.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,19 +20,17 @@ export default {
   },
 };
 
-export const Default = (args) => {
-  return (
-    <div style={{ width: args.defaultWidth }}>
-      <PasswordInput
-        {...args}
-        id="text-input-1"
-        labelText="Text input label"
-        helperText="Optional help text"
-        autoComplete="true"
-      />
-    </div>
-  );
-};
+export const Default = ({ defaultWidth, ...passwordInputArgs }) => (
+  <div style={{ width: defaultWidth }}>
+    <PasswordInput
+      {...passwordInputArgs}
+      id="text-input-1"
+      labelText="Text input label"
+      helperText="Optional help text"
+      autoComplete="true"
+    />
+  </div>
+);
 
 Default.args = {
   defaultWidth: 300,


### PR DESCRIPTION
No issue. https://github.com/carbon-design-system/carbon/pull/21721#discussion_r2892294291

Removed story `defaultWidth` from component props.

### Changelog

**Removed**

- Removed story `defaultWidth` from component props.

#### Testing / Reviewing

Review the stories.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
