### PR TITLE
fix: fire ComboBox onChange on Tab selection

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -202,6 +202,30 @@ describe('ComboBox', () => {
     });
   });
 
+  it('should call `onChange` when a highlighted item is committed on Tab', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <ComboBox {...mockProps} />
+        <button type="button">Next focus target</button>
+      </>
+    );
+
+    await user.click(findInputNode());
+    await user.type(findInputNode(), 'Item');
+    await user.keyboard('[ArrowDown]');
+    await user.keyboard('[Tab]');
+
+    expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+    expect(mockProps.onChange).toHaveBeenCalledWith({
+      selectedItem: mockProps.items[1],
+    });
+    expect(
+      screen.getByRole('button', { name: 'Next focus target' })
+    ).toHaveFocus();
+  });
+
   describe('onInputChange', () => {
     let onInputChange;
     beforeEach(() => {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -900,9 +900,10 @@ const ComboBox = forwardRef(
         if (
           (type === ItemClick ||
             type === FunctionSelectItem ||
-            type === InputKeyDownEnter) &&
+            type === InputKeyDownEnter ||
+            (!allowCustomValue && type === InputBlur)) &&
           typeof newSelectedItem !== 'undefined' &&
-          !isEqual(selectedItemProp, newSelectedItem)
+          !isEqual(currentSelectedItem, newSelectedItem)
         ) {
           if (items.some((item) => isEqual(item, newSelectedItem))) {
             committedCustomValueRef.current = '';


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19777

Fired `ComboBox` `onChange` on Tab selection.

### Changelog

**Changed**

- Fired `ComboBox` `onChange` on Tab selection.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/ComboBox/ComboBox-test.js
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
