### PR TITLE
fix: narrow react element and child types

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5346,6 +5346,9 @@ Map {
       "onChange": {
         "type": "func",
       },
+      "readOnly": {
+        "type": "bool",
+      },
     },
     "render": [Function],
   },
@@ -13339,6 +13342,9 @@ Map {
       "onChange": {
         "type": "func",
       },
+      "readOnly": {
+        "type": "bool",
+      },
     },
     "render": [Function],
   },
@@ -15318,6 +15324,9 @@ Map {
       },
       "onChange": {
         "type": "func",
+      },
+      "readOnly": {
+        "type": "bool",
       },
     },
     "render": [Function],

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -76,8 +76,7 @@ export interface AccordionItemProps {
    */
   renderExpando?: (
     props: PropsWithChildren<AccordionToggleProps>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ) => ReactElement<any>;
+  ) => ReactElement;
 
   /**
    * The callback function to render the expand button.
@@ -85,8 +84,7 @@ export interface AccordionItemProps {
    */
   renderToggle?: (
     props: PropsWithChildren<AccordionToggleProps>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ) => ReactElement<any>;
+  ) => ReactElement;
 
   /**
    * The accordion title.

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1533,8 +1533,7 @@ type ComboboxComponentProps<ItemType> = PropsWithChildren<
   RefAttributes<HTMLInputElement>;
 
 export interface ComboBoxComponent {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  <ItemType>(props: ComboboxComponentProps<ItemType>): ReactElement<any> | null;
+  <ItemType>(props: ComboboxComponentProps<ItemType>): ReactElement | null;
 }
 
 export default ComboBox as ComboBoxComponent;

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -9,24 +9,20 @@ import PropTypes from 'prop-types';
 import React, {
   Children,
   cloneElement,
-  isValidElement,
   useContext,
   useEffect,
   useRef,
   useState,
   type HTMLAttributes,
-  type KeyboardEvent,
-  type MouseEvent,
   type ReactElement,
 } from 'react';
 import classNames from 'classnames';
 import { deprecate } from '../../prop-types/deprecate';
 import { LayoutConstraint } from '../Layout';
-import { composeEventHandlers } from '../../tools/events';
-import { getNextIndex, matches, keys } from '../../internal/keyboard';
+import { getNextIndex, match, keys } from '../../internal/keyboard';
 import { PrefixContext } from '../../internal/usePrefix';
 import { isComponentElement } from '../../internal';
-import { IconSwitch } from '../Switch';
+import { IconSwitch, Switch } from '../Switch';
 import type { SwitchEventHandlersParams } from '../Switch/Switch';
 
 export interface ContentSwitcherProps
@@ -34,8 +30,7 @@ export interface ContentSwitcherProps
   /**
    * Pass in Switch components to be rendered in the ContentSwitcher
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  children?: ReactElement<any>[];
+  children?: ReactElement | ReactElement[];
 
   /**
    * Specify an optional className to be added to the container node
@@ -118,23 +113,19 @@ export const ContentSwitcher = ({
     }
   };
 
-  const isKeyboardEvent = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-    event: any
-  ): event is KeyboardEvent<HTMLButtonElement> | globalThis.KeyboardEvent =>
-    event && typeof event === 'object' && 'key' in event;
+  const hasKey = (
+    event: SwitchEventHandlersParams
+  ): event is SwitchEventHandlersParams & { key: string | number } =>
+    typeof event === 'object' && event !== null && 'key' in event;
 
-  const handleChildChange = (
-    event: SwitchEventHandlersParams &
-      (KeyboardEvent<HTMLButtonElement> | MouseEvent<HTMLButtonElement>)
-  ) => {
+  const handleChildChange = (event: SwitchEventHandlersParams) => {
     if (typeof event.index === 'undefined') return;
 
     const { index } = event;
 
     if (
-      isKeyboardEvent(event) &&
-      matches(event, [keys.ArrowRight, keys.ArrowLeft])
+      hasKey(event) &&
+      (match(event.key, keys.ArrowRight) || match(event.key, keys.ArrowLeft))
     ) {
       const nextIndex = getNextIndex(event.key, index, childrenArray.length);
 
@@ -147,7 +138,10 @@ export const ContentSwitcher = ({
 
         setSelectedIndex(nextIndex);
 
-        if (isValidElement<SwitchEventHandlersParams>(child)) {
+        if (
+          isComponentElement(child, Switch) ||
+          isComponentElement(child, IconSwitch)
+        ) {
           onChange({
             ...event,
             index: nextIndex,
@@ -158,7 +152,9 @@ export const ContentSwitcher = ({
       }
     } else if (
       selectedIndex !== index &&
-      (isKeyboardEvent(event) ? matches(event, [keys.Enter, keys.Space]) : true)
+      (hasKey(event)
+        ? match(event.key, keys.Enter) || match(event.key, keys.Space)
+        : true)
     ) {
       setSelectedIndex(index);
       focusSwitch(index);
@@ -185,23 +181,32 @@ export const ContentSwitcher = ({
       className={classes}
       role="tablist"
       onChange={undefined}>
-      {children &&
-        Children.map(children, (child, index) =>
-          cloneElement(child, {
-            index,
-            onClick: composeEventHandlers([
-              handleChildChange,
-              child.props.onClick,
-            ]),
-            onKeyDown: composeEventHandlers([
-              handleChildChange,
-              child.props.onKeyDown,
-            ]),
-            selected: index === selectedIndex,
-            ref: handleItemRef(index),
-            size,
-          })
-        )}
+      {Children.map(children, (child, index) => {
+        if (
+          !isComponentElement(child, Switch) &&
+          !isComponentElement(child, IconSwitch)
+        )
+          return child;
+
+        const sharedProps = {
+          index,
+          onClick: (event: SwitchEventHandlersParams) => {
+            handleChildChange(event);
+            child.props.onClick?.(event);
+          },
+          onKeyDown: (event: SwitchEventHandlersParams) => {
+            handleChildChange(event);
+            child.props.onKeyDown?.(event);
+          },
+          selected: index === selectedIndex,
+          ref: handleItemRef(index),
+        };
+
+        return cloneElement(child, {
+          ...sharedProps,
+          ...(isComponentElement(child, IconSwitch) ? { size } : {}),
+        });
+      })}
     </LayoutConstraint>
   );
 };

--- a/packages/react/src/components/DataTable/TableSlugRow.tsx
+++ b/packages/react/src/components/DataTable/TableSlugRow.tsx
@@ -1,12 +1,17 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React, { ReactNode, useEffect } from 'react';
+import React, {
+  cloneElement,
+  isValidElement,
+  useEffect,
+  type ReactNode,
+} from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { deprecateComponent } from '../../prop-types/deprecateComponent';
@@ -39,13 +44,11 @@ const TableSlugRow = ({ className, slug }: TableSlugRowProps) => {
   });
 
   // Slug is always size `mini`
-  let normalizedSlug;
-  if (slug) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-    normalizedSlug = React.cloneElement(slug as React.ReactElement<any>, {
-      size: 'mini',
-    });
-  }
+  const normalizedSlug = isValidElement<{ size?: string }>(slug)
+    ? cloneElement(slug, {
+        size: 'mini',
+      })
+    : undefined;
 
   return <td className={TableSlugRowClasses}>{normalizedSlug}</td>;
 };

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -735,8 +735,7 @@ const Dropdown = React.forwardRef(
 interface DropdownComponent {
   <ItemType>(
     props: DropdownProps<ItemType> & { ref?: Ref<HTMLButtonElement> }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ): React.ReactElement<any> | null;
+  ): React.ReactElement | null;
 }
 
 Dropdown.displayName = 'Dropdown';

--- a/packages/react/src/components/FluidTimePicker/FluidTimePicker.tsx
+++ b/packages/react/src/components/FluidTimePicker/FluidTimePicker.tsx
@@ -1,13 +1,15 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import FluidTextInput, { FluidTextInputProps } from '../FluidTextInput';
+import FluidTimePickerSelect from '../FluidTimePickerSelect';
+import { isComponentElement } from '../../internal';
 import { usePrefix } from '../../internal/usePrefix';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 
@@ -102,18 +104,20 @@ const FluidTimePicker = React.forwardRef<
     const childrenWithProps = () => {
       if (disabled) {
         return React.Children.toArray(children).map((child) =>
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-          React.cloneElement(child as React.ReactElement<any>, {
-            disabled: true,
-          })
+          isComponentElement(child, FluidTimePickerSelect)
+            ? cloneElement(child, {
+                disabled: true,
+              })
+            : child
         );
       }
       if (readOnly) {
         return React.Children.toArray(children).map((child) =>
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-          React.cloneElement(child as React.ReactElement<any>, {
-            readOnly: true,
-          })
+          isComponentElement(child, FluidTimePickerSelect)
+            ? cloneElement(child, {
+                readOnly: true,
+              })
+            : child
         );
       }
       return children;

--- a/packages/react/src/components/FluidTimePickerSelect/FluidTimePickerSelect.tsx
+++ b/packages/react/src/components/FluidTimePickerSelect/FluidTimePickerSelect.tsx
@@ -46,6 +46,11 @@ export interface FluidTimePickerSelectProps {
    * the underlying `<input>` changes
    */
   onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+
