### PR TITLE
fix: restore Toggletip caret styling

### DIFF
--- a/packages/web-components/src/components/toggle-tip/toggletip.scss
+++ b/packages/web-components/src/components/toggle-tip/toggletip.scss
@@ -26,7 +26,22 @@
   justify-content: center;
 
   outline: none;
+}
 
+:host(#{$prefix}-toggletip[open]:not([autoalign])) {
+  // Keep the caret fill on `::after` so the container does not render as a
+  // block.
+  .#{$prefix}--popover-caret {
+    background: transparent;
+
+    &::after {
+      background-color: $background-inverse;
+    }
+  }
+}
+
+:host(#{$prefix}-toggletip[open][autoalign]) {
+  // `autoalign` uses the rotated caret container as the visible shape.
   .#{$prefix}--popover-caret {
     background-color: $background-inverse;
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21031

Restored `Toggletip` caret styling.

### Changelog

**Changed**

- Restored `Toggletip` caret styling.

#### Testing / Reviewing

I'm not sure how to add visual testing. It may help prevent regressions. If there are other approaches to preventing regressions, let me know.

---

Check that the fix works:

```sh
yarn workspace @carbon/web-components storybook
```

Then revert the change and confirm that the issue reappears:

```sh
git checkout main packages/web-components/src/components/toggle-tip/toggletip.scss
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
