### PR TITLE
fix: remove stale flatpickr DatePicker workarounds

### DIFF
--- a/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.ts
+++ b/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.ts
@@ -90,17 +90,6 @@ const fixEventsPlugin: FixEventsPlugin = (config) => (fp) => {
             fp.close();
           });
         }
-      } else if (
-        match(event, keys.ArrowLeft) ||
-        match(event, keys.ArrowRight)
-      ) {
-        // Prevents Flatpickr code from canceling the event if left/right arrow keys are hit on `<input>`,
-        // so user can move the keyboard cursor for editing dates
-        // Workaround for: https://github.com/flatpickr/flatpickr/issues/1943
-        //
-        // TODO: https://github.com/flatpickr/flatpickr/issues/1943 has been
-        // addressed. Can the workaround be deleted?
-        event.stopPropagation();
       } else if (match(event, keys.ArrowDown)) {
         event.preventDefault();
         fp.open();

--- a/packages/web-components/src/components/date-picker/fix-events-plugin.ts
+++ b/packages/web-components/src/components/date-picker/fix-events-plugin.ts
@@ -67,15 +67,6 @@ export default (config: DatePickerFixEventsPluginConfig): Plugin =>
             );
             event.stopPropagation();
             break;
-          case 'ArrowLeft':
-          case 'Left':
-          case 'ArrowRight':
-          case 'Right':
-            // Prevents Flatpickr code from canceling the event if left/right arrow keys are hit on `<input>`,
-            // so user can move the keyboard cursor for editing dates
-            // Workaround for: https://github.com/flatpickr/flatpickr/issues/1943
-            event.stopPropagation();
-            break;
           default:
             break;
         }

--- a/packages/web-components/src/components/date-picker/range-plugin.ts
+++ b/packages/web-components/src/components/date-picker/range-plugin.ts
@@ -33,15 +33,9 @@ export interface ExtendedFlatpickrInstanceRangePlugin
  * @returns
  *   An extension of Flatpickr `rangePlugin` that does the following:
  *
- *   Better ensures the calendar dropdown is always aligned to the `<input>` for the starting date.
+ *   Positions the calendar dropdown relative to the `<input>` for the starting date.
  *     Workaround for: https://github.com/flatpickr/flatpickr/issues/1944
- *   Disables the logic in Flatpickr `rangePlugin` that calculates the new range with the old selected date
- *     when user selects a date from calendar dropdown.
- *     We'd like to reset the selection when user re-opens calendar dropdown and re-selects a date.
- *     Workaround for: https://github.com/flatpickr/flatpickr/issues/1958
- *   Disables the logic in Flatpickr `rangePlugin` that closes the calendar dropdown
- *     when it's launched from the `<input>` for the end date and user selects a date.
- *     Workaround for: https://github.com/flatpickr/flatpickr/issues/1958
+ *   Commits manual range input values on blur for both inputs when `allowInput` is enabled.
  *   Ensures that the `<input>` in shadow DOM is treated as part of Flatpickr UI,
  *     by ensuring such `<input>` hits `.contains()` search from `fp.config.ignoredFocusElements`.
  *     Without that, Flatpickr clears the `<input>` when end date hasn't been selected yet (which we don't want).


### PR DESCRIPTION
No issue. https://github.com/carbon-design-system/carbon/pull/21836#discussion_r3014734127

Removed stale `flatpickr` `DatePicker` workarounds.

### Changelog

**Removed**

- Removed stale `flatpickr` `DatePicker` workarounds.

#### Testing / Reviewing

Existing tests should cover these changes.

I deleted the https://github.com/flatpickr/flatpickr/issues/1958 references from `packages/web-components/src/components/date-picker/range-plugin.ts`. That file does not appear to override the upstream `rangePlugin` logic tied to `_prevDates`, `_secondInputFocused`, `onChange`, or `onValueUpdate`, which is where the https://github.com/flatpickr/flatpickr/issues/1958 behavior lives. The current wrapper only:

- Positions the calendar relative to the start input.
- Commits manual range input values on blur when `allowInput` is enabled.
- Treats shadow DOM inputs as ignored focus elements.

Keeping the https://github.com/flatpickr/flatpickr/issues/1958 reference would imply that the file fixes behavior it does not currently change. Let me know if I'm missing something.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
