### PR TITLE
fix(multi-select): update styles for select-all item to improve layout

### DIFF
--- a/packages/web-components/src/components/multi-select/multi-select.scss
+++ b/packages/web-components/src/components/multi-select/multi-select.scss
@@ -440,9 +440,12 @@ $css--plex: true !default;
 // treatment
 :host(#{$prefix}-multi-select-item[is-select-all]) {
   .#{$prefix}--list-box__menu-item__option {
-    padding: 0.6875rem $spacing-05;
+    display: flex;
+    align-items: center;
     margin: 0;
     border-block-end: 1px solid $border-subtle-01;
+    padding-block: 0;
+    padding-inline: $spacing-05;
   }
 }
 


### PR DESCRIPTION
Closes #21556

fix(web-components): vertically center "Select all" item in MultiSelect for sm and lg sizes

### Changelog


**Changed**

- Updated is-select-all item styles in multi-select.scss to use display: flex and align-items: center instead of a fixed padding-block value, ensuring the "Select all" row is vertically centered at sm, md, and lg sizes


#### Testing / Reviewing

1. Open the FilterableMultiSelect story in Storybook with selectAll enabled
2. Set component size to sm → confirm "All roles" is vertically centered in its row
3. Set component size to md → confirm "All roles" is vertically centered
4. Set component size to lg → confirm "All roles" is vertically centered
5. For each size, type in the search input to filter, then clear it → confirm alignment stays correct throughout
6. Confirm the separator border below "All roles" still renders correctly at all sizes

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [√] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [√ ] Addressed any impact on accessibility (a11y)
- [√] Tested for cross-browser consistency
- [√ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
