### PR TITLE
Refactor ProgressIndicator button to span element when not using onclick

### DIFF
--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -310,42 +310,58 @@ function ProgressStep({
     message = t('carbon.progress-step.invalid');
   }
 
-  return (
+  const stepContents = <>
+    <SVGIcon
+      complete={complete}
+      current={current}
+      description={description}
+      invalid={invalid}
+      prefix={prefix}
+    />
+      <div className={`${prefix}--progress-text`}>
+        <Text as="span" className={`${prefix}--progress-label`}>
+          {label}
+        </Text>
+        {secondaryLabel !== null && secondaryLabel !== undefined ? (
+          <Text as="span" className={`${prefix}--progress-optional`}>
+            {secondaryLabel}
+          </Text>
+        ) : null}
+      </div>
+      <span className={`${prefix}--assistive-text`}>{message}</span>
+      <span className={`${prefix}--progress-line`} />
+  </>;
+
+  if (!!onClick || disabled) {
+    return (
+      <li className={classes}>
+        <button
+          className={cx(`${prefix}--progress-step-button`, {
+            [`${prefix}--progress-step-button--unclickable`]: !onClick || current,
+          })}
+          disabled={disabled}
+          aria-disabled={disabled}
+          tabIndex={disabled ? -1 : 0}
+          onClick={!current ? onClick : undefined}
+          onKeyDown={handleKeyDown}
+          title={label}
+          {...rest}>
+          {stepContents}
+        </button>
+      </li>
+    );
+  } else {
     <li className={classes}>
-      <button
-        type="button"
+      <span
         className={cx(`${prefix}--progress-step-button`, {
           [`${prefix}--progress-step-button--unclickable`]: !onClick || current,
         })}
-        disabled={disabled}
-        aria-disabled={disabled}
-        tabIndex={disabled ? -1 : 0}
-        onClick={!current ? onClick : undefined}
-        onKeyDown={handleKeyDown}
         title={label}
         {...rest}>
-        <SVGIcon
-          complete={complete}
-          current={current}
-          description={description}
-          invalid={invalid}
-          prefix={prefix}
-        />
-        <div className={`${prefix}--progress-text`}>
-          <Text as="span" className={`${prefix}--progress-label`}>
-            {label}
-          </Text>
-          {secondaryLabel !== null && secondaryLabel !== undefined ? (
-            <Text as="span" className={`${prefix}--progress-optional`}>
-              {secondaryLabel}
-            </Text>
-          ) : null}
-        </div>
-        <span className={`${prefix}--assistive-text`}>{message}</span>
-        <span className={`${prefix}--progress-line`} />
-      </button>
+        {stepContents}
+      </span>
     </li>
-  );
+  }
 }
 
 ProgressStep.propTypes = {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12058

When the ProgressStep is non-interactive, then the button role is incorrect. This only uses the button role when the button is clickable. Note that I also removed the onKeyDown customization when the step wasn't interactive. I couldn't think of a case where it would have a keyboard behavior, but not a click behavior.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
