### PR TITLE
fix(DatePicker): link invalid/warn text via aria-describedby

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -180,6 +180,56 @@ describe('DatePicker', () => {
     spy.mockRestore();
   });
 
+  describe('accessibility', () => {
+    it('associates helper text with the input using aria-describedby', () => {
+      render(
+        <DatePickerInput
+          id="date-picker-input-helper"
+          labelText="Date Picker label"
+          helperText="Helpful text"
+        />
+      );
+
+      const input = screen.getByLabelText('Date Picker label');
+      const helperText = screen.getByText('Helpful text');
+
+      expect(input).toHaveAttribute('aria-describedby', helperText.id);
+    });
+
+    it('associates invalid text with the input and marks input as invalid', () => {
+      render(
+        <DatePickerInput
+          id="date-picker-input-invalid"
+          labelText="Date Picker label"
+          invalid
+          invalidText="Invalid date"
+        />
+      );
+
+      const input = screen.getByLabelText('Date Picker label');
+      const invalidText = screen.getByText('Invalid date');
+
+      expect(input).toHaveAttribute('aria-describedby', invalidText.id);
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('associates warning text with the input using aria-describedby', () => {
+      render(
+        <DatePickerInput
+          id="date-picker-input-warn"
+          labelText="Date Picker label"
+          warn
+          warnText="Warning message"
+        />
+      );
+
+      const input = screen.getByLabelText('Date Picker label');
+      const warnText = screen.getByText('Warning message');
+
+      expect(input).toHaveAttribute('aria-describedby', warnText.id);
+    });
+  });
+
   it('should respect parseDate prop', async () => {
     const parseDate = jest.fn();
     parseDate.mockReturnValueOnce(new Date('1989/01/20'));

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -243,6 +243,15 @@ const DatePickerInput = frFn((props, ref) => {
     ? undefined
     : `datepicker-input-helper-text-${datePickerInputInstanceId}`;
 
+  let ariaDescribedBy: string | undefined;
+  if (normalizedProps.invalid) {
+    ariaDescribedBy = normalizedProps.invalidId;
+  } else if (normalizedProps.warn) {
+    ariaDescribedBy = normalizedProps.warnId;
+  } else {
+    ariaDescribedBy = helperText ? datePickerInputHelperId : undefined;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
   const inputProps: any = {
     ...rest,
@@ -250,10 +259,11 @@ const DatePickerInput = frFn((props, ref) => {
     className: inputClasses,
     disabled: normalizedProps.disabled,
     ref,
-    ['aria-describedby']: helperText ? datePickerInputHelperId : undefined,
+    ['aria-describedby']: ariaDescribedBy,
   };
   if (normalizedProps.invalid) {
     inputProps['data-invalid'] = true;
+    inputProps['aria-invalid'] = true;
   }
   const input = <input {...inputProps} />;
 


### PR DESCRIPTION
Closes #21986

Fixed `DatePickerInput` a11y so invalid/warn messages are announced by screen readers (aria-describedby + aria-invalid).

### Changelog

**New**

- None.

**Changed**

- Updated `DatePickerInput` accessibility wiring so `aria-describedby` points to:
  - invalid text when `invalid`
  - warning text when `warn`
  - helper text otherwise
- Added `aria-invalid="true"` when `DatePickerInput` is invalid
- Added tests for helper/invalid/warn accessibility behavior

**Removed**

- None.

#### Testing / Reviewing

- Go to `React Deploy Preview` > `DatePicker` > `Default`
- Turn on `VoiceOver` 
- Set `invalid` or `warn` to true and add `invalidText` or `warnText` in Storybook controls
- Confirm `VoiceOver` announces the `invalid` or `warn` message

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)