### PR TITLE
chore(project): initial Bob configs

### DIFF
--- a/.bob/README.md
+++ b/.bob/README.md
@@ -1,0 +1,53 @@
+# Carbon Bob Workspace
+
+This workspace config gives Bob a repo-specific starting point without replacing
+the existing Carbon docs.
+
+## What is configured
+
+- `.bobignore` excludes noisy artifacts and generated output
+- `.bob/rules/` sets shared repo behavior and review standards
+- `.bob/rules-code/` adds implementation-specific coding guidance
+- `.bob/rules-plan/` keeps planning narrow in this monorepo
+- `.bob/skills/` adds focused workflows for PR review and PR preparation
+- `.bob/commands/` adds reusable project commands
+
+## Maintainer usage
+
+Start with [`maintainer-workflows.md`](./maintainer-workflows.md).
+
+Use the project commands when they match the task:
+
+- `/review-carbon` to review a local diff, branch, or issue-aligned change
+- `/prepare-pr` to draft a PR title and body from the current diff
+- `/plan-package <path-or-package>` to force package-scoped planning in this
+  monorepo
+
+The project skills are intended to trigger automatically when the task matches,
+but maintainers can also mention them by name in the prompt:
+
+- `carbon-pr-review`
+- `carbon-pr-prep`
+
+## Recommended local Bob settings
+
+These are Bob IDE settings, not repo-tracked config:
+
+- Review exclusions: exclude the same artifact patterns as `.bobignore`
+- Large-project discipline: prefer explicit file and folder mentions over broad
+  repo context
+- Auto-approve: keep `read` low-friction only if trusted; keep `write`,
+  `browser`, and `command` conservative
+- Reviews: use issue coverage when reviewing work against a GitHub issue or spec
+
+## Source of truth
+
+Use the repo docs for policy and conventions:
+
+- `docs/guides/reviewing-pull-requests.md`
+- `docs/style.md`
+- `docs/developer-handbook.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `docs/feature-flags.md`
+- `docs/preview-code.md`
+- `docs/experimental-code.md`

--- a/.bob/commands/plan-package.md
+++ b/.bob/commands/plan-package.md
@@ -1,0 +1,21 @@
+---
+description: Create a narrow implementation plan for a Carbon package or path
+argument-hint: <path-or-package>
+---
+
+Create a plan for work in this monorepo, scoped as narrowly as possible.
+
+Focus on `$1`.
+
+If `$1` is a package name, path, component directory, workflow file, or docs
+path, use that as the primary context surface.
+
+Planning requirements:
+
+- identify the affected package or workspace first
+- read the nearest relevant `AGENTS.md` and repo docs before broadening scope
+- avoid repo-wide scans unless the task clearly crosses package boundaries
+- call out React and web-components parity impacts when relevant
+- propose package-scoped commands, tests, and verification steps first
+
+Return a concise implementation plan with assumptions and verification steps.

--- a/.bob/commands/prepare-pr.md
+++ b/.bob/commands/prepare-pr.md
@@ -1,0 +1,20 @@
+---
+description: Draft a Carbon PR title and body that matches the repo template
+---
+
+Prepare a pull request title and body for this repository using the
+`carbon-pr-prep` skill.
+
+Requirements:
+
+- follow `.github/PULL_REQUEST_TEMPLATE.md`
+- use the actual diff only
+- keep the short description concise and specific
+- write a concrete `Testing / Reviewing` section
+- flag missing changelog or validation details instead of guessing
+- leave unverifiable author checklist items explicit for the author
+
+Output:
+
+- a proposed PR title
+- a complete PR body ready for the author to edit

--- a/.bob/commands/review-carbon.md
+++ b/.bob/commands/review-carbon.md
@@ -1,0 +1,27 @@
+---
+description:
+  Review Carbon changes with repo-specific standards and blocker follow-up nit
+  findings
+argument-hint: <branch-or-issue>
+---
+
+Review the current Carbon changes using the `carbon-pr-review` skill and the
+repo guidance in `docs/guides/reviewing-pull-requests.md`.
+
+If `$1` is empty, review the local uncommitted diff.
+
+If `$1` looks like a branch name, review that branch diff.
+
+If `$1` looks like `#1234` or a GitHub issue URL, run an issue-coverage review
+instead of a generic code-quality review. In that case:
+
+- validate whether the change addresses the issue
+- call out missing acceptance criteria coverage
+- separate issue mismatch from normal code review comments
+
+Always:
+
+- classify findings as `Blocker`, `Follow-up`, or `Nit`
+- optimize for net-positive merge decisions rather than perfection
+- cite relevant Carbon docs when a finding depends on repo policy
+- put findings first, then open questions, then a short summary

