### PR TITLE
Fix date picker calendar sync when kind changes

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2161,6 +2161,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "SebayK",
+      "name": "Sebastian Kamiński",
+      "avatar_url": "https://avatars.githubusercontent.com/u/185592440?v=4",
+      "profile": "https://github.com/SebayK",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/suniltc-ibm"><img src="https://avatars.githubusercontent.com/u/186133269?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sunil TC</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=suniltc-ibm" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/baadhira"><img src="https://avatars.githubusercontent.com/u/69342013?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Badira P P</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=baadhira" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/harishjanardhanan"><img src="https://avatars.githubusercontent.com/u/32760275?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Harish</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=harishjanardhanan" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/SebayK"><img src="https://avatars.githubusercontent.com/u/185592440?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastian Kamiński</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=SebayK" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/web-components/src/components/date-picker/__tests__/date-picker-test.js
+++ b/packages/web-components/src/components/date-picker/__tests__/date-picker-test.js
@@ -9,6 +9,15 @@ import '@carbon/web-components/es/components/date-picker/index.js';
 import { fixture, html, expect } from '@open-wc/testing';
 
 describe('cds-date-picker', () => {
+  const waitForDatePickerSync = async (callback = () => true, retries = 5) => {
+    for (let i = 0; i < retries; i++) {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      if (callback()) {
+        return;
+      }
+    }
+  };
+
   describe('Invalid and Warning States with Disabled/ReadOnly', () => {
     it('should not show invalid state when disabled', async () => {
       const el = await fixture(html`
@@ -112,6 +121,69 @@ describe('cds-date-picker', () => {
   });
 
   describe('Date Picker Functionality', () => {
+    describe('dynamic kind switching', () => {
+      it('should instantiate the calendar when switching from simple to single', async () => {
+        const el = await fixture(html`
+          <cds-date-picker>
+            <cds-date-picker-input
+              kind="simple"
+              label-text="Date"
+              placeholder="mm/dd/yyyy">
+            </cds-date-picker-input>
+          </cds-date-picker>
+        `);
+
+        const input = el.querySelector('cds-date-picker-input');
+        expect(el.calendar).to.be.null;
+
+        input.kind = 'single';
+        await input.updateComplete;
+        await el.updateComplete;
+        await waitForDatePickerSync(() => Boolean(el.calendar));
+
+        const floatingMenuContainer = el.shadowRoot?.querySelector(
+          '#floating-menu-container'
+        );
+
+        expect(el.calendar).to.exist;
+        expect(floatingMenuContainer?.children.length).to.be.greaterThan(0);
+      });
+
+      it('should destroy the calendar when switching back from single to simple', async () => {
+        const el = await fixture(html`
+          <cds-date-picker>
+            <cds-date-picker-input
+              kind="simple"
+              label-text="Date"
+              placeholder="mm/dd/yyyy">
+            </cds-date-picker-input>
+          </cds-date-picker>
+        `);
+
+        const input = el.querySelector('cds-date-picker-input');
+        const floatingMenuContainer = el.shadowRoot?.querySelector(
+          '#floating-menu-container'
+        );
+        expect(el.calendar).to.be.null;
+
+        input.kind = 'single';
+        await input.updateComplete;
+        await el.updateComplete;
+        await waitForDatePickerSync(() => Boolean(el.calendar));
+
+        expect(el.calendar).to.exist;
+        expect(floatingMenuContainer?.children.length).to.be.greaterThan(0);
+
+        input.kind = 'simple';
+        await input.updateComplete;
+        await el.updateComplete;
+        await waitForDatePickerSync(() => !el.calendar);
+
+        expect(el.calendar).to.be.null;
+        expect(floatingMenuContainer?.children.length).to.equal(0);
+      });
+    });
+
     it('should render date picker with calendar', async () => {
       const el = await fixture(html`
         <cds-date-picker>

--- a/packages/web-components/src/components/date-picker/date-picker.mdx
+++ b/packages/web-components/src/components/date-picker/date-picker.mdx
@@ -17,6 +17,7 @@ import * as DatePickerStories from './date-picker.stories';
 - [Overview](#overview)
   - [Simple date picker](#simple-datepicker)
   - [Range date picker](#range-datepicker)
+  - [Dynamic kind switching](#dynamic-kind-switching)
   - [Skeleton state](#skeleton-state)
   - [AI label](#ai-label)
 - [Component API](#component-api)
@@ -56,6 +57,15 @@ years, however they work best when used for recent or near future dates.
 
 <Canvas of={DatePickerStories.SingleWithCalendar} />
 <Canvas of={DatePickerStories.RangeWithCalendar} />
+
+### Dynamic kind switching
+
+If your application updates the `kind` of the same `cds-date-picker-input` at
+runtime, the date picker should stay in sync with that change. Use the
+regression story below to verify that switching between `simple` and `single`
+creates and destroys the calendar correctly.
+
+<Canvas of={DatePickerStories.KindSwitchingRegression} />
 
 ### Skeleton state
 

--- a/packages/web-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.stories.ts
@@ -14,6 +14,7 @@ import FolderOpen16 from '@carbon/icons/es/folder--open/16.js';
 import Folders16 from '@carbon/icons/es/folders/16.js';
 import './date-picker';
 import './date-picker-input-skeleton';
+import '../button';
 import '../layer/index';
 import '../ai-label';
 import '../../../.storybook/templates/with-layer';
@@ -406,6 +407,74 @@ export const SingleWithCalendar = {
         </cds-date-picker-input>
       </cds-date-picker>
     `;
+  },
+};
+
+const setDatePickerKind =
+  (kind: 'simple' | 'single') =>
+  (event: Event & { currentTarget: Element }) => {
+    const container = event.currentTarget.closest(
+      '[data-date-picker-kind-switching]'
+    );
+    const input = container?.querySelector(
+      `${prefix}-date-picker-input`
+    ) as HTMLElement | null;
+    const status = container?.querySelector(
+      '[data-date-picker-kind-status]'
+    ) as HTMLElement | null;
+
+    input?.setAttribute('kind', kind);
+
+    if (status) {
+      status.textContent = `Current kind: ${kind}`;
+    }
+  };
+
+export const KindSwitchingRegression = {
+  args: { ...defaultArgs, placeholder: 'mm/dd/yyyy', size: INPUT_SIZE.MEDIUM },
+  argTypes: {
+    placeholder: controls.placeholder,
+    size: controls.size,
+  },
+  render: ({ placeholder, size }) => {
+    const switchToSimple = setDatePickerKind('simple');
+    const switchToSingle = setDatePickerKind('single');
+
+    return html`
+      <div
+        data-date-picker-kind-switching
+        style="display:grid;gap:1rem;max-width:20rem;">
+        <div style="display:flex;gap:0.75rem;align-items:center;">
+          <cds-button size="sm" kind="secondary" @click="${switchToSimple}">
+            Switch to simple
+          </cds-button>
+          <cds-button size="sm" @click="${switchToSingle}">
+            Switch to single
+          </cds-button>
+        </div>
+        <p
+          data-date-picker-kind-status
+          style="margin:0;color:#525252;font-size:0.875rem;">
+          Current kind: simple
+        </p>
+        <cds-date-picker>
+          <cds-date-picker-input
+            kind="simple"
+            label-text="Date Picker label"
+            placeholder="${placeholder}"
+            size="${size}">
+          </cds-date-picker-input>
+        </cds-date-picker>
+      </div>
+    `;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Manual regression case for dynamic `kind` switching. Toggle the same input between `simple` and `single` to verify that the calendar is created and destroyed correctly.',
+      },
+    },
   },
 };
 

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -75,9 +75,19 @@ flatpickr!.l10ns!.en!.weekdays.shorthand.forEach((_day, index) => {
 @customElement(`${prefix}-date-picker`)
 class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
   /**
+   * Observes light DOM changes that can affect the effective date picker mode.
+   */
+  private _observerMutation: MutationObserver | null = null;
+
+  /**
    * The slotted `<cds-date-input kind="from">`.
    */
   private _dateInteractNode: CDSDatePickerInput | null = null;
+
+  /**
+   * The last effective date picker mode synchronized with Flatpickr.
+   */
+  private _modeCurrent: DATE_PICKER_MODE | null = null;
 
   /**
    * The element to put calendar dropdown in.
@@ -240,18 +250,58 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
    * Handles `slotchange` event in the `<slot>`.
    */
   private _handleSlotChange({ target }: Event) {
-    const { _dateInteractNode: oldDateInteractNode } = this;
-    const dateInteractNode = (target as HTMLSlotElement)
-      .assignedNodes()
-      .find(
-        (node) =>
-          node.nodeType === Node.ELEMENT_NODE &&
-          (node as HTMLElement).matches(
-            (this.constructor as typeof CDSDatePicker).selectorInputFrom
-          )
-      );
-    if (oldDateInteractNode !== dateInteractNode) {
+    this._syncDateInteractNode((target as HTMLSlotElement).assignedNodes());
+  }
+
+  /**
+   * Handles mutations in the light DOM that can affect the effective date picker mode.
+   */
+  private _handleMutation = (mutationsList: MutationRecord[]) => {
+    for (const mutation of mutationsList) {
+      if (
+        mutation.type === 'attributes' &&
+        mutation.target instanceof HTMLElement &&
+        mutation.target.matches(`${prefix}-date-picker-input`)
+      ) {
+        this._syncDateInteractNode();
+        return;
+      }
+
+      if (
+        mutation.type === 'childList' &&
+        ([...mutation.addedNodes, ...mutation.removedNodes] as Node[]).some(
+          (node) =>
+            node instanceof HTMLElement &&
+            node.matches(`${prefix}-date-picker-input`)
+        )
+      ) {
+        this._syncDateInteractNode();
+        return;
+      }
+    }
+  };
+
+  /**
+   * Syncs the date picker state with its slotted date inputs.
+   */
+  private _syncDateInteractNode(nodes: Iterable<Node> = this.childNodes) {
+    const assignedNodes = [...nodes];
+    const mode = this._mode;
+    const dateInteractNode = assignedNodes.find(
+      (node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        (node as HTMLElement).matches(
+          (this.constructor as typeof CDSDatePicker).selectorInputFrom
+        )
+    );
+
+    if (
+      this._dateInteractNode !== dateInteractNode ||
+      this._modeCurrent !== mode ||
+      this.calendar
+    ) {
       this._dateInteractNode = dateInteractNode as CDSDatePickerInput;
+      this._modeCurrent = mode;
       this._instantiateDatePicker();
     }
   }
@@ -511,11 +561,24 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
 
   connectedCallback() {
     super.connectedCallback();
-    this._instantiateDatePicker();
+    this._observerMutation = new MutationObserver(this._handleMutation);
+    this._observerMutation.observe(this, {
+      attributes: true,
+      attributeFilter: ['kind'],
+      childList: true,
+      subtree: true,
+    });
+    this._syncDateInteractNode();
   }
 
   disconnectedCallback() {
+    if (this._observerMutation) {
+      this._observerMutation.disconnect();
+      this._observerMutation = null;
+    }
     this._releaseDatePicker();
+    this._dateInteractNode = null;
+    this._modeCurrent = null;
     super.disconnectedCallback();
   }
 


### PR DESCRIPTION
Closes #21905 

Fixes `cds-date-picker` so changing a slotted `cds-date-picker-input` between
`simple` and `single` correctly creates and destroys the Flatpickr calendar at
runtime.

### Changelog

**New**

- Added regression tests for dynamic `kind` switching in `cds-date-picker`
- Added a Storybook regression scenario for switching `kind` at runtime
- Added documentation coverage for dynamic `kind` switching in the date picker
  docs

**Changed**

- Updated `cds-date-picker` to observe `kind` changes on slotted
  `cds-date-picker-input` elements
- Re-synchronized Flatpickr initialization and teardown when the effective date
  picker mode changes after initial render

**Removed**

- No removals

#### Testing / Reviewing

- Run the targeted date picker tests:
  - `cd packages/web-components`
  - `npx web-test-runner --files src/components/date-picker/__tests__/date-picker-test.js --node-resolve --concurrency=1 --static-logging`
- Run package type checking:
  - `cd packages/web-components`
  - `yarn typecheck`
- Open Storybook and verify the regression story:
  - `cd packages/web-components`
  - `yarn storybook`
  - Open `Components/Date picker`
  - Use the `KindSwitchingRegression` story
- Confirm both flows manually:
  - Switching `simple -> single` creates the calendar and allows it to open
  - Switching `single -> simple` destroys the calendar and prevents it from opening
- Cross-browser validation completed in:
  - Chrome
  - Firefox
  - Safari

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
