### PR TITLE
fix: preserve DatePicker tab flow in readOnly mode

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -709,6 +709,32 @@ describe('Single date picker', () => {
     expect(document.body).toHaveFocus();
     expect(onClose).toHaveBeenCalledTimes(2);
   });
+
+  it('should keep native tab navigation when `readOnly` is true', async () => {
+    render(
+      <>
+        <DatePicker datePickerType="single" readOnly>
+          <DatePickerInput id="readonly-input-id" labelText="Read only input" />
+        </DatePicker>
+        <button data-testid="next-focus-target" type="button">
+          Next focus target
+        </button>
+      </>
+    );
+
+    const dateInput = screen.getByLabelText('Read only input');
+    const nextFocusTarget = screen.getByTestId('next-focus-target');
+    const calendar = screen.getByRole('application');
+
+    expect(calendar).not.toHaveClass('open');
+    expect(document.body).toHaveFocus();
+    await userEvent.tab();
+    expect(dateInput).toHaveFocus();
+    expect(calendar).not.toHaveClass('open');
+    await userEvent.tab();
+    expect(nextFocusTarget).toHaveFocus();
+    expect(calendar).not.toHaveClass('open');
+  });
 });
 
 describe('Range date picker', () => {

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -654,6 +654,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((props, ref) => {
     calendarRef.current = calendar;
 
     const handleInputFieldKeyDown = (event: KeyboardEvent) => {
+      if (readOnly && match(event, keys.Tab)) return;
+
       const {
         calendarContainer,
         selectedDateElem: fpSelectedDateElem,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21152

Preserve `DatePicker` tab flow in `readOnly` mode.

### Changelog

**Changed**

- Preserve `DatePicker` tab flow in `readOnly` mode.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/DatePicker/DatePicker-test.js
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
