### PR TITLE
fix: restore pure annotations for generated icons

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next.js
+++ b/packages/icon-build-helpers/src/builders/react/next.js
@@ -15,6 +15,7 @@ const path = require('path');
 const ts = require('typescript');
 const virtual = require('../plugins/virtual');
 const { svgToJSX, jsToAST } = require('./next/convert');
+const { annotateAsPure } = require('./next/pure');
 const templates = require('./next/templates');
 const { writeTsDefinitions } = require('./next/typescript');
 
@@ -372,7 +373,9 @@ function createIconSource(moduleName, sizes, preamble = []) {
     ].filter(Boolean),
   });
 
-  return source;
+  // Mark `forwardRef` calls as pure so the bundler can drop unused icon
+  // exports.
+  return annotateAsPure(source);
 }
 
 /**

--- a/packages/icon-build-helpers/src/builders/react/next/__tests__/templates-test.js
+++ b/packages/icon-build-helpers/src/builders/react/next/__tests__/templates-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { default: generate } = require('@babel/generator');
+const t = require('@babel/types');
+const { annotateAsPure } = require('../pure');
+const templates = require('../templates');
+
+describe('react next templates', () => {
+  it('should mark generated icon components as pure for tree shaking', () => {
+    const nodes = annotateAsPure(
+      templates.component({
+        moduleName: t.identifier('Add'),
+        defaultSize: t.numericLiteral(16),
+        statements: [t.returnStatement(t.nullLiteral())],
+      })
+    );
+
+    const code = generate(t.file(t.program(nodes))).code;
+
+    expect(code).toContain('const Add = /*#__PURE__*/React.forwardRef(');
+  });
+});

--- a/packages/icon-build-helpers/src/builders/react/next/pure.js
+++ b/packages/icon-build-helpers/src/builders/react/next/pure.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+function annotateAsPure(nodes) {
+  nodes[0].declarations[0].init.leadingComments = [
+    {
+      type: 'CommentBlock',
+      value: '#__PURE__',
+    },
+  ];
+
+  return nodes;
+}
+
+module.exports = {
+  annotateAsPure,
+};


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21906

Restored pure annotations for generated icons.

### Changelog

**Changed**

- Restored pure annotations for generated icons. With that, the bundler should be able to tree shake unused `@carbon/icons-react` exports.

#### Testing / Reviewing

Reference commits: https://github.com/carbon-design-system/carbon/compare/597001a9b6710da9531883b65a0852fde9ff199d...43b0b4cf9fe620a24195b4b6b9525a8264c09e11

```sh
yarn test packages/icon-build-helpers/src/builders/react/next/__tests__/templates-test.js
```

Follow steps in https://github.com/carbon-design-system/carbon/blob/43b0b4cf9fe620a24195b4b6b9525a8264c09e11/test-fix.md. Local results:
- With the fix: `193.14 kB` JS, `61.10 kB` gzip.
- Without the fix: `275.61 kB` JS, `77.02 kB` gzip.

````md
Run this repro on a branch with the fix, then compare the results against the
broken version using the same Vite app.

1. Build and pack the local package from this repo.

   ```sh
   cd /path/to/carbon/repo
   yarn workspace @carbon/icons-react build
   npm pack ./packages/icons-react
   ```

2. Create a Vite app that imports a single icon.

   ```sh
   mkdir -p /tmp/carbon-icons-size-repro
   cd /tmp/carbon-icons-size-repro
   npm create vite@latest .
   npm install
   npm install /path/to/carbon/repo/carbon-icons-react-*.tgz
   ```

3. Replace the contents of `src/App.jsx` with a single icon import.

   ```tsx
   import { Add } from '@carbon/icons-react';

   const App = () => {
     return <Add />;
   };

   export default App;
   ```

4. Build the app and inspect the output size. The gzipped bundle size is the
   metric to compare between versions.

   ```sh
   npm run build
   du -h dist/assets/*
   gzip -c dist/assets/*.js | wc -c
   ```

5. Compare the results with the broken version. In the Carbon repo, revert the
   fix, then rerun:

   ```sh
   cd /path/to/carbon/repo
   yarn workspace @carbon/icons-react build
   rm carbon-icons-react-*.tgz
   npm pack ./packages/icons-react
   ```

6. Back in `/tmp/carbon-icons-size-repro`, reinstall the new tarball and
   rebuild.

   ```sh
   cd /tmp/carbon-icons-size-repro
   rm -rf node_modules package-lock.json dist
   npm install
   npm install /path/to/carbon/repo/carbon-icons-react-*.tgz
   npm run build
   du -h dist/assets/*
   gzip -c dist/assets/*.js | wc -c
   ```

7. Clean up the repro environment.

   ```sh
   rm -rf /tmp/carbon-icons-size-repro
   rm -f /path/to/carbon/repo/carbon-icons-react-*.tgz
   ```
````

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