+  /**
+   * Whether the component is read-only.
+   */
+  readOnly?: boolean;
 }
 
 // eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
@@ -97,6 +102,11 @@ FluidTimePickerSelect.propTypes = {
    * the underlying `<input>` changes
    */
   onChange: PropTypes.func,
+
+  /**
+   * Whether the component is read-only.
+   */
+  readOnly: PropTypes.bool,
 };
 
 export default FluidTimePickerSelect;

--- a/packages/react/src/components/Grid/Column.tsx
+++ b/packages/react/src/components/Grid/Column.tsx
@@ -8,7 +8,7 @@
 import { enabled } from '@carbon/feature-flags';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type ReactElement } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { useGridSettings } from './GridContext';
 import { PolymorphicComponentPropWithRef } from '../../internal/PolymorphicProps';
@@ -95,8 +95,7 @@ export interface ColumnComponent {
     props: ColumnProps<T>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
     context?: any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ): React.ReactElement<any, any> | null;
+  ): ReactElement | null;
 }
 
 // eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452

--- a/packages/react/src/components/Grid/ColumnHang.tsx
+++ b/packages/react/src/components/Grid/ColumnHang.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type ReactElement } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 
@@ -33,8 +33,7 @@ export interface ColumnHangComponent {
     props: ColumnHangProps<T>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
     context?: any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ): React.ReactElement<any, any> | null;
