### PR TITLE
fix(unordered-list): avoid nested list item style to be emoji

### DIFF
--- a/packages/styles/scss/components/list/_list.scss
+++ b/packages/styles/scss/components/list/_list.scss
@@ -91,7 +91,7 @@
   .#{$prefix}--list--unordered.#{$prefix}--list--nested
     > .#{$prefix}--list__item::before {
     // ▪ square
-    content: '\0025AA';
+    content: '\0025AA\00FE0E';
     // offset to account for smaller ▪ vs –
     inset-inline-start: calc(-1 * #{$spacing-04});
   }


### PR DESCRIPTION
On mobile Safari (tested on iOS 26.4), nested list items in unordered lists are preceded by a black square emoji instead of the monochrome text variant.

### Changelog

**Changed**

- Added the unicode VS15 (`U+FE0E`) variant selector code to the unordered list's `::before` pseudo element

#### Testing / Reviewing

- Visit PR storybook preview on mobile and compare to production storybook

| Production storybook | PR storybook preview |
| :- | :- |
| <img width="603" height="1311" alt="Screenshot 2026-03-30 at 17 37 23" src="https://github.com/user-attachments/assets/3ad0ac74-0008-4a54-a0cc-f24d909d3bc3" /> | <img width="603" height="1311" alt="Screenshot 2026-03-30 at 17 38 44" src="https://github.com/user-attachments/assets/bf2f4cdb-0633-4503-9ed7-65ab90313969" /> |

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass