### PR TITLE
fix(data-table): render Small Persistent Toolbar with xs size

### DIFF
--- a/packages/react/src/components/DataTable/stories/DataTable-toolbar.stories.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-toolbar.stories.js
@@ -222,7 +222,7 @@ export const SmallPersistentToolbar = (args) => (
             <Button onClick={action('Button click')}>Primary Button</Button>
           </TableToolbarContent>
         </TableToolbar>
-        <Table {...getTableProps()} size="sm" aria-label="sample table">
+        <Table {...getTableProps()} size="xs" aria-label="sample table">
           <TableHead>
             <TableRow>
               {headers.map((header) => (

--- a/packages/web-components/src/components/data-table/stories/data-table-toolbar.stories.ts
+++ b/packages/web-components/src/components/data-table/stories/data-table-toolbar.stories.ts
@@ -362,7 +362,7 @@ export const PersistentToolbar = {
 
 export const SmallPersistentToolbar = {
   render: () => html`
-    <cds-table size="sm">
+    <cds-table size="xs">
       <cds-table-header-title slot="title">DataTable</cds-table-header-title>
       <cds-table-header-description slot="description"
         >With toolbar</cds-table-header-description


### PR DESCRIPTION
Closes #21914

Fixes the DataTable Toolbar stories so the Small Persistent Toolbar renders the true `xs` size (24px) in both React and Web Components.

### Changelog

**New**

- None

**Changed**

- Updated React `SmallPersistentToolbar` story table size from `sm` to `xs`
- Updated WC `SmallPersistentToolbar` story table size from `sm` to `xs`

**Removed**

- None

#### Testing / Reviewing

- [x] Open React `DataTable/Toolbar` story and verify `Small Persistent Toolbar` row height is XS (24px)
- [x] Open WC `DataTable/Toolbar` story and verify `Small Persistent Toolbar` row height is XS (24px)
- [x] Confirm no unrelated visual regressions in toolbar examples

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Addressed any impact on accessibility (a11y)
- [x] Validated that this code is ready for review and status checks should pass
