### PR TITLE
chore(release): v11.104.1

### DIFF
--- a/packages/carbon-components-react/package.json
+++ b/packages/carbon-components-react/package.json
@@ -2,7 +2,7 @@
   "name": "carbon-components-react",
   "private": true,
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences. This package reached end of support on September 30, 2024 and will not receive any more updates.",
-  "version": "8.104.0",
+  "version": "8.104.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -43,7 +43,7 @@
     "sass": "^1.33.0"
   },
   "dependencies": {
-    "@carbon/react": "^1.104.0",
+    "@carbon/react": "^1.104.1",
     "@carbon/styles": "^1.103.0",
     "@ibm/telemetry-js": "^1.5.0",
     "chalk": "1.1.3"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/elements",
   "description": "A collection of design elements in code for the IBM Design Language",
-  "version": "11.86.0",
+  "version": "11.86.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@carbon/colors": "^11.49.0",
     "@carbon/grid": "^11.52.0",
-    "@carbon/icons": "^11.77.0",
+    "@carbon/icons": "^11.77.1",
     "@carbon/layout": "^11.50.0",
     "@carbon/motion": "^11.43.0",
     "@carbon/themes": "^11.70.0",

--- a/packages/icon-build-helpers/package.json
+++ b/packages/icon-build-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/icon-build-helpers",
   "private": true,
   "description": "Build helpers for the Carbon Design System icon library",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "repository": {

--- a/packages/icon-build-helpers/src/builders/react/next.js
+++ b/packages/icon-build-helpers/src/builders/react/next.js
@@ -207,6 +207,10 @@ async function builder(metadata, { output }) {
         return {
           ...options,
           banner: templates.banner,
+          // use .js extension for both entries and chunks so that
+          // CJS chunks (e.g. rolldown runtime helpers) don't get a
+          // .cjs extension which breaks Jest moduleFileExtensions
+          chunkFileNames: '[name]-[hash].js',
           entryFileNames: '[name]',
           exports: 'auto',
         };

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/icons-react",
   "description": "React components for icons in digital and software products using the Carbon Design System",
-  "version": "11.77.0",
+  "version": "11.77.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -43,8 +43,8 @@
     "prop-types": "^15.8.1"
   },
   "devDependencies": {
-    "@carbon/icon-build-helpers": "^1.55.0",
-    "@carbon/icons": "^11.77.0",
+    "@carbon/icon-build-helpers": "^1.55.1",
+    "@carbon/icons": "^11.77.1",
     "rimraf": "^6.0.1"
   },
   "sideEffects": false

--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/icons-vue",
   "description": "Vue components for icons in digital and software products using the Carbon Design System",
-  "version": "10.126.0",
+  "version": "10.126.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -34,7 +34,7 @@
     "@ibm/telemetry-js": "^1.5.0"
   },
   "devDependencies": {
-    "@carbon/icons": "^11.77.0",
+    "@carbon/icons": "^11.77.1",
     "rimraf": "^6.0.1",
     "vue": "^3.0.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/icons",
   "description": "Icons for digital and software products using the Carbon Design System",
-  "version": "11.77.0",
+  "version": "11.77.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@carbon/cli": "^11.42.0",
-    "@carbon/icon-build-helpers": "^1.55.0",
+    "@carbon/icon-build-helpers": "^1.55.1",
     "rimraf": "^6.0.1"
   },
   "dependencies": {

--- a/packages/pictograms-react/package.json
+++ b/packages/pictograms-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/pictograms-react",
   "description": "React components for pictograms in digital and software products using the Carbon Design System",
-  "version": "11.98.0",
+  "version": "11.98.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -45,8 +45,8 @@
     "prop-types": "^15.8.1"
   },
   "devDependencies": {
-    "@carbon/icon-build-helpers": "^1.55.0",
-    "@carbon/pictograms": "^12.72.0",
+    "@carbon/icon-build-helpers": "^1.55.1",
+    "@carbon/pictograms": "^12.72.1",
     "rimraf": "^6.0.1"
   },
   "sideEffects": false

--- a/packages/pictograms/package.json
+++ b/packages/pictograms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/pictograms",
   "description": "Pictograms for digital and software products using the Carbon Design System",
-  "version": "12.72.0",
+  "version": "12.72.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -33,7 +33,7 @@
     "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
-    "@carbon/icon-build-helpers": "^1.55.0",
+    "@carbon/icon-build-helpers": "^1.55.1",
     "rimraf": "^6.0.1"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/react",
   "description": "React components for the Carbon Design System",
-  "version": "1.104.0",
+  "version": "1.104.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,7 +53,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.3",
     "@carbon/feature-flags": "^1.2.0",
-    "@carbon/icons-react": "^11.77.0",
+    "@carbon/icons-react": "^11.77.1",
     "@carbon/layout": "^11.50.0",
     "@carbon/styles": "^1.103.0",
     "@carbon/utilities": "^0.18.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/web-components",
   "description": "Web components for the Carbon Design System",
-  "version": "2.51.0",
+  "version": "2.51.1",
   "license": "Apache-2.0",
   "main": "es/index.js",
   "module": "es/index.js",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@carbon/icon-helpers": "10.47.0",
-    "@carbon/icons": "^11.77.0",
+    "@carbon/icons": "^11.77.1",
     "@carbon/styles": "^1.103.0",
     "@floating-ui/dom": "^1.6.3",
     "@ibm/telemetry-js": "^1.10.2",

--- a/packages/web-components/src/globals/mixins/focus.ts
+++ b/packages/web-components/src/globals/mixins/focus.ts
@@ -11,8 +11,15 @@ import { selectorTabbable } from '../settings';
  * @param Base The base class.
  * @returns A mix-in implementing `.focus()` method that focuses on the first focusable element in the shadow DOM.
  */
-const FocusMixin = <T extends Constructor<HTMLElement>>(Base: T) =>
-  class extends Base {
+const FocusMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    focus(): void;
+  };
+} & T => {
+  return class extends Base {
     /**
      * Focuses on the first focusable element in the shadow DOM.
      */
@@ -32,6 +39,8 @@ const FocusMixin = <T extends Constructor<HTMLElement>>(Base: T) =>
         }
       }
     }
