### PR TITLE
fix(ExpandableSearch): fix magnifier icon tooltip size

### DIFF
--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -273,7 +273,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
     const magnifierWithTooltip =
       onExpand && !isExpanded ? (
         <Tooltip
-          className={`${prefix}--search-tooltip ${prefix}--search-magnifier-tooltip`}
+          className={`${prefix}--search-tooltip ${prefix}--search-magnifier-tooltip ${prefix}--icon-tooltip`}
           align="top"
           label="Search">
           {magnifierButton}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21567

Before:

<img width="236" height="147" alt="Bildschirmfoto 2026-04-13 um 13 58 34" src="https://github.com/user-attachments/assets/b5d1a2c2-4cfb-431d-b7d7-916215d9298b" />

After:

<img width="228" height="139" alt="Bildschirmfoto 2026-04-13 um 13 57 19" src="https://github.com/user-attachments/assets/7e6ffd25-48f8-40e1-b954-b2bcf57c945b" />


### Changelog

**Changed**

- Applied correct class for icon tooltips

#### Testing / Reviewing

- Storybook

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