--- a/.bob/maintainer-workflows.md
+++ b/.bob/maintainer-workflows.md
@@ -1,0 +1,176 @@
+# Carbon Bob Maintainer Workflows
+
+This document explains how maintainers should use the repo's Bob config.
+
+## Quick start
+
+- Open Bob from the repository root when possible so the workspace rules apply.
+- Start narrow. In this monorepo, mention the package, component, workflow, or
+  doc path you care about.
+- Prefer the project commands for repeatable workflows.
+- Let the repo docs stay authoritative. The Bob config is a shortcut, not a
+  replacement for Carbon policy.
+
+## What Bob has in this repo
+
+- `.bobignore` keeps Bob out of artifact-heavy and generated directories.
+- `.bob/rules/` gives Bob Carbon-wide repo and review guidance.
+- `.bob/rules-code/` adds implementation conventions for coding work.
+- `.bob/rules-plan/` keeps plans scoped to the relevant package or path.
+- `.bob/skills/` adds reusable maintainer workflows.
+- `.bob/commands/` provides slash commands for the most common tasks.
+
+## Recommended workflows
+
+### Review a PR or local diff
+
+Use:
+
+- `/review-carbon`
+- `/review-carbon <branch-name>`
+- `/review-carbon #1234`
+- `/review-carbon https://github.com/carbon-design-system/carbon/issues/1234`
+
+What this does:
+
+- applies the `carbon-pr-review` skill
+- uses the Carbon PR review guide
+- classifies findings as `Blocker`, `Follow-up`, or `Nit`
+- pushes Bob toward net-positive merge decisions instead of perfection reviews
+
+When to use issue coverage:
+
+- when the work is tied to a GitHub issue or written acceptance criteria
+- when you want Bob to check scope alignment, not just code quality
+
+### Prepare a pull request
+
+Use:
+
+- `/prepare-pr`
+
+What this does:
+
+- applies the `carbon-pr-prep` skill
+- follows `.github/PULL_REQUEST_TEMPLATE.md`
+- drafts changelog and description sections from the actual diff
+- writes concrete `Testing / Reviewing` steps
+- leaves unresolved checklist items explicit instead of guessing
+
+Recommended maintainer follow-up:
+
+- confirm the changelog bullets are accurate
+- confirm the testing steps are enough for a second reviewer
+- keep author checklist items as human confirmations unless the diff proves them
+
+### Plan work in a specific package
+
+Use:
+
+- `/plan-package packages/react`
+- `/plan-package packages/web-components/src/components/button`
+- `/plan-package .github/workflows/pull-request-closed.yml`
+
+What this does:
+
+- keeps Bob scoped to the relevant package or file path
+- encourages use of the nearest `AGENTS.md`
+- reduces broad repo scanning and noisy context
+
+Use this before implementation when the task affects a narrow part of Carbon.
+
+## Skills
+
+### `carbon-pr-review`
+
+Use this skill for:
+
+- reviewing a local diff before pushing
+- reviewing a PR branch
+- checking whether a change actually solves its linked issue
+
+Behavior:
+
+- starts with scope and affected package detection
+- uses the review checklist by change type
+- uses the severity guide to keep findings calibrated
+- outputs findings first
+
+Maintainer prompt examples:
+
+- `Use carbon-pr-review to review the current diff in packages/react`
+- `Use carbon-pr-review and focus on whether this PR is net-positive and safe to merge`
+- `Use carbon-pr-review with issue coverage against #1234`
+
+### `carbon-pr-prep`
+
+Use this skill for:
+
+- drafting a new PR body from local commits or diff
+- tightening a vague PR description before review
+- filling in the template without fabricating missing validation
+
+Behavior:
+
+- preserves the repo's PR template structure
+- writes concrete reviewer instructions
+- flags unknowns for the author to confirm
+
+Maintainer prompt examples:
+
+- `Use carbon-pr-prep to draft a PR body for the current diff`
+- `Use carbon-pr-prep and focus the testing section on packages/styles`
+- `Use carbon-pr-prep to tighten this draft PR description`
+
+## Review philosophy
+
+The review standard in this repo is not "find every possible improvement."
+
+Use:
+
+- `Blocker` for merge-critical problems
+- `Follow-up` for worthwhile but non-blocking work
+- `Nit` for cosmetic or preference comments
+
+Do not block on:
+
+- optional refactors
+- speculative abstractions
+- taste-only preferences
+- cleanup that can land separately
+
+This keeps reviews aligned with a net-positive contribution model.
+
+## How to write effective prompts in this repo
+
+- Mention the package or file path early.
+- Mention the issue, PR, or acceptance criteria when they exist.
+- Say whether you want planning, review, implementation, or PR drafting.
+- Ask for file references when you want actionable review output.
+
+Examples:
+
+- `Review packages/react/src/components/Button against issue #1234`
+- `Plan the minimal change in packages/styles for this Sass regression`
+- `Draft a PR body for the current diff and keep the testing steps concrete`
+
+## When to fall back to repo docs
+
+Go to the repo docs directly when the answer depends on policy details:
+
+- `docs/guides/reviewing-pull-requests.md` for review expectations
+- `docs/style.md` for JS, React, Sass, and testing conventions
+- `docs/developer-handbook.md` for package and workflow conventions
+- `.github/PULL_REQUEST_TEMPLATE.md` for PR structure
+- `docs/feature-flags.md`, `docs/preview-code.md`, and
+  `docs/experimental-code.md` for staged or non-stable work
+
+## Local Bob settings maintainers should configure themselves
+
+These are recommendations, not repo-enforced settings:
+
+- exclude the same artifact-heavy paths from reviews that `.bobignore` excludes
+- keep auto-approve conservative, especially for write, browser, and command
+  actions
+- prefer issue coverage in reviews when work is tied to an issue or spec
+- keep prompts narrow in this monorepo to avoid low-signal context

