### PR TITLE
fix(tsdown): mixin declaration regressions and CJS interop 

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next.js
+++ b/packages/icon-build-helpers/src/builders/react/next.js
@@ -207,6 +207,10 @@ async function builder(metadata, { output }) {
         return {
           ...options,
           banner: templates.banner,
+          // use .js extension for both entries and chunks so that
+          // CJS chunks (e.g. rolldown runtime helpers) don't get a
+          // .cjs extension which breaks Jest moduleFileExtensions
+          chunkFileNames: '[name]-[hash].js',
           entryFileNames: '[name]',
           exports: 'auto',
         };

--- a/packages/react/tasks/build.js
+++ b/packages/react/tasks/build.js
@@ -295,7 +295,7 @@ async function patchCjsDefaultInterop(filepath) {
   // makes React components import as module objects in downstream CJS tests.
   // Normalize to `default || module` so consumers receive the component value.
   const updated = contents.replace(
-    /^exports\.(\w+)\s*=\s*(require_\w+);$/gm,
+    /^exports\.(\w+)\s*=\s*(require_[\w$]+);$/gm,
     'exports.$1 = $2.default || $2;'
   );
 

--- a/packages/web-components/src/globals/mixins/focus.ts
+++ b/packages/web-components/src/globals/mixins/focus.ts
@@ -11,8 +11,15 @@ import { selectorTabbable } from '../settings';
  * @param Base The base class.
  * @returns A mix-in implementing `.focus()` method that focuses on the first focusable element in the shadow DOM.
  */
-const FocusMixin = <T extends Constructor<HTMLElement>>(Base: T) =>
-  class extends Base {
+const FocusMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    focus(): void;
+  };
+} & T => {
+  return class extends Base {
     /**
      * Focuses on the first focusable element in the shadow DOM.
      */
@@ -32,6 +39,8 @@ const FocusMixin = <T extends Constructor<HTMLElement>>(Base: T) =>
         }
       }
     }
-  };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+};
 
 export default FocusMixin;

--- a/packages/web-components/src/globals/mixins/form.ts
+++ b/packages/web-components/src/globals/mixins/form.ts
@@ -12,7 +12,17 @@ import Handle from '../internal/handle';
  * @param Base The base class.
  * @returns A mix-in to handle `formdata` event on the containing form.
  */
-const FormMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+const FormMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    _hFormdata: Handle | null;
+    _handleFormdata(event: Event): void;
+    connectedCallback(): void;
+    disconnectedCallback(): void;
+  };
+} & T => {
   /**
    * A mix-in class to handle `formdata` event on the containing form.
    */
@@ -50,7 +60,8 @@ const FormMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       super.disconnectedCallback();
     }
   }
-  return FormMixinImpl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return FormMixinImpl as any;
 };
 
 export default FormMixin;

--- a/packages/web-components/src/globals/mixins/host-listener.ts
+++ b/packages/web-components/src/globals/mixins/host-listener.ts
@@ -18,7 +18,23 @@ const EVENT_NAME_FORMAT =
  * @param Base The base class.
  * @returns A mix-in that sets up and cleans up event listeners defined by `@HostListener` decorator.
  */
-const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+const HostListenerMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    _handles: Set<Handle>;
+    connectedCallback(): void;
+    disconnectedCallback(): void;
+  };
+  _hostListeners: {
+    [listenerName: string]: {
+      [type: string]: {
+        options?: boolean | AddEventListenerOptions;
+      };
+    };
+  };
+} & T => {
   /**
    * A mix-in class that sets up and cleans up event listeners defined by `@HostListener` decorator.
    */
@@ -90,7 +106,8 @@ const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
     } = {}; // Not using TypeScript `private` due to: microsoft/TypeScript#17744
   }
 
-  return HostListenerMixinImpl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return HostListenerMixinImpl as any;
 };
 
 export default HostListenerMixin;

