### PR TITLE
fix(ai-label): React & WC link colors

### DIFF
--- a/packages/react/src/components/AILabel/AILabel.stories.js
+++ b/packages/react/src/components/AILabel/AILabel.stories.js
@@ -137,7 +137,8 @@ export const Default = (args) => {
       <hr />
       <p className="secondary">Model type</p>
       <p className="bold">Foundation model</p>
-      <Link>test</Link>
+      <a href="#">normal link</a>
+      <Link href="#">cds link</Link>
     </div>
   );
 

--- a/packages/react/src/components/AILabel/AILabel.stories.js
+++ b/packages/react/src/components/AILabel/AILabel.stories.js
@@ -12,6 +12,7 @@ import { action } from 'storybook/actions';
 import { View, FolderOpen, Folders } from '@carbon/icons-react';
 import Button from '../Button';
 import { IconButton } from '../IconButton';
+import { Link } from '../Link';
 import mdx from './AILabel.mdx';
 import './ailabel-story.scss';
 
@@ -136,6 +137,7 @@ export const Default = (args) => {
       <hr />
       <p className="secondary">Model type</p>
       <p className="bold">Foundation model</p>
+      <Link>test</Link>
     </div>
   );
 

--- a/packages/styles/scss/components/slug/_slug.scss
+++ b/packages/styles/scss/components/slug/_slug.scss
@@ -13,6 +13,7 @@
 @use '../../type' as *;
 @use '../../utilities/ai-gradient' as *;
 @use '../../utilities/convert';
+@use '../../utilities/custom-property';
 @use '../toggletip';
 @use '../popover';
 
@@ -1061,6 +1062,13 @@ $sizes: (
     // This sets the max size to the size of the action bar with 3 buttons
     padding-block: convert.to-rem(24px) convert.to-rem(80px);
     padding-inline: convert.to-rem(24px);
+
+    // Reset the custom properties of the link styles to initial for AI-label and slug. as the AI-label uses gradient backgrounds.
+    @include custom-property.declaration('button-focus-color', initial);
+    @include custom-property.declaration('link-text-color', initial);
+    @include custom-property.declaration('link-hover-text-color', initial);
+    @include custom-property.declaration('link-visited-text-color', initial);
+    @include custom-property.declaration('link-focus-text-color', initial);
   }
 
   .#{$prefix}--ai-label

--- a/packages/web-components/src/components/ai-label/ai-label.stories.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.stories.ts
@@ -62,6 +62,8 @@ const content = html`
     <hr />
     <p class="secondary">Model type</p>
     <p class="bold">Foundation model</p>
+    <a href="#">normal link</a>
+    <cds-link href="#">cds link</cds-link>
   </div>
 `;
 


### PR DESCRIPTION
Closes #18647 

AILabel builds on the base of ToggleTip
functionally it inherits every behavior of toggletip.
with a visual difference
the background color of toggletip content follows a contrasting color compared to theme background
the background color of ai-label follows similar color of theme background. but with a gradient.

in this case we have to reset the tokens to their defaults in `AILabel` to avoid any unwanted changes which are valid only in the `ToggleTip`.

### Changelog

**New**

- reset the tokens
`button-focus-color`
`link-text-color`
`link-hover-text-color`
`link-visited-text-color`
`link-focus-text-color`
to `initial` in `_slug.scss`

#### Testing / Reviewing

added example links in ai-label story for demo purposes. which will be cleaned up after review. and can be tested in deploy preview storybook.

this change covers [react](https://deploy-preview-21991--v11-carbon-react.netlify.app/?path=/story/components-ailabel--default&globals=theme:g100) and [web-components](https://deploy-preview-21991--v11-carbon-web-components.netlify.app/?path=/story/components-ai-label--default&globals=theme:g100) too. pls verify.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
