### PR TITLE
fix: remove tabindex from disabled dropdown

### DIFF
--- a/packages/web-components/src/components/dropdown/__tests__/dropdown-test.js
+++ b/packages/web-components/src/components/dropdown/__tests__/dropdown-test.js
@@ -199,6 +199,7 @@ describe('cds-dropdown', function () {
       triggerButton.click();
       await el.updateComplete;
       expect(el.open).to.be.false;
+      expect(el.getAttribute('tabindex')).to.be.null;
     });
 
     it('should respect the readOnly property', async () => {

--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -1269,6 +1269,7 @@ class CDSDropdown extends ValidityMixin(
     const {
       ariaLabel,
       _classes: classes,
+      disabled,
       helperText,
       invalidText,
       open,
@@ -1358,7 +1359,9 @@ class CDSDropdown extends ValidityMixin(
           )}"
           class="${prefix}--list-box__field"
           part="trigger-button"
-          tabindex="${ifDefined(!shouldTriggerBeFocusable ? undefined : '0')}"
+          tabindex="${ifDefined(
+            !shouldTriggerBeFocusable ? undefined : disabled ? undefined : '0'
+          )}"
           role="${ifDefined(
             !shouldTriggerBeFocusable ? undefined : 'combobox'
           )}"


### PR DESCRIPTION
Closes #21982 

removes tabindex from dropdown web component when disabled

### Changelog

**Changed**

- removes tabindex from dropdown web component when disabled

#### Testing / Reviewing

added unit test and confirmed behavior with voiceover

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
