### PR TITLE
chore(mend): add unified agent scan for mend

### DIFF
--- a/.github/workflows/mend-scan.yml
+++ b/.github/workflows/mend-scan.yml
@@ -11,15 +11,16 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17' # Required to run the Mend Unified Agent .jar

--- a/.github/workflows/mend-scan.yml
+++ b/.github/workflows/mend-scan.yml
@@ -1,0 +1,40 @@
+name: Mend Scan - Carbon Monorepo
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at Midnight UTC
+  workflow_dispatch: # Allows you to run this manually from the Actions tab
+
+jobs:
+  mend-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17' # Required to run the Mend Unified Agent .jar
+
+      - name: Run Mend Scan
+        env:
+          WS_APIKEY: ${{ secrets.WS_APIKEY }}
+          WS_USERKEY: ${{ secrets.WS_USERKEY }}
+          WS_WSS_URL: ${{ secrets.WS_WSS_URL }}
+
+          # Project Configuration
+          WS_PRODUCTNAME: 'PSIRT_PRD0013444'
+          WS_PROJECTNAME: 'GH_carbon'
+        run: |
+          # Download the latest Mend Unified Agent
+          curl -L https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar -o wss-unified-agent.jar
+          # Execute the scan
+          java -jar wss-unified-agent.jar


### PR DESCRIPTION
## Description
This PR migrates the automated security scanning for **Carbon Monorepo** from Jenkins to GitHub Actions. This workflow executes the **Mend Unified Agent** to identify vulnerabilities in the codebase and synchronizes the findings with our internal PSIRT compliance tracking under product ID `PSIRT_PRD0013444`.

Moving this to GitHub Actions provides better visibility into our security posture directly within the repository and ensures scans are executed in a clean, consistent environment.

## Changes
- Created `.github/workflows/mend-scan.yml` to automate nightly security scans.
- Configured the workflow to run daily at **00:00 UTC (Midnight)**.
- Standardized the build environment using **Node.js 22** and **Java 17**.
- Optimized the scan by removing legacy Jenkins-specific flags and unused configurations.

## Security & Environment
This workflow is designed for a public repository; therefore, all sensitive routing and authentication details are handled via encrypted secrets and organization variables.

| Variable | Source | Description |
| :--- | :--- | :--- |
| `WS_APIKEY` | **Secret** | The Mend Organization API Key. |
| `WS_USERKEY` | **Secret** | The Mend User Key for authentication. |
| `WS_WSS_URL` | **Org Secret** | The internal endpoint for Mend agent data. |

## Verification
- [ ] Manual trigger (`workflow_dispatch`) tested and verified successful completion.
- [ ] Confirmed that the scan results are correctly mapped to the `GH_carbon` project in the Mend dashboard under `PSIRT_PRD0013444`.