### PR TITLE
feat: migrate @carbon/layout to TypeScript

### DIFF
--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -4,6 +4,7 @@
   "version": "11.51.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "module": "es/index.js",
   "sass": "index.scss",
   "repository": {
@@ -26,7 +27,8 @@
     "provenance": true
   },
   "scripts": {
-    "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonLayout && node tasks/build.js",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "yarn clean && carbon-cli bundle src/index.ts --name CarbonLayout && node tasks/build.js && yarn build:types",
     "clean": "rimraf es lib umd scss/generated",
     "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
@@ -36,7 +38,9 @@
     "@carbon/scss-generator": "^10.20.0",
     "@carbon/test-utils": "^10.41.0",
     "core-js": "^3.16.0",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "typescript": "^5.7.3",
+    "typescript-config-carbon": "workspace:^0.9.0"
   },
   "dependencies": {
     "@ibm/telemetry-js": "^1.5.0"

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -1,48 +1,47 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { unstable_tokens } from './tokens.js';
+import { unstable_tokens } from './tokens';
 
 export { unstable_tokens };
+
+export type BreakpointName = 'sm' | 'md' | 'lg' | 'xlg' | 'max';
+export type Breakpoint = {
+  width: string;
+  columns: number;
+  margin: string;
+};
+export type SizeName =
+  | 'XSmall'
+  | 'Small'
+  | 'Medium'
+  | 'Large'
+  | 'XLarge'
+  | '2XLarge';
 
 // Convert
 // Default, Use with em() and rem() functions
 export const baseFontSize = 16;
 
-/**
- * Convert a given px unit to a rem unit
- * @param {number} px
- * @returns {string}
- */
-export function rem(px) {
+export const rem = (px: number) => {
   return `${px / baseFontSize}rem`;
-}
+};
 
-/**
- * Convert a given px unit to a em unit
- * @param {number} px
- * @returns {string}
- */
-export function em(px) {
+export const em = (px: number) => {
   return `${px / baseFontSize}em`;
-}
+};
 
-/**
- * Convert a given px unit to its string representation
- * @param {number} value - number of pixels
- * @returns {string}
- */
-export function px(value) {
+export const px = (value: number) => {
   return `${value}px`;
-}
+};
 
 // Breakpoint
 // Initial map of our breakpoints and their values
-export const breakpoints = {
+export const breakpoints: Record<BreakpointName, Breakpoint> = {
   sm: {
     width: rem(320),
     columns: 4,
@@ -70,24 +69,22 @@ export const breakpoints = {
   },
 };
 
-export function breakpointUp(name) {
+export const breakpointUp = (name: BreakpointName) => {
   return `@media (min-width: ${breakpoints[name].width})`;
-}
+};
 
-export function breakpointDown(name) {
+export const breakpointDown = (name: BreakpointName) => {
   return `@media (max-width: ${breakpoints[name].width})`;
-}
+};
 
-export function breakpoint(...args) {
-  return breakpointUp(...args);
-}
+export const breakpoint = breakpointUp;
 
 // Mini-unit
 export const miniUnit = 8;
 
-export function miniUnits(count) {
+export const miniUnits = (count: number) => {
   return rem(miniUnit * count);
-}
+};
 
 // Spacing
 export const spacing01 = miniUnits(0.25);
@@ -169,7 +166,7 @@ export const sizeMedium = rem(40);
 export const sizeLarge = rem(48);
 export const sizeXLarge = rem(64);
 export const size2XLarge = rem(80);
-export const sizes = {
+export const sizes: Record<SizeName, string> = {
   XSmall: sizeXSmall,
   Small: sizeSmall,
   Medium: sizeMedium,

--- a/packages/layout/src/tokens.ts
+++ b/packages/layout/src/tokens.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -53,4 +53,4 @@ export const unstable_tokens = [
   'layout05',
   'layout06',
   'layout07',
-];
+] as const;

--- a/packages/layout/tasks/build.js
+++ b/packages/layout/tasks/build.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2015, 2025
+ * Copyright IBM Corp. 2015, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ import {
   fluidSpacing,
   sizes,
   layout,
-} from '../src/index.js';
+} from '../es/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/layout/tsconfig.json
+++ b/packages/layout/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "typescript-config-carbon/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/layout/tsconfig.types.json
+++ b/packages/layout/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "./lib"
+  },
+  "include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,6 +1891,8 @@ __metadata:
     "@ibm/telemetry-js": "npm:^1.5.0"
     core-js: "npm:^3.16.0"
     rimraf: "npm:^6.0.1"
+    typescript: "npm:^5.7.3"
+    typescript-config-carbon: "workspace:^0.9.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
No issue.

Migrated `@carbon/layout` to TypeScript and emitted type definitions.

### Changelog

**New**

- Migrated `@carbon/layout` to TypeScript.
- Added type definitions for `@carbon/layout`.

#### Testing / Reviewing

I considered adding template literal return types to the utils, for example:

```tsx
export const rem = (px: number): `${number}rem` => {
  return `${px / baseFontSize}rem`;
};
```

I decided not to include it to keep the changes focused. If others think that would be beneficial, I can explore it in a follow-up.


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
