### PR TITLE
refactor: use isDisabledItem throughout ComboBox

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -495,7 +495,7 @@ describe('ComboBox', () => {
 
   it('should skip disabled matches when pressing Enter with a partial input value', async () => {
     const onChange = jest.fn();
-    const disabledItems = [
+    const items = [
       { id: 'ibm-cloud', text: 'IBM Cloud', disabled: true },
       { id: 'ibm-quantum', text: 'IBM Quantum' },
       { id: 'ibm-z', text: 'IBM Z' },
@@ -504,7 +504,7 @@ describe('ComboBox', () => {
     render(
       <ComboBox
         id="test-combobox"
-        items={disabledItems}
+        items={items}
         itemToString={(item) => (item ? item.text : '')}
         onChange={onChange}
       />
@@ -516,7 +516,7 @@ describe('ComboBox', () => {
 
     expect(findInputNode()).toHaveDisplayValue('IBM Quantum');
     expect(onChange).toHaveBeenLastCalledWith({
-      selectedItem: disabledItems[1],
+      selectedItem: items[1],
     });
   });
 

--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -493,6 +493,33 @@ describe('ComboBox', () => {
     expect(screen.getByTestId('selected-item').textContent).toBe('Item 0');
   });
 
+  it('should skip disabled matches when pressing Enter with a partial input value', async () => {
+    const onChange = jest.fn();
+    const disabledItems = [
+      { id: 'ibm-cloud', text: 'IBM Cloud', disabled: true },
+      { id: 'ibm-quantum', text: 'IBM Quantum' },
+      { id: 'ibm-z', text: 'IBM Z' },
+    ];
+
+    render(
+      <ComboBox
+        id="test-combobox"
+        items={disabledItems}
+        itemToString={(item) => (item ? item.text : '')}
+        onChange={onChange}
+      />
+    );
+
+    await userEvent.click(findInputNode());
+    await userEvent.type(findInputNode(), 'IBM ');
+    await userEvent.keyboard('{Enter}');
+
+    expect(findInputNode()).toHaveDisplayValue('IBM Quantum');
+    expect(onChange).toHaveBeenLastCalledWith({
+      selectedItem: disabledItems[1],
+    });
+  });
+
   it('should restore selected item label on blur when input does not match any item and a selection exists', async () => {
     render(
       <ComboBox

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -139,8 +139,7 @@ const findHighlightedIndex = <ItemType,>(
 
   for (let i = 0; i < items.length; i++) {
     const item = itemToString(items[i]).toLowerCase();
-    // TODO: Use `isDisabledItem`.
-    if (!items[i]['disabled'] && item.indexOf(searchValue) !== -1) {
+    if (!isDisabledItem(items[i]) && item.indexOf(searchValue) !== -1) {
       return i;
     }
   }
@@ -679,9 +678,7 @@ const ComboBox = forwardRef(
                 );
                 const highlightedItem = filteredList[state.highlightedIndex];
 
-                // TODO: Use `isDisabledItem`.
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-                if (highlightedItem && !(highlightedItem as any).disabled) {
+                if (highlightedItem && !isDisabledItem(highlightedItem)) {
                   return {
                     ...changes,
                     selectedItem: highlightedItem,
@@ -693,9 +690,7 @@ const ComboBox = forwardRef(
                 if (autoIndex !== -1) {
                   const matchingItem = items[autoIndex];
 
-                  // TODO: Use `isDisabledItem`.
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-                  if (matchingItem && !(matchingItem as any).disabled) {
+                  if (matchingItem && !isDisabledItem(matchingItem)) {
                     return {
                       ...changes,
                       selectedItem: matchingItem,
@@ -883,11 +878,7 @@ const ComboBox = forwardRef(
       initialSelectedItem: initialSelectedItem,
       inputId: id,
       stateReducer,
-      isItemDisabled(item) {
-        // TODO: Use `isDisabledItem`.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-        return (item as any)?.disabled;
-      },
+      isItemDisabled: isDisabledItem,
       ...downshiftProps,
       onStateChange: ({ type, selectedItem: newSelectedItem }) => {
         downshiftProps?.onStateChange?.({


### PR DESCRIPTION
No issue.

Used `isDisabledItem` throughout `ComboBox`.

### Changelog

**New**

- Added test coverage for partial input value matching with `disabled` items in `ComboBox`.

**Changed**

- Used `isDisabledItem` throughout `ComboBox`.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/ComboBox/ComboBox-test.js
```

Reverting the changes will not cause the test to fail, as they do not affect behavior. `ComboBox` should continue to behave the same as before. These updates are just a refactor, and the new test fills a gap in a related scenario to help ensure no regressions.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