--- a/.bob/rules-code/code-standards.md
+++ b/.bob/rules-code/code-standards.md
@@ -1,0 +1,22 @@
+# Carbon code-mode standards
+
+- Follow `docs/style.md` and `docs/developer-handbook.md`.
+- In JavaScript and TypeScript, prefer explicit code over terse implicit style
+  when both are reasonable.
+- For React work, prefer declarative patterns, refs over DOM queries, and avoid
+  unnecessary `useEffect` usage.
+- For Sass work, prefer current Sass module practices, design tokens, logical
+  properties, and existing Carbon style architecture.
+- Keep `@carbon/react` and `@carbon/web-components` behavior aligned when the
+  task spans both packages.
+- Respect preview, feature-flagged, and experimental code guidance in
+  `docs/preview-code.md`, `docs/feature-flags.md`, and
+  `docs/experimental-code.md`.
+- When public API snapshots, types, or props change, check versioning and
+  backwards-compatibility expectations.
+- When storybook or docs-facing APIs change, update the relevant `.mdx` or
+  Storybook documentation.
+- New behavior should include the tests needed for the affected layer: unit,
+  accessibility, visual regression, or workflow checks as appropriate.
+- For GitHub Actions changes, third-party actions must be pinned to a full
+  commit SHA.

--- a/.bob/rules-plan/planning-standards.md
+++ b/.bob/rules-plan/planning-standards.md
@@ -1,0 +1,14 @@
+# Carbon plan-mode standards
+
+- Identify the affected package, workspace, or doc surface before proposing
+  implementation steps.
+- Keep plans package-scoped by default; expand to multiple packages only when
+  the task genuinely crosses boundaries.
+- Cite the relevant repo docs or package guidance that materially constrain the
+  plan.
+- Call out cross-package parity impacts between React and web components when
+  relevant.
+- Avoid repo-wide scans and file inventories unless they are necessary to reduce
+  ambiguity.
+- Prefer command, test, and verification steps that target the changed package
+  or workflow.

--- a/.bob/rules/review-standards.md
+++ b/.bob/rules/review-standards.md
@@ -1,0 +1,17 @@
+# Carbon review standards
+
+- Reviews should optimize for net-positive contributions that are safe to merge,
+  not for theoretical perfection.
+- Classify findings as `Blocker`, `Follow-up`, or `Nit`.
+- `Blocker` means correctness regressions, accessibility regressions, public API
+  or versioning mistakes, CI/workflow security issues, issue mismatch, or
+  missing required tests or docs.
+- `Follow-up` means worthwhile improvements that are not required for safe
+  merge.
+- `Nit` means cosmetic, naming, wording, or local preference comments.
+- Do not block on optional refactors, speculative abstractions, or taste-based
+  preferences.
+- For PR and review work, follow `.github/PULL_REQUEST_TEMPLATE.md` and
+  `docs/guides/reviewing-pull-requests.md`.
+- If a change affects a documented Carbon convention, cite the relevant repo doc
+  instead of stating a free-form preference.