--- a/packages/web-components/src/globals/mixins/validity.ts
+++ b/packages/web-components/src/globals/mixins/validity.ts
@@ -24,7 +24,22 @@ export enum VALIDATION_STATUS {
  * @param Base The base class.
  * @returns A mix-in implementing `.setCustomValidity()` method.
  */
-const ValidityMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+const ValidityMixin = <T extends Constructor<HTMLElement>>(
+  Base: T
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): {
+    _getValidityMessage(state: string): string | undefined;
+    _testValidity(): string;
+    invalid: boolean;
+    required: boolean;
+    requiredValidityMessage: string;
+    validityMessage: string;
+    value: string;
+    checkValidity(): boolean;
+    setCustomValidity(validityMessage: string): void;
+  };
+} & T => {
   abstract class ValidityMixinImpl extends Base {
     // Not using TypeScript `protected` due to: microsoft/TypeScript#17744
     // Using `string` instead of `VALIDATION_STATUS` until we can require TypeScript 3.8
@@ -118,7 +133,8 @@ const ValidityMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       this.validityMessage = validityMessage;
     }
   }
-  return ValidityMixinImpl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ValidityMixinImpl as any;
 };
 
 export default ValidityMixin;

--- a/packages/web-components/tasks/build.js
+++ b/packages/web-components/tasks/build.js
@@ -11,14 +11,16 @@ import { fileURLToPath } from 'url';
 import { globby } from 'globby';
 import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
+import fs from 'fs-extra';
 import litSCSS from '../tools/lit-scss-plugin.js';
 import path from 'path';
 import postcss from 'postcss';
