### PR TITLE
fix: remove react hook eslint rule suppressions

### DIFF
--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -290,10 +290,8 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
     const enableTreeviewControllable = useFeatureFlag(
       'enable-treeview-controllable'
     );
-
-    // eslint-disable-next-line  react-hooks/rules-of-hooks -- https://github.com/carbon-design-system/carbon/issues/20452
-    const { current: id } = useRef(nodeId || useId());
-
+    const generatedId = useId();
+    const { current: id } = useRef(nodeId ?? generatedId);
     const controllableExpandedState = useControllableState({
       value: isExpanded,
       onChange: onToggle as ControlledOnToggle,

--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -93,9 +93,8 @@ const TreeView: TreeViewComponent = ({
   const enableTreeviewControllable = useFeatureFlag(
     'enable-treeview-controllable'
   );
-
-  // eslint-disable-next-line  react-hooks/rules-of-hooks -- https://github.com/carbon-design-system/carbon/issues/20452
-  const { current: treeId } = useRef(rest.id || useId());
+  const generatedId = useId();
+  const { current: treeId } = useRef(rest.id ?? generatedId);
   const prefix = usePrefix();
   const treeClasses = classNames(className, `${prefix}--tree`, {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452

--- a/packages/react/src/internal/useOutsideClick.ts
+++ b/packages/react/src/internal/useOutsideClick.ts
@@ -19,21 +19,17 @@ export const useOutsideClick = <T extends HTMLElement | null>(
     savedCallback.current = callback;
   }, [callback]);
 
-  // We conditionally guard the `useEvent` hook for SSR. `canUseDOM` can be
-  // treated as a constant as it will be false when executed in a Node.js
-  // environment and true when executed in the browser
-  if (canUseDOM) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useWindowEvent('click', (event) => {
-      const { target } = event;
+  useWindowEvent('click', (event) => {
+    if (!canUseDOM) return;
 
-      if (
-        target instanceof Node &&
-        ref.current &&
-        !ref.current.contains(target)
-      ) {
-        savedCallback.current(event);
-      }
-    });
-  }
+    const { target } = event;
+
+    if (
+      target instanceof Node &&
+      ref.current &&
+      !ref.current.contains(target)
+    ) {
+      savedCallback.current(event);
+    }
+  });
 };


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Removed React hook ESLint rule suppressions.

### Changelog

**Removed**

- Removed React hook ESLint rule suppressions.

#### Testing / Reviewing

There should be no more `react-hooks/rules-of-hooks` violations in the codebase.

Existing tests should cover these changes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