--- a/.bob/rules/workspace-standards.md
+++ b/.bob/rules/workspace-standards.md
@@ -1,0 +1,13 @@
+# Carbon workspace standards
+
+- Treat this repository as a large Yarn workspaces and Lerna monorepo.
+- Start from the narrowest relevant package, component, workflow, or doc.
+- Avoid broad repo scans unless the task truly spans multiple packages.
+- Use `.nvmrc` for the expected Node version.
+- Prefer package-scoped commands and package-scoped reasoning before top-level
+  commands.
+- Use repo docs as the source of truth instead of inventing new policy.
+- Preserve functional and visual parity expectations between `@carbon/react` and
+  `@carbon/web-components` when relevant, but do not force shared implementation
+  when framework-specific solutions are better.
+- Respect package-specific guidance in nested `AGENTS.md` files.

--- a/.bob/skills/carbon-pr-prep/SKILL.md
+++ b/.bob/skills/carbon-pr-prep/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: carbon-pr-prep
+description:
+  Prepare Carbon pull request titles and bodies that match the repo template,
+  include concrete testing and reviewing steps, and leave unresolved author
+  checklist items explicit instead of guessed.
+---
+
+Prepare a Carbon pull request description using the repository template and the
+actual diff.
+
+Use this skill when the task is to draft or improve a PR title or body.
+
+## Workflow
+
+<Steps>
+<Step>
+Read the current diff and identify the affected packages, docs, or workflows.
+</Step>
+
+<Step>
+Use `.github/PULL_REQUEST_TEMPLATE.md` as the required structure.
+
+- Preserve the existing section names and order.
+- Fill the changelog areas from the actual diff only. </Step>
+
+<Step>
+Write a concrete `Testing / Reviewing` section.
+
+- Include practical reviewer steps for the actual change.
+- Mention package-specific commands or Storybook/manual steps when relevant.
+- Do not leave generic placeholders. </Step>
+
+<Step>
+Handle uncertainty explicitly.
+
+- Do not invent issue links, changelog items, browser coverage, accessibility
+  validation, or checklist confirmations.
+- If information is missing, mark it as unresolved for the author to confirm.
+  </Step>
+
+<Step>
+Output a concise PR title and body.
+
+- Keep the title aligned with the change and existing commit/PR conventions.
+- Prefer a body that is easy for maintainers to review.
+- Use `checklist.md` to verify completeness before finalizing. </Step> </Steps>

--- a/.bob/skills/carbon-pr-prep/checklist.md
+++ b/.bob/skills/carbon-pr-prep/checklist.md
@@ -1,0 +1,10 @@
+# Carbon PR prep checklist
+
+- Use the exact section structure from `.github/PULL_REQUEST_TEMPLATE.md`.
+- Keep the short description factual and specific to the diff.
+- Put changelog bullets only in sections justified by the change.
+- Write concrete reviewer instructions in `Testing / Reviewing`.
+- Flag missing details instead of fabricating them.
+- Leave author checklist items for the author unless the diff proves them.
+- Reference relevant packages or docs when that helps reviewers validate the
+  change.

--- a/.bob/skills/carbon-pr-review/SKILL.md
+++ b/.bob/skills/carbon-pr-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: carbon-pr-review
+description:
+  Review Carbon pull requests and local diffs using repo-specific standards,
+  change-type checks, and a blocker follow-up nit rubric focused on net-positive
+  merge decisions.
+---
+
+Review Carbon changes using the repository's maintainer guidance.
+
+Use this skill when the task is to review a diff, a branch, or a change against
+an issue.
+
+## Workflow
+
+<Steps>
+<Step>
+Start with scope.
+
+- Identify the affected packages, docs, workflows, or public APIs.
+- Read the PR description, issue, or spec when provided.
+- Use narrow context first in this monorepo. </Step>
+
+<Step>
+Review using Carbon's existing guidance.
+
+- Use `docs/guides/reviewing-pull-requests.md` as the base review workflow.
+- Use the change-type checklist in `checklist.md`.
+- Use `severity-guide.md` to classify findings. </Step>
+
+<Step>
+Apply the net-positive review philosophy.
+
+- Block only on merge-critical problems.
+- Do not block on optional refactors, speculative abstractions, or taste-based
+  preferences.
+- If a comment is not a blocker, classify it as `Follow-up` or `Nit`. </Step>
+
+<Step>
+If the review is tied to an issue, validate issue coverage.
+
+- Check that the change addresses the stated problem.
+- Call out missing acceptance criteria or scope drift.
+- Distinguish issue mismatch from general quality comments. </Step>
+
+<Step>
+Produce findings first.
+
+- List `Blocker`, `Follow-up`, and `Nit` items with file references when
+  possible.
+- Keep each finding concrete: problem, impact, expected fix.
+- If there are no findings, say that explicitly and mention residual risk or
+  test gaps. </Step> </Steps>