-  };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+};
 
 export default FocusMixin;

--- a/packages/web-components/src/globals/mixins/form.ts
+++ b/packages/web-components/src/globals/mixins/form.ts
@@ -12,7 +12,17 @@ import Handle from '../internal/handle';
  * @param Base The base class.
  * @returns A mix-in to handle `formdata` event on the containing form.
  */
-const FormMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+const FormMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    _hFormdata: Handle | null;
+    _handleFormdata(event: Event): void;
+    connectedCallback(): void;
+    disconnectedCallback(): void;
+  };
+} & T => {
   /**
    * A mix-in class to handle `formdata` event on the containing form.
    */
@@ -50,7 +60,8 @@ const FormMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       super.disconnectedCallback();
     }
   }
-  return FormMixinImpl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return FormMixinImpl as any;
 };
 
 export default FormMixin;

--- a/packages/web-components/src/globals/mixins/host-listener.ts
+++ b/packages/web-components/src/globals/mixins/host-listener.ts
@@ -18,7 +18,23 @@ const EVENT_NAME_FORMAT =
  * @param Base The base class.
  * @returns A mix-in that sets up and cleans up event listeners defined by `@HostListener` decorator.
  */
-const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+const HostListenerMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    _handles: Set<Handle>;
+    connectedCallback(): void;
+    disconnectedCallback(): void;
+  };
+  _hostListeners: {
+    [listenerName: string]: {
+      [type: string]: {
+        options?: boolean | AddEventListenerOptions;
+      };
+    };
+  };
+} & T => {
   /**
    * A mix-in class that sets up and cleans up event listeners defined by `@HostListener` decorator.
    */
@@ -90,7 +106,8 @@ const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
     } = {}; // Not using TypeScript `private` due to: microsoft/TypeScript#17744
   }
 
-  return HostListenerMixinImpl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return HostListenerMixinImpl as any;
 };
 
 export default HostListenerMixin;

--- a/packages/web-components/src/globals/mixins/validity.ts
+++ b/packages/web-components/src/globals/mixins/validity.ts
@@ -24,7 +24,22 @@ export enum VALIDATION_STATUS {
  * @param Base The base class.
  * @returns A mix-in implementing `.setCustomValidity()` method.
  */
-const ValidityMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+const ValidityMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    _getValidityMessage(state: string): string | undefined;
+    _testValidity(): string;
+    invalid: boolean;
+    required: boolean;
+    requiredValidityMessage: string;
+    validityMessage: string;
+    value: string;
+    checkValidity(): boolean;
+    setCustomValidity(validityMessage: string): void;
+  };
+} & T => {
   abstract class ValidityMixinImpl extends Base {
     // Not using TypeScript `protected` due to: microsoft/TypeScript#17744
     // Using `string` instead of `VALIDATION_STATUS` until we can require TypeScript 3.8
@@ -118,7 +133,8 @@ const ValidityMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       this.validityMessage = validityMessage;
     }
   }
