### PR TITLE
fix: rework Search clear button focus geometry

### DIFF
--- a/packages/styles/scss/components/search/_search.scss
+++ b/packages/styles/scss/components/search/_search.scss
@@ -154,29 +154,8 @@
     inset-block-start: 0;
     inset-inline-end: 0;
 
-    &::before {
-      position: absolute;
-      display: block;
-      background-color: $field;
-      block-size: calc(100% - 2px);
-      content: '';
-      inline-size: 2px;
-      inset-block-start: convert.to-rem(1px);
-      inset-inline-start: 0;
-      transition: background-color $duration-fast-02
-        motion(standard, productive);
-
-      @media screen and (prefers-reduced-motion: reduce) {
-        transition: none;
-      }
-    }
-
     &:hover {
       border-block-end: 1px solid $border-strong;
-
-      &::before {
-        background-color: $field-hover;
-      }
     }
   }
 
@@ -191,7 +170,10 @@
     }
   }
 
+  // Keep the clear icon above the hover fill overlay.
   .#{$prefix}--search-close svg {
+    position: relative;
+    z-index: 1;
     fill: inherit;
   }
 
@@ -200,7 +182,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border-width: 1px 0;
+    border-width: 0 0 1px;
     border-style: solid;
     border-color: transparent;
     block-size: convert.to-rem(40px);
@@ -208,11 +190,6 @@
     fill: $icon-primary;
     inline-size: convert.to-rem(40px);
     opacity: 1;
-    transition:
-      opacity $duration-fast-02 motion(standard, productive),
-      background-color $duration-fast-02 motion(standard, productive),
-      outline $duration-fast-02 motion(standard, productive),
-      border $duration-fast-02 motion(standard, productive);
     visibility: inherit;
 
     &:hover {
@@ -227,6 +204,22 @@
       @include focus-outline('outline');
 
       background-color: $background-selected;
+    }
+  }
+
+  // Preserve the field focus outline while the clear button is hovered.
+  .#{$prefix}--search-input:focus ~ .#{$prefix}--search-close:hover {
+    background-color: transparent;
+    border-block-end-color: transparent;
+    outline: none;
+
+    &::after {
+      position: absolute;
+      background-color: $field-hover;
+      content: '';
+      inset-block: $spacing-01;
+      inset-inline: 0 $spacing-01;
+      pointer-events: none;
     }
   }
 
@@ -248,17 +241,6 @@
 
   .#{$prefix}--search--disabled svg {
     fill: $icon-on-color-disabled;
-  }
-
-  .#{$prefix}--search-close:focus,
-  .#{$prefix}--search-close:active {
-    &::before {
-      background-color: $focus;
-    }
-  }
-
-  .#{$prefix}--search-input:focus ~ .#{$prefix}--search-close:hover {
-    @include focus-outline('outline');
   }
 
   // Small


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18157

Reworked the `Search` clear button focus geometry.

### Changelog

**Changed**

- Reworked the `Search` clear button focus geometry.

**Removed**

- Removed unnecessary styles.

#### Testing / Reviewing

Fix I initially implemented before deciding to rework the styles: https://github.com/carbon-design-system/carbon/commit/2325187b745a178b6fdec262284a00d1d8e342a9. I chose to rework the styles because the asymmetric `calc(100% - 3px)` combined with a `2px` offset seemed like a rendering workaround rather than a solid fix. It was compensating for the visual artifact instead of actually aligning the underlying component geometry.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
