### PR TITLE
fix: hide fixed unknown Pagination story controls

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -183,17 +183,30 @@ PaginationWithCustomPageSizesLabel.storyName =
   'Pagination with custom page sizes label';
 
 export const PaginationUnknownPages = (args) => {
+  const { pageInputDisabled, pagesUnknown, totalItems, ...rest } = args ?? {};
+
   return (
     <div>
       <Pagination
         {...props()}
-        pagesUnknown={true}
-        totalItems={undefined}
         page={1}
-        {...args}
+        {...rest}
+        pagesUnknown
+        totalItems={undefined}
       />
     </div>
   );
 };
 
 PaginationUnknownPages.storyName = 'Unknown pages and items';
+PaginationUnknownPages.argTypes = {
+  pageInputDisabled: {
+    control: false,
+  },
+  pagesUnknown: {
+    control: false,
+  },
+  totalItems: {
+    control: false,
+  },
+};

--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -201,12 +201,18 @@ export const PaginationUnknownPages = (args) => {
 PaginationUnknownPages.storyName = 'Unknown pages and items';
 PaginationUnknownPages.argTypes = {
   pageInputDisabled: {
-    control: false,
+    table: {
+      disable: true,
+    },
   },
   pagesUnknown: {
-    control: false,
+    table: {
+      disable: true,
+    },
   },
   totalItems: {
-    control: false,
+    table: {
+      disable: true,
+    },
   },
 };

--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -199,20 +199,8 @@ export const PaginationUnknownPages = (args) => {
 };
 
 PaginationUnknownPages.storyName = 'Unknown pages and items';
-PaginationUnknownPages.argTypes = {
-  pageInputDisabled: {
-    table: {
-      disable: true,
-    },
-  },
-  pagesUnknown: {
-    table: {
-      disable: true,
-    },
-  },
-  totalItems: {
-    table: {
-      disable: true,
-    },
+PaginationUnknownPages.parameters = {
+  controls: {
+    exclude: ['pageInputDisabled', 'pagesUnknown', 'totalItems'],
   },
 };

--- a/packages/web-components/src/components/pagination/pagination.stories.ts
+++ b/packages/web-components/src/components/pagination/pagination.stories.ts
@@ -215,13 +215,19 @@ export const PaginationUnknownPages = {
   },
   argTypes: {
     pageInputDisabled: {
-      control: false,
+      table: {
+        disable: true,
+      },
     },
     pagesUnknown: {
-      control: false,
+      table: {
+        disable: true,
+      },
     },
     totalItems: {
-      control: false,
+      table: {
+        disable: true,
+      },
     },
   },
   render: (args) => {

--- a/packages/web-components/src/components/pagination/pagination.stories.ts
+++ b/packages/web-components/src/components/pagination/pagination.stories.ts
@@ -211,8 +211,18 @@ export const MultiplePaginationComponents = {
 export const PaginationUnknownPages = {
   name: 'Unknown pages and items',
   args: {
-    pagesUnknown: true,
     totalItems: undefined,
+  },
+  argTypes: {
+    pageInputDisabled: {
+      control: false,
+    },
+    pagesUnknown: {
+      control: false,
+    },
+    totalItems: {
+      control: false,
+    },
   },
   render: (args) => {
     const {
@@ -222,12 +232,9 @@ export const PaginationUnknownPages = {
       isLastPage,
       itemsPerPageText,
       page,
-      pageInputDisabled,
       pageSize,
       pageSizeInputDisabled,
-      pagesUnknown,
       size,
-      totalItems,
     } = args ?? {};
 
     return html`
@@ -239,11 +246,11 @@ export const PaginationUnknownPages = {
         items-per-page-text=${itemsPerPageText}
         page=${page}
         page-size=${pageSize}
-        ?page-input-disabled=${pageInputDisabled}
+        ?page-input-disabled=${false}
         ?page-size-input-disabled=${pageSizeInputDisabled}
         size=${size}
-        ?pages-unknown=${pagesUnknown}
-        total-items=${totalItems}
+        ?pages-unknown=${true}
+        .totalItems=${undefined}
         @cds-page-sizes-select-changed=${(event: CustomEvent) => {
           action('cds-page-sizes-select-changed')(event.detail);
         }}

--- a/packages/web-components/src/components/pagination/pagination.stories.ts
+++ b/packages/web-components/src/components/pagination/pagination.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -213,21 +213,9 @@ export const PaginationUnknownPages = {
   args: {
     totalItems: undefined,
   },
-  argTypes: {
-    pageInputDisabled: {
-      table: {
-        disable: true,
-      },
-    },
-    pagesUnknown: {
-      table: {
-        disable: true,
-      },
-    },
-    totalItems: {
-      table: {
-        disable: true,
-      },
+  parameters: {
+    controls: {
+      exclude: ['pageInputDisabled', 'pagesUnknown', 'totalItems'],
     },
   },
   render: (args) => {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21156

Locked unknown `Pagination` story controls.

### Changelog

**Changed**

- Locked unknown `Pagination` story controls.

#### Testing / Reviewing

I wasn’t sure whether the "remove" statement in the issue was meant literally or intended to restrict modification of the controls. I went with the latter, since the controls themselves are valid, but users should not be able to change them in this specific story. If the former is preferred, let me know.

`totalItems` wasn’t mentioned in the issue, but it seemed like it should be locked too.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