+  ): ReactElement | null;
 }
 
 /**

--- a/packages/react/src/components/Grid/Row.tsx
+++ b/packages/react/src/components/Grid/Row.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type ReactElement } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 
@@ -45,8 +45,7 @@ export interface RowComponent {
     props: RowProps<T>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
     context?: any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ): React.ReactElement<any, any> | null;
+  ): ReactElement | null;
 }
 
 function Row<T extends React.ElementType>({

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -1145,8 +1145,7 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
     </div>
   );
 }) as {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  <ItemType>(props: FilterableMultiSelectProps<ItemType>): ReactElement<any>;
+  <ItemType>(props: FilterableMultiSelectProps<ItemType>): ReactElement;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
   propTypes?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -908,8 +908,7 @@ interface MultiSelectComponent {
   displayName: string;
   <ItemType>(
     props: MultiSelectComponentProps<ItemType>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  ): React.ReactElement<any> | null;
+  ): React.ReactElement | null;
 }
 
 MultiSelect.displayName = 'MultiSelect';

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -9,7 +9,6 @@ import React, {
   Children,
   cloneElement,
   forwardRef,
-  isValidElement,
   RefObject,
   useCallback,
   useContext,
@@ -19,7 +18,6 @@ import React, {
   type ElementType,
   type KeyboardEvent,
   type MouseEvent,
-  type ReactElement,
   type ReactNode,
   type Ref,
 } from 'react';
@@ -41,10 +39,13 @@ import { deprecate } from '../../prop-types/deprecate';
 import { mergeRefs } from '../../tools/mergeRefs';
 import { setupGetInstanceId } from '../../tools/setupGetInstanceId';
 import { IconButton, IconButtonProps } from '../IconButton';
-import { OverflowMenuItemProps } from '../OverflowMenuItem/OverflowMenuItem';
+import OverflowMenuItem, {
+  OverflowMenuItemProps,
+} from '../OverflowMenuItem/OverflowMenuItem';
 import { useOutsideClick } from '../../internal/useOutsideClick';
 import { deprecateValuesWithin } from '../../prop-types/deprecateValuesWithin';
 import { mapPopoverAlign } from '../../tools/mapPopoverAlign';
+import { isComponentElement } from '../../internal';
 
 const getInstanceId = setupGetInstanceId();
 
@@ -531,10 +532,9 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
     );
 
     const childrenWithProps = Children.toArray(children).map((child, index) => {
-      if (isValidElement(child)) {
-        const childElement = child as ReactElement<OverflowMenuItemProps>;
-        return cloneElement(childElement, {
-          closeMenu: childElement.props.closeMenu || closeMenuAndFocus,
+      if (isComponentElement(child, OverflowMenuItem)) {
+        return cloneElement(child, {
+          closeMenu: child.props.closeMenu || closeMenuAndFocus,
           handleOverflowMenuItemFocus,
           ref: (el: HTMLElement) => {
             menuItemRefs.current[index] = el;

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -7,16 +7,16 @@
 
 import PropTypes from 'prop-types';
 import React, {
+  Children,
   cloneElement,
   createContext,
   useEffect,
   useRef,
   useState,
-  type ReactElement,
   type ReactNode,
 } from 'react';
 import classNames from 'classnames';
-import type { RadioButtonProps } from '../RadioButton';
+import RadioButton, { type RadioButtonProps } from '../RadioButton';
 import { Legend } from '../Text/createTextComponent';
 import { usePrefix } from '../../internal/usePrefix';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
@@ -177,29 +177,26 @@ const RadioButtonGroup = React.forwardRef(
     }, [valueSelected]);
 
     function getRadioButtons() {
-      const mappedChildren = React.Children.map(
-        children as ReactElement<RadioButtonProps>,
-        (radioButton) => {
-          if (!radioButton) {
-            return;
-          }
-
-          const newProps = {
-            name: name,
-            key: radioButton.props.value,
-            value: radioButton.props.value,
-            onChange: handleOnChange,
-            checked: radioButton.props.value === selected,
-            required: required,
-          };
-
-          if (!selected && radioButton.props.checked) {
-            newProps.checked = true;
-          }
-
-          return React.cloneElement(radioButton, newProps);
+      const mappedChildren = Children.map(children, (radioButton) => {
+        if (!isComponentElement(radioButton, RadioButton)) {
+          return radioButton;
         }
-      );
+
+        const newProps = {
+          name: name,
+          key: radioButton.props.value,
+          value: radioButton.props.value,
+          onChange: handleOnChange,
+          checked: radioButton.props.value === selected,
+          required: required,
+        };
+
+        if (!selected && radioButton.props.checked) {
+          newProps.checked = true;
+        }
+
+        return cloneElement(radioButton, newProps);
+      });
 
       return mappedChildren;
     }

--- a/packages/react/src/components/Theme/index.tsx
+++ b/packages/react/src/components/Theme/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,14 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { ElementType, useMemo, type PropsWithChildren } from 'react';
+import React, {
+  cloneElement,
+  isValidElement,
+  useMemo,
+  type ElementType,
+  type PropsWithChildren,
+  type Ref,
+} from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 import { LayerContext } from '../Layer/LayerContext';
@@ -34,11 +41,9 @@ export const GlobalTheme = React.forwardRef(
       };
     }, [theme]);
 
-    const childrenWithProps = React.cloneElement(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-      children as React.ReactElement<any>,
-      { ref: ref }
-    );
+    const childrenWithProps = isValidElement<{ ref?: Ref<unknown> }>(children)
+      ? cloneElement(children, { ref })
+      : children;
 
     return (
       <ThemeContext.Provider value={value}>

--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -9,14 +9,16 @@ import { CaretDown } from '@carbon/icons-react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {
+  isValidElement,
+  useCallback,
+  useContext,
   useEffect,
   useRef,
   useState,
-  useCallback,
-  useContext,
   type ElementType,
   type FocusEvent,
   type MouseEvent,
+  type ReactNode,
 } from 'react';
 import { keys, match, matches } from '../../internal/keyboard';
 import { deprecate } from '../../prop-types/deprecate';
@@ -165,9 +167,8 @@ const extractTextContent = (node: React.ReactNode): string => {
     return node.map(extractTextContent).join('');
   }
 
-  if (React.isValidElement(node)) {
-    const element = node as React.ReactElement<{ children?: React.ReactNode }>;
-    const children = element.props.children;
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    const children = node.props.children;
     return extractTextContent(children);
   }
 

--- a/packages/react/src/components/UIShell/HeaderMenu.tsx
+++ b/packages/react/src/components/UIShell/HeaderMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,26 +11,24 @@ import React, {
   Children,
   cloneElement,
   forwardRef,
-  isValidElement,
   useContext,
   useRef,
   useState,
-  type ComponentProps,
   type FocusEvent,
   type KeyboardEvent,
   type MouseEvent,
-  type ReactElement,
   type ReactNode,
   type Ref,
 } from 'react';
 import PropTypes from 'prop-types';
 import { keys, matches } from '../../internal/keyboard';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
+import { isComponentElement } from '../../internal';
 import { PrefixContext } from '../../internal/usePrefix';
 import { deprecate } from '../../prop-types/deprecate';
 import { composeEventHandlers } from '../../tools/events';
 import { useMergedRefs } from '../../internal/useMergedRefs';
-import type HeaderMenuItem from './HeaderMenuItem';
+import HeaderMenuItem from './HeaderMenuItem';
 
 export interface HeaderMenuProps {
   /**
@@ -201,7 +199,7 @@ export const HeaderMenu = frFn((props, ref) => {
 
   const hasActiveDescendant = (childrenArg: ReactNode): boolean =>
     Children.toArray(childrenArg).some((child) => {
-      if (!isValidElement<ComponentProps<typeof HeaderMenuItem>>(child)) {
+      if (!isComponentElement(child, HeaderMenuItem)) {
         return false;
       }
 
@@ -221,9 +219,8 @@ export const HeaderMenu = frFn((props, ref) => {
    * sequence when they might not want to go through all the items.
    */
   const renderMenuItem = (item: ReactNode, index: number): ReactNode => {
-    if (isValidElement(item)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-      return cloneElement(item as ReactElement<any>, {
+    if (isComponentElement(item, HeaderMenuItem)) {
+      return cloneElement(item, {
         ref: handleItemRef(index),
       });
     }

--- a/packages/react/src/internal/FloatingMenu.tsx
+++ b/packages/react/src/internal/FloatingMenu.tsx
@@ -7,7 +7,6 @@
 
 import React, {
   cloneElement,
-  JSXElementConstructor,
   useCallback,
   useContext,
   useEffect,
@@ -59,6 +58,11 @@ interface FloatingPosition {
   top: number;
 }
 
+type FloatingMenuChildProps = {
+  ref?: (node: HTMLElement | null) => void;
+  style?: CSSProperties;
+};
+
 export type MenuDirection =
   | typeof DIRECTION_LEFT
   | typeof DIRECTION_TOP
@@ -78,7 +82,7 @@ interface FloatingMenuProps {
   /**
    * Contents of the floating menu.
    */
-  children: ReactElement;
+  children: ReactElement<FloatingMenuChildProps>;
 
   /**
    * Whether the menu alignment should be flipped.
@@ -440,13 +444,7 @@ export const FloatingMenu = ({
           visibility: 'hidden',
           top: '0px',
         };
-    const child = children as ReactElement<
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-      any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-      string | JSXElementConstructor<any>
-    >;
-    return cloneElement(child, {
+    return cloneElement(children, {
       ref: handleMenuRef,
       style: {
         ...styles,

--- a/packages/react/src/tools/wrapComponent.ts
+++ b/packages/react/src/tools/wrapComponent.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { type HTMLAttributes } from 'react';
+import React, { type HTMLAttributes, type ReactElement } from 'react';
 import { usePrefix } from '../internal/usePrefix';
 
 type HTMLTagName = keyof HTMLElementTagNameMap;
@@ -26,10 +26,7 @@ const wrapComponent = <T extends HTMLTagName>({
   name,
   className: getClassName,
   type,
-}: WrapComponentArgs<T>): ((
-  props: HTMLAttributes<T>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-) => React.ReactElement<any>) => {
+}: WrapComponentArgs<T>): ((props: HTMLAttributes<T>) => ReactElement) => {
   /**
    *
    * @param {{ className?: string, [x: string]: any}} param0
@@ -55,8 +52,7 @@ const wrapComponent = <T extends HTMLTagName>({
   Component.propTypes = {
     className: PropTypes.string,
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  return Component as (props: HTMLAttributes<T>) => React.ReactElement<any>;
+  return Component as (props: HTMLAttributes<T>) => React.ReactElement;
 };
 
 export default wrapComponent;


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Narrowed React element and child types.

### Changelog

**Changed**

- Narrowed React element and child types.

#### Testing / Reviewing

Existing tests should cover these changes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
