### PR TITLE
fix: preserve DatePickerInput invalid state

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -401,6 +401,26 @@ describe('DatePicker', () => {
         document.querySelector(`.${prefix}--date-picker__icon--warn`)
       ).not.toBeInTheDocument();
     });
+
+    it('should preserve invalid state from DatePickerInput when DatePicker is not invalid', () => {
+      render(
+        <DatePicker datePickerType="single">
+          <DatePickerInput
+            id="date-picker-input-id-start"
+            placeholder="mm/dd/yyyy"
+            labelText="Date Picker label"
+            invalid
+            invalidText="Invalid date"
+          />
+        </DatePicker>
+      );
+
+      expect(screen.getByText('Invalid date')).toBeInTheDocument();
+      expect(screen.getByLabelText('Date Picker label')).toHaveAttribute(
+        'data-invalid',
+        'true'
+      );
+    });
   });
 });
 

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -440,7 +440,6 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((props, ref) => {
 
   const savedOnOpen = useSavedCallback(onOpen);
 
-  const effectiveWarn = warn && !invalid;
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   const datePickerClasses = cx(`${prefix}--date-picker`, {
@@ -460,13 +459,18 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((props, ref) => {
   const childrenWithProps = React.Children.toArray(children as any).map(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
     (child: any, index) => {
+      const childInvalid = child.props?.invalid;
+      const childWarn = child.props?.warn;
+      const mergedInvalid = invalid ?? childInvalid;
+      const mergedWarn = mergedInvalid ? false : (warn ?? childWarn);
+
       if (index === 0 && isComponentElement(child, DatePickerInput)) {
         return React.cloneElement(child, {
           datePickerType,
           ref: startInputField,
           readOnly,
-          invalid,
-          warn: effectiveWarn,
+          invalid: mergedInvalid,
+          warn: mergedWarn,
         });
       }
       if (index === 1 && isComponentElement(child, DatePickerInput)) {
@@ -474,24 +478,24 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((props, ref) => {
           datePickerType,
           ref: endInputField,
           readOnly,
-          invalid,
-          warn: effectiveWarn,
+          invalid: mergedInvalid,
+          warn: mergedWarn,
         });
       }
       if (index === 0) {
         return React.cloneElement(child, {
           ref: startInputField,
           readOnly,
-          invalid,
-          warn: effectiveWarn,
+          invalid: mergedInvalid,
+          warn: mergedWarn,
         });
       }
       if (index === 1) {
         return React.cloneElement(child, {
           ref: endInputField,
           readOnly,
-          invalid,
-          warn: effectiveWarn,
+          invalid: mergedInvalid,
+          warn: mergedWarn,
         });
       }
     }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21035

Preserved `DatePickerInput` `invalid` state when `DatePicker` was not `invalid`.

### Changelog

**Changed**

- Preserved `DatePickerInput` `invalid` state when `DatePicker` was not `invalid`.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/DatePicker/DatePicker-test.js
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
