### PR TITLE
chore(chromatic): actionable notification inline story

### DIFF
--- a/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
+++ b/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
@@ -54,10 +54,10 @@ export const Default = (args) => (
   <ActionableNotification {...args}></ActionableNotification>
 );
 
-export const Inline = (args) => (
-  <ActionableNotification {...args}></ActionableNotification>
-);
-Inline.args = {
-  inline: true,
+export const Inline = {
+  ...Default,
+  args: {
+    inline: true,
+  },
+  tags: ['!dev', '!autodocs'],
 };
-Inline.tags = ['!dev', '!autodocs'];

--- a/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
+++ b/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,6 +23,11 @@ export default {
     },
   },
   args: {
+    actionButtonLabel: 'Action',
+    inline: false,
+    closeOnEscape: true,
+    title: 'Notification title',
+    subtitle: 'Subtitle text goes here',
     kind: 'error',
     lowContrast: false,
     hideCloseButton: false,
@@ -32,27 +37,27 @@ export default {
     onCloseButtonClick: action('onCloseButtonClick'),
     onActionButtonClick: action('onActionButtonClick'),
   },
+  argTypes: {
+    onActionButtonClick: {
+      action: 'onActionButtonClick',
+    },
+    onClose: {
+      action: 'onClose',
+    },
+    onCloseButtonClick: {
+      action: 'onCloseButtonClick',
+    },
+  },
 };
 
 export const Default = (args) => (
   <ActionableNotification {...args}></ActionableNotification>
 );
 
-Default.argTypes = {
-  onActionButtonClick: {
-    action: 'onActionButtonClick',
-  },
-  onClose: {
-    action: 'onClose',
-  },
-  onCloseButtonClick: {
-    action: 'onCloseButtonClick',
-  },
+export const Inline = (args) => (
+  <ActionableNotification {...args}></ActionableNotification>
+);
+Inline.args = {
+  inline: true,
 };
-Default.args = {
-  actionButtonLabel: 'Action',
-  inline: false,
-  closeOnEscape: true,
-  title: 'Notification title',
-  subtitle: 'Subtitle text goes here',
-};
+Inline.tags = ['!dev', '!autodocs'];


### PR DESCRIPTION
Closes #21892

Adds the previously removed Percy snapshot for ActionableNotification `inline` variant:

https://github.com/carbon-design-system/carbon/blob/12c190a9713150a5445241561cbcf88e6447eec3/e2e/components/Notifications/Notifications-test.e2e.js#L42-L59

into the ActionableNotification stories as a hidden test story that will appear as a snapshot in Chromatic.


### Changelog

**New**

- Added hidden story for `inline` variant

**Changed**

- Cleaned up the `args` and `argTypes` in this file to all be in one location inside the `export default`


#### Testing / Reviewing

- Go to https://deploy-preview-21941--v11-carbon-react.netlify.app/?path=/story/components-notifications-actionable--inline
- ActionableNotification should render with as the `inline` variant
- This story should be present in Chromatic

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- ~~[ ] Tested for cross-browser consistency~~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)