### PR TITLE
fix: remove native title from TableToolbarMenu

### DIFF
--- a/packages/react/src/components/DataTable/TableToolbarMenu.tsx
+++ b/packages/react/src/components/DataTable/TableToolbarMenu.tsx
@@ -37,7 +37,6 @@ const TableToolbarMenu = ({
     <OverflowMenu
       renderIcon={renderIcon}
       className={toolbarActionClasses}
-      title={iconDescription}
       iconDescription={iconDescription}
       menuOptionsClass={menuOptionsClasses}
       flipped

--- a/packages/react/src/components/DataTable/__tests__/TableToolbarMenu-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableToolbarMenu-test.js
@@ -41,7 +41,21 @@ describe('TableToolbarMenu', () => {
         </TableToolbarMenu>
       );
 
-      expect(screen.getByText('Icon description')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Icon description' })
+      ).not.toHaveAttribute('title');
+    });
+
+    it('should not render a native title attribute', () => {
+      render(
+        <TableToolbarMenu>
+          <span>test</span>
+        </TableToolbarMenu>
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Settings' })
+      ).not.toHaveAttribute('title');
     });
 
     it('should respect renderIcon prop', () => {

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -585,7 +585,6 @@ exports[`DataTable behaves as expected selection should render and match snapsho
                 aria-haspopup="true"
                 aria-labelledby="tooltip-_r_2t_"
                 class="cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--ghost cds--btn--icon-only"
-                title="Settings"
                 type="button"
               >
                 <svg
@@ -1022,7 +1021,6 @@ exports[`DataTable renders as expected - Component API should render and match s
                 aria-haspopup="true"
                 aria-labelledby="tooltip-_r_m_"
                 class="cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--ghost cds--btn--icon-only"
-                title="Settings"
                 type="button"
               >
                 <svg

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
@@ -16,7 +16,6 @@ exports[`TableToolbarMenu renders as expected - Component API should render 1`] 
           aria-haspopup="true"
           aria-labelledby="tooltip-_r_1_"
           class="custom-class cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--ghost cds--btn--icon-only"
-          title="Add"
           type="button"
         >
           <svg


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19233

Removed native `title` from `TableToolbarMenu`.

### Changelog

**Removed**

- Removed native `title` from `TableToolbarMenu`.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/DataTable
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
