### PR TITLE
fix: include utilities as option in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -34,6 +34,7 @@ body:
         - '@carbon/themes'
         - '@carbon/type'
         - '@carbon/upgrade'
+        - '@carbon/utilities'
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
Closes #22072 

I've been doing a lot of work in the utilities package recently. I wanted to open a bug report there today, but I noticed that utilities is not an option in the bug report template

by the way, if we want to take the opportunity to add any other missing packages from this list i'm happy to include them. i'm not exactly sure what the criteria is to be included or if the other not included packages are being used as much, but i've definitely been doing some work in utilities, which is why I wanted to add it in 👍 

### Changelog

**Changed**

- include utilities as option in bug report

#### Testing / Reviewing

NA

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