-  return ValidityMixinImpl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ValidityMixinImpl as any;
 };
 
 export default ValidityMixin;

--- a/packages/web-components/tasks/build.js
+++ b/packages/web-components/tasks/build.js
@@ -11,14 +11,16 @@ import { fileURLToPath } from 'url';
 import { globby } from 'globby';
 import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
+import fs from 'fs-extra';
 import litSCSS from '../tools/lit-scss-plugin.js';
 import path from 'path';
 import postcss from 'postcss';
-import fs from 'fs-extra';
+import ts from 'typescript';
 
 import * as packageJson from '../package.json' with { type: 'json' };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
 
 const banner = `/**
  * Copyright IBM Corp. 2026
@@ -30,7 +32,6 @@ const banner = `/**
 
 async function build() {
   const { build: tsdown } = await import('tsdown');
-  const packageRoot = path.resolve(__dirname, '..');
   const tsconfigPath = path.resolve(packageRoot, 'tsconfig.json');
   const external = getExternalPatterns();
 
@@ -68,7 +69,11 @@ async function build() {
     await tsdown({
       banner,
       clean: false,
-      dts: true,
+      // use tsc for declaration emit instead of tsdown's dts plugin.
+      // tsdown/rolldown-plugin-dts does not correctly handle mixin patterns
+      // (e.g. HostListenerMixin) — it strips the generic base class type,
+      // breaking downstream consumers
+      dts: false,
       entry: format.inputs.map((input) => path.resolve(packageRoot, input)),
       external,
       failOnWarn: false,
@@ -110,6 +115,7 @@ async function build() {
   }
 
   await copyScssSources();
+  await generateDeclarations();
   await postBuild();
 }
 
@@ -120,8 +126,8 @@ function withInputCompatibilityAndPlugins(inputOptions) {
     ...(options.plugins || []),
     litSCSS({
       includePaths: [
-        path.resolve(__dirname, '../node_modules'),
-        path.resolve(__dirname, '../../../node_modules'),
+        path.resolve(packageRoot, './node_modules'),
+        path.resolve(packageRoot, '../../node_modules'),
       ],
       async preprocessor(contents, id) {
         return (
@@ -155,32 +161,31 @@ async function copyScssSources() {
     files.map(async (file) => {
       const relative = path.relative('src/components', file);
       const destination = path.resolve(
-        __dirname,
-        '..',
+        packageRoot,
         'scss',
         'components',
         relative
       );
       await fs.ensureDir(path.dirname(destination));
-      await fs.copyFile(path.resolve(__dirname, '..', file), destination);
+      await fs.copyFile(path.resolve(packageRoot, file), destination);
     })
   );
 }
 
 // TODO: remove and add scoped elements!
 async function postBuild() {
-  const sourceDir = path.resolve(__dirname, '../es');
+  const sourceDir = path.resolve(packageRoot, 'es');
 
   if (sourceDir) {
-    const targetDir = path.resolve(__dirname, '../es-custom');
+    const targetDir = path.resolve(packageRoot, 'es-custom');
 
-    // Copy `es` directory to `es-custom`
+    // copy `es` directory to `es-custom`
     await fs.copy(sourceDir, targetDir);
 
-    // Find all files in the `es-custom` directory
+    // find all files in the `es-custom` directory
     const files = await globby([`${targetDir}/**/*`], { onlyFiles: true });
 
-    // Replace "cds" with "cds-custom" in all files
+    // replace "cds" with "cds-custom" in all files
     await Promise.all(
       files.map(async (file) => {
         const content = await fs.promises.readFile(file, 'utf8');
@@ -191,7 +196,99 @@ async function postBuild() {
   }
 }
 
+async function generateDeclarations() {
+  const declarationTsconfigPath = path.resolve(
+    packageRoot,
+    'tsconfig.declarations.json'
+  );
+
+  await emitDeclarations(declarationTsconfigPath, path.join(packageRoot, 'es'));
+
+  await copyDeclarations(
+    path.join(packageRoot, 'es'),
+    path.join(packageRoot, 'lib')
+  );
+}
+
+async function emitDeclarations(tsconfigPath, outDir) {
+  const sourceRoot = path.resolve(packageRoot, 'src');
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+
+  if (configFile.error) {
+    throw new Error(formatDiagnostics([configFile.error]));
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(tsconfigPath),
+    {
+      declaration: true,
+      declarationMap: true,
+      emitDeclarationOnly: true,
+      inlineSources: false,
+      noEmit: false,
+      noEmitOnError: false,
+      outDir,
+      rootDir: sourceRoot,
+      sourceMap: false,
+    },
+    tsconfigPath
+  );
+
+  const rootNames = parsed.fileNames;
+  const program = ts.createProgram({
+    options: parsed.options,
+    rootNames,
+  });
+  const emitResult = program.emit();
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
+
+  if (emitResult.emitSkipped) {
+    throw new Error(formatDiagnostics(diagnostics));
+  }
+
+  if (diagnostics.length > 0) {
+    console.warn(formatDiagnostics(diagnostics));
+  }
+}
+
+async function copyDeclarations(fromDir, toDir) {
+  const entries = await fs.readdir(fromDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fromPath = path.join(fromDir, entry.name);
+    const toPath = path.join(toDir, entry.name);
+
+    if (entry.isDirectory()) {
+      await fs.ensureDir(toPath);
+      await copyDeclarations(fromPath, toPath);
+      continue;
+    }
+
+    if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.d.ts.map')) {
+      await fs.copy(fromPath, toPath);
+    }
+  }
+}
+
+function formatDiagnostics(diagnostics) {
+  return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName(filepath) {
+      return filepath;
+    },
+    getCurrentDirectory() {
+      return process.cwd();
+    },
+    getNewLine() {
+      return '\n';
+    },
+  });
+}
+
 build().catch((error) => {
-  console.log(error);
+  console.error(error);
   process.exit(1);
 });

--- a/packages/web-components/tsconfig.declarations.json
+++ b/packages/web-components/tsconfig.declarations.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.stories.ts",
+    "src/globals/internal/storybook-cdn.ts",
+    "src/polyfills/**",
+    "tests/**",
+    ".storybook/**"
+  ]
+}

--- a/www/package.json
+++ b/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "www",
   "private": true,
-  "version": "0.113.0",
+  "version": "0.113.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.104.0",
+    "@carbon/react": "^1.104.1",
     "@octokit/core": "^7.0.3",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,7 +1755,7 @@ __metadata:
     "@carbon/cli": "npm:^11.42.0"
     "@carbon/colors": "npm:^11.49.0"
     "@carbon/grid": "npm:^11.52.0"
-    "@carbon/icons": "npm:^11.77.0"
+    "@carbon/icons": "npm:^11.77.1"
     "@carbon/layout": "npm:^11.50.0"
     "@carbon/motion": "npm:^11.43.0"
     "@carbon/themes": "npm:^11.70.0"
@@ -1798,7 +1798,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icon-build-helpers@npm:^1.55.0, @carbon/icon-build-helpers@workspace:packages/icon-build-helpers":
+"@carbon/icon-build-helpers@npm:^1.55.1, @carbon/icon-build-helpers@workspace:packages/icon-build-helpers":
   version: 0.0.0-use.local
   resolution: "@carbon/icon-build-helpers@workspace:packages/icon-build-helpers"
   dependencies:
@@ -1842,13 +1842,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icons-react@npm:^11.77.0, @carbon/icons-react@workspace:packages/icons-react":
+"@carbon/icons-react@npm:^11.77.1, @carbon/icons-react@workspace:packages/icons-react":
   version: 0.0.0-use.local
   resolution: "@carbon/icons-react@workspace:packages/icons-react"
   dependencies:
-    "@carbon/icon-build-helpers": "npm:^1.55.0"
+    "@carbon/icon-build-helpers": "npm:^1.55.1"
     "@carbon/icon-helpers": "npm:^10.74.0"
-    "@carbon/icons": "npm:^11.77.0"
+    "@carbon/icons": "npm:^11.77.1"
     "@ibm/telemetry-js": "npm:^1.5.0"
     prop-types: "npm:^15.8.1"
     rimraf: "npm:^6.0.1"
@@ -1862,19 +1862,19 @@ __metadata:
   resolution: "@carbon/icons-vue@workspace:packages/icons-vue"
   dependencies:
     "@carbon/icon-helpers": "npm:^10.74.0"
-    "@carbon/icons": "npm:^11.77.0"
+    "@carbon/icons": "npm:^11.77.1"
     "@ibm/telemetry-js": "npm:^1.5.0"
     rimraf: "npm:^6.0.1"
     vue: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
-"@carbon/icons@npm:^11.77.0, @carbon/icons@workspace:packages/icons":
+"@carbon/icons@npm:^11.77.1, @carbon/icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@carbon/icons@workspace:packages/icons"
   dependencies:
     "@carbon/cli": "npm:^11.42.0"
-    "@carbon/icon-build-helpers": "npm:^1.55.0"
+    "@carbon/icon-build-helpers": "npm:^1.55.1"
     "@ibm/telemetry-js": "npm:^1.5.0"
     rimraf: "npm:^6.0.1"
   languageName: unknown
@@ -1908,9 +1908,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/pictograms-react@workspace:packages/pictograms-react"
   dependencies:
-    "@carbon/icon-build-helpers": "npm:^1.55.0"
+    "@carbon/icon-build-helpers": "npm:^1.55.1"
     "@carbon/icon-helpers": "npm:^10.74.0"
-    "@carbon/pictograms": "npm:^12.72.0"
+    "@carbon/pictograms": "npm:^12.72.1"
     "@ibm/telemetry-js": "npm:^1.5.0"
     prop-types: "npm:^15.8.1"
     rimraf: "npm:^6.0.1"
@@ -1919,17 +1919,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/pictograms@npm:^12.72.0, @carbon/pictograms@workspace:packages/pictograms":
+"@carbon/pictograms@npm:^12.72.1, @carbon/pictograms@workspace:packages/pictograms":
   version: 0.0.0-use.local
   resolution: "@carbon/pictograms@workspace:packages/pictograms"
   dependencies:
-    "@carbon/icon-build-helpers": "npm:^1.55.0"
+    "@carbon/icon-build-helpers": "npm:^1.55.1"
     "@ibm/telemetry-js": "npm:^1.5.0"
     rimraf: "npm:^6.0.1"
   languageName: unknown
   linkType: soft
 
-"@carbon/react@npm:^1.104.0, @carbon/react@workspace:packages/react":
+"@carbon/react@npm:^1.104.1, @carbon/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@carbon/react@workspace:packages/react"
   dependencies:
@@ -1943,7 +1943,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.27.1"
     "@babel/runtime": "npm:^7.27.3"
     "@carbon/feature-flags": "npm:^1.2.0"
-    "@carbon/icons-react": "npm:^11.77.0"
+    "@carbon/icons-react": "npm:^11.77.1"
     "@carbon/layout": "npm:^11.50.0"
     "@carbon/styles": "npm:^1.103.0"
     "@carbon/test-utils": "npm:^10.40.0"
@@ -2156,7 +2156,7 @@ __metadata:
   resolution: "@carbon/web-components@workspace:packages/web-components"
   dependencies:
     "@carbon/icon-helpers": "npm:10.47.0"
-    "@carbon/icons": "npm:^11.77.0"
+    "@carbon/icons": "npm:^11.77.1"
     "@carbon/layout": "npm:^11.50.0"
     "@carbon/motion": "npm:^11.43.0"
     "@carbon/styles": "npm:^1.103.0"
@@ -8976,7 +8976,7 @@ __metadata:
     "@babel/plugin-transform-react-constant-elements": "npm:^7.27.1"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/preset-react": "npm:^7.27.1"
-    "@carbon/react": "npm:^1.104.0"
+    "@carbon/react": "npm:^1.104.1"
     "@carbon/styles": "npm:^1.103.0"
     "@carbon/test-utils": "npm:^10.40.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
@@ -24372,7 +24372,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "www@workspace:www"
   dependencies:
-    "@carbon/react": "npm:^1.104.0"
+    "@carbon/react": "npm:^1.104.1"
     "@octokit/core": "npm:^7.0.3"
     "@octokit/plugin-retry": "npm:^3.0.9"
     "@octokit/plugin-throttling": "npm:^4.0.0"


### PR DESCRIPTION
Closes 
#21896
#21900

Fixes several regressions introduced when migrating from Rollup to tsdown, affecting both the React and web components packages.

### Changelog

**New**

- add `chunkFilenames` to `@carbon/icon-build-helpers` build file to output correct extension (`.js`) (fb9f111c6874ebe22d17e18302323cd6fe271145)

**Changed**

- update web component mixins to return correct type annotations (6c978436efeac9410581a8d6ae92c3914e7776a9)
- update web components build to use `tsc` declarations rather than tsdown's `dts` plugin (6c978436efeac9410581a8d6ae92c3914e7776a9)
- update React build regex to match `$`-suffixed variable names (`require_index$12`) generated by Rolldown for post-build ineterpo (`patchCjsDefaultInterop`) (126248d073a36172677746f21c236d93cfd7b9db)

#### Testing / Reviewing

Issue reporters tested against the RC versions and confirmed the fixes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