--- a/.bob/skills/carbon-pr-review/checklist.md
+++ b/.bob/skills/carbon-pr-review/checklist.md
@@ -1,0 +1,44 @@
+# Carbon review checklist
+
+Use only the sections relevant to the diff.
+
+## Public API and versioning
+
+- Check public API snapshots and versioning expectations.
+- Treat narrowed prop or type changes as potential breaking changes.
+- Confirm docs and examples reflect API changes.
+
+## React
+
+- Check for avoidable `useEffect` usage and imperative DOM access.
+- Check SSR-sensitive behavior and event handling patterns.
+- Check visible strings, accessibility behavior, and test coverage.
+
+## Web components
+
+- Check component behavior, stories, docs, and tests.
+- Call out parity issues if the React implementation is materially different in
+  user-facing behavior.
+
+## Storybook and docs
+
+- Confirm args and controls still work.
+- Confirm `.mdx` and docs tables match changed APIs.
+- Remove temporary or test-only stories.
+
+## Testing
+
+- Check that the changed behavior is covered by the right test layer.
+- Prefer accessible queries in tests.
+- Note missing a11y or visual regression coverage when required.
+
+## Styles
+
+- Prefer tokens over magic numbers.
+- Use logical properties instead of left/right-specific properties.
+- Preserve expected prefixes and style module dependencies.
+
+## CI and workflows
+
+- Pin third-party GitHub Actions to full commit SHAs.
+- Treat workflow security or release regressions as blockers.

--- a/.bob/skills/carbon-pr-review/severity-guide.md
+++ b/.bob/skills/carbon-pr-review/severity-guide.md
@@ -1,0 +1,30 @@
+# Carbon review severity guide
+
+## Blocker
+
+Use for problems that should prevent merge:
+
+- Correctness regressions
+- Accessibility regressions
+- Public API or semver mistakes
+- CI, release, or workflow security issues
+- Missing required tests or docs for the change
+- Changes that do not satisfy the linked issue or spec
+
+## Follow-up
+
+Use for meaningful improvements that are not required before merge:
+
+- Maintainability improvements
+- Better test coverage beyond the minimum needed
+- Reasonable cleanup that can land separately
+- Documentation polish that is useful but not required for correctness
+
+## Nit
+
+Use for low-risk, non-blocking comments:
+
+- Naming preferences
+- Small wording suggestions
+- Tiny readability adjustments
+- Minor local consistency notes

--- a/.bobignore
+++ b/.bobignore
@@ -1,0 +1,16 @@
+node_modules/
+.nx/
+.playwright/
+coverage/
+blob-report/
+
+.eslintcache
+.stylelintcache
+junit.xml
+lerna-debug.log
+
+.yarn/cache/
+.yarn/unplugged/
+
+**/{es,lib,storybook,ts,umd}/
+


### PR DESCRIPTION
I steered and generated this PR to spur conversation around what a set of helpful config for Bob could look like.

- Would you find these skills useful?
- Does this approach to commands feel good or missing something?
- Did we miss anything in the bobignore?
- Is there a way to avoid duplicating our review/coding standards into these new .md files? We already have them elsewhere - AGENTS.md and various docs in `./docs/`
- Do you see any mistakes or areas where we can be more clear?

**Overall, how does this land with you and what other ideas do you have we could add or modify here?**

- A `.bob` repo for common org config be useful
  - Probably would have to clone this into .bob on your machine, then projects having .bob in the project.
    - Can these be hosted in .bob repo and then we `link` to that file to get the latest by curl-ing that (always stays updated, etc)
  - Project level config's are nice, update as you pull in latest from main
  - Start off as slim as possible, try it out, built it out from there
  - Feedback can be decentralized through PRs, we'll iterate
- could we expose reusable skills through propel?
- .bobignore-ing node_modules can be useful
  - it'll grep the libraries you've installed which can be helpful
- try using symlinks in .bob to the standard .agents/skills

<!--

Closes #

{{short description}}

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist -->

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

<!-- As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
-->