-import fs from 'fs-extra';
+import ts from 'typescript';
 
 import * as packageJson from '../package.json' with { type: 'json' };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
 
 const banner = `/**
  * Copyright IBM Corp. 2026
@@ -30,7 +32,6 @@ const banner = `/**
 
 async function build() {
   const { build: tsdown } = await import('tsdown');
-  const packageRoot = path.resolve(__dirname, '..');
   const tsconfigPath = path.resolve(packageRoot, 'tsconfig.json');
   const external = getExternalPatterns();
 
@@ -68,7 +69,11 @@ async function build() {
     await tsdown({
       banner,
       clean: false,
-      dts: true,
+      // use tsc for declaration emit instead of tsdown's dts plugin.
+      // tsdown/rolldown-plugin-dts does not correctly handle mixin patterns
+      // (e.g. HostListenerMixin) — it strips the generic base class type,
+      // breaking downstream consumers
+      dts: false,
       entry: format.inputs.map((input) => path.resolve(packageRoot, input)),
       external,
       failOnWarn: false,
@@ -110,6 +115,7 @@ async function build() {
   }
 
   await copyScssSources();
+  await generateDeclarations();
   await postBuild();
 }
 
@@ -120,8 +126,8 @@ function withInputCompatibilityAndPlugins(inputOptions) {
     ...(options.plugins || []),
     litSCSS({
       includePaths: [
-        path.resolve(__dirname, '../node_modules'),
-        path.resolve(__dirname, '../../../node_modules'),
+        path.resolve(packageRoot, './node_modules'),
+        path.resolve(packageRoot, '../../node_modules'),
       ],
       async preprocessor(contents, id) {
         return (
@@ -155,32 +161,31 @@ async function copyScssSources() {
     files.map(async (file) => {
       const relative = path.relative('src/components', file);
       const destination = path.resolve(
-        __dirname,
-        '..',
+        packageRoot,
         'scss',
         'components',
         relative
       );
       await fs.ensureDir(path.dirname(destination));
-      await fs.copyFile(path.resolve(__dirname, '..', file), destination);
+      await fs.copyFile(path.resolve(packageRoot, file), destination);
     })
   );
 }
 
 // TODO: remove and add scoped elements!
 async function postBuild() {
-  const sourceDir = path.resolve(__dirname, '../es');
+  const sourceDir = path.resolve(packageRoot, 'es');
 
   if (sourceDir) {
-    const targetDir = path.resolve(__dirname, '../es-custom');
+    const targetDir = path.resolve(packageRoot, 'es-custom');
 
-    // Copy `es` directory to `es-custom`
+    // copy `es` directory to `es-custom`
     await fs.copy(sourceDir, targetDir);
 
-    // Find all files in the `es-custom` directory
+    // find all files in the `es-custom` directory
     const files = await globby([`${targetDir}/**/*`], { onlyFiles: true });
 
-    // Replace "cds" with "cds-custom" in all files
+    // replace "cds" with "cds-custom" in all files
     await Promise.all(
       files.map(async (file) => {
         const content = await fs.promises.readFile(file, 'utf8');
@@ -191,7 +196,99 @@ async function postBuild() {
   }
 }
 
+async function generateDeclarations() {
+  const declarationTsconfigPath = path.resolve(
+    packageRoot,
+    'tsconfig.declarations.json'
+  );
+
+  await emitDeclarations(declarationTsconfigPath, path.join(packageRoot, 'es'));
+
+  await copyDeclarations(
+    path.join(packageRoot, 'es'),
+    path.join(packageRoot, 'lib')
+  );
+}
+
+async function emitDeclarations(tsconfigPath, outDir) {
+  const sourceRoot = path.resolve(packageRoot, 'src');
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+
+  if (configFile.error) {
+    throw new Error(formatDiagnostics([configFile.error]));
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(tsconfigPath),
+    {
+      declaration: true,
+      declarationMap: true,
+      emitDeclarationOnly: true,
+      inlineSources: false,
+      noEmit: false,
+      noEmitOnError: false,
+      outDir,
+      rootDir: sourceRoot,
+      sourceMap: false,
+    },
+    tsconfigPath
+  );
+
+  const rootNames = parsed.fileNames;
+  const program = ts.createProgram({
+    options: parsed.options,
+    rootNames,
+  });
+  const emitResult = program.emit();
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
+
+  if (emitResult.emitSkipped) {
+    throw new Error(formatDiagnostics(diagnostics));
+  }
+
+  if (diagnostics.length > 0) {
+    console.warn(formatDiagnostics(diagnostics));
+  }
+}
+
+async function copyDeclarations(fromDir, toDir) {
+  const entries = await fs.readdir(fromDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fromPath = path.join(fromDir, entry.name);
+    const toPath = path.join(toDir, entry.name);
+
+    if (entry.isDirectory()) {
+      await fs.ensureDir(toPath);
+      await copyDeclarations(fromPath, toPath);
+      continue;
+    }
+
+    if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.d.ts.map')) {
+      await fs.copy(fromPath, toPath);
+    }
+  }
+}
+
+function formatDiagnostics(diagnostics) {
+  return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName(filepath) {
+      return filepath;
+    },
+    getCurrentDirectory() {
+      return process.cwd();
+    },
+    getNewLine() {
+      return '\n';
+    },
+  });
+}
+
 build().catch((error) => {
-  console.log(error);
+  console.error(error);
   process.exit(1);
 });

--- a/packages/web-components/tsconfig.declarations.json
+++ b/packages/web-components/tsconfig.declarations.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.stories.ts",
+    "src/globals/internal/storybook-cdn.ts",
+    "src/polyfills/**",
+    "tests/**",
+    ".storybook/**"
+  ]
+}


### PR DESCRIPTION
Closes 
#21896
#21900

Fixes regressions introduced when migrating from Rollup to tsdown for build pipeline. Affects both the React and web components packages.

### Changelog

**New**

- add `chunkFilenames` to `@carbon/icon-build-helpers` build file to output correct extension (`.js`)

**Changed**

- update web component mixins to return correct type annotations 
- update web components build to use `tsc` declarations rather than tsdown's `dts` plugin 
- update React build regex to match `$`-suffixed variable names (`require_index$12`) generated by Rolldown for post-build ineterpo (`patchCjsDefaultInterop`)

#### Testing / Reviewing

1. install `@carbon/web-components@latest` - project should build with no errors
2. Jest/Mocha tests that import `@carbon/react` should no longer throw the following errors
```bash
TypeError: require_chunk.__toESM is not a function

Element type is invalid: expected a string... but got: object
```

Issue reporters tested against the RC releases and confirmed the fixes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
