### PR TITLE
fix: restore initial controlled ComboBox selection

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -511,6 +511,24 @@ describe('ComboBox', () => {
     expect(findInputNode()).toHaveDisplayValue('Item 1');
   });
 
+  it('should restore controlled selected item label on blur when input does not match any item on initial load', async () => {
+    render(
+      <ComboBox
+        {...mockProps}
+        selectedItem={mockProps.items[1]}
+        allowCustomValue={false}
+      />
+    );
+
+    expect(findInputNode()).toHaveDisplayValue('Item 1');
+
+    await userEvent.clear(findInputNode());
+    await userEvent.type(findInputNode(), 'no-match');
+    await userEvent.keyboard('[Tab]');
+
+    expect(findInputNode()).toHaveDisplayValue('Item 1');
+  });
+
   it('should keep exact match input on blur when it matches an item label', async () => {
     render(<ComboBox {...mockProps} allowCustomValue={false} />);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -657,10 +657,12 @@ const ComboBox = forwardRef(
                 items.some((item) => itemToString(item) === currentInput);
 
               if (!hasExactMatch) {
+                const selectedItem =
+                  typeof selectedItemProp !== 'undefined'
+                    ? selectedItemProp
+                    : state.selectedItem;
                 const restoredInput =
-                  state.selectedItem !== null
-                    ? itemToString(state.selectedItem)
-                    : '';
+                  selectedItem !== null ? itemToString(selectedItem) : '';
 
                 return { ...changes, inputValue: restoredInput };
               }
@@ -729,10 +731,12 @@ const ComboBox = forwardRef(
                 items.some((item) => itemToString(item) === currentInput);
 
               if (!hasExactMatch) {
+                const selectedItem =
+                  typeof selectedItemProp !== 'undefined'
+                    ? selectedItemProp
+                    : state.selectedItem;
                 const restoredInput =
-                  state.selectedItem !== null
-                    ? itemToString(state.selectedItem)
-                    : '';
+                  selectedItem !== null ? itemToString(selectedItem) : '';
 
                 return { ...changes, inputValue: restoredInput };
               }


### PR DESCRIPTION
No issue.

Restored initial controlled `ComboBox` selection.

### Changelog

**Changed**

- Restored initial controlled `ComboBox` selection.

#### Testing / Reviewing

When the component is initially rendered with a `selectedItem` prop, clearing the field or entering an invalid value does not revert to the previously selected value. After making a new selection, the behavior works as expected, suggesting the issue only occurs on initial load.

Using `initialSelectedItem` produces the expected behavior, but passing both `initialSelectedItem` and `selectedItem` isn't appropriate since they represent uncontrolled and controlled usage, respectively.

The issue can be reproduced in the Storybook: https://react.carbondesignsystem.com/?path=/docs/components-combobox--overview#selecteditem.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
