### PR TITLE
fix(grid): honour $prefix in --cds-grid-* custom properties

### DIFF
--- a/packages/grid/__tests__/css-grid-prefix-test.js
+++ b/packages/grid/__tests__/css-grid-prefix-test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const { SassRenderer } = require('@carbon/test-utils/scss');
+
+const { render } = SassRenderer.create(__dirname);
+
+describe('@carbon/grid css-grid mixin', () => {
+  it('honours $prefix for every emitted custom property', async () => {
+    const { result } = await render(`
+      @use '../scss/config' with ($prefix: 'test');
+      @use '../scss/css-grid';
+
+      @include css-grid.css-grid;
+    `);
+    const cssText = result.css.toString();
+
+    expect(cssText).not.toMatch(/--cds-/);
+
+    expect(cssText).toMatch(/--test-grid-gutter\b/);
+    expect(cssText).toMatch(/--test-grid-columns\b/);
+    expect(cssText).toMatch(/--test-grid-margin\b/);
+    expect(cssText).toMatch(/--test-grid-gutter-start\b/);
+    expect(cssText).toMatch(/--test-grid-gutter-end\b/);
+    expect(cssText).toMatch(/--test-grid-column-hang\b/);
+    expect(cssText).toMatch(/--test-grid-mode-start\b/);
+    expect(cssText).toMatch(/--test-grid-mode-end\b/);
+  });
+});

--- a/packages/grid/scss/_css-grid.scss
+++ b/packages/grid/scss/_css-grid.scss
@@ -40,7 +40,7 @@
   /// Properties, including the overall grid gutter, grid column count, and grid
   /// margin
   :root {
-    --cds-grid-gutter: #{$grid-gutter};
+    --#{$prefix}-grid-gutter: #{$grid-gutter};
 
     // Iterate through the grid breakpoints and only emit the grid-columns and
     // grid-margin CSS Custom Properties if they've changed from the previous
@@ -48,8 +48,8 @@
     // :root selector
     @each $key, $value in $breakpoints {
       @if is-smallest-breakpoint($key, $breakpoints) {
-        --cds-grid-columns: #{get-column-count($breakpoints, $key)};
-        --cds-grid-margin: #{get-margin($breakpoints, $key)};
+        --#{$prefix}-grid-columns: #{get-column-count($breakpoints, $key)};
+        --#{$prefix}-grid-margin: #{get-margin($breakpoints, $key)};
       } @else {
         $previous-breakpoint: breakpoint-prev($key, $breakpoints);
         $changes: ();
@@ -76,7 +76,7 @@
 
         @include breakpoint($key) {
           @each $name, $value in $changes {
-            --cds-#{$name}: #{$value};
+            --#{$prefix}-#{$name}: #{$value};
           }
         }
       }
@@ -87,21 +87,24 @@
   // Base CSS Grid
   // -----------------------------------------------------------------------------
   .#{$prefix}--css-grid {
-    --cds-grid-gutter-start: calc(var(--cds-grid-gutter) / 2);
-    --cds-grid-gutter-end: calc(var(--cds-grid-gutter) / 2);
+    --#{$prefix}-grid-gutter-start: calc(var(--#{$prefix}-grid-gutter) / 2);
+    --#{$prefix}-grid-gutter-end: calc(var(--#{$prefix}-grid-gutter) / 2);
     // We split out a separate "column hang" since "gutter-start" is set
     // dynamically and could be 0
-    --cds-grid-column-hang: calc(var(--cds-grid-gutter) / 2);
+    --#{$prefix}-grid-column-hang: calc(var(--#{$prefix}-grid-gutter) / 2);
 
     display: grid;
-    grid-template-columns: repeat(var(--cds-grid-columns), minmax(0, 1fr));
+    grid-template-columns: repeat(
+      var(--#{$prefix}-grid-columns),
+      minmax(0, 1fr)
+    );
     inline-size: 100%;
     margin-inline: auto;
     max-inline-size: get-grid-width(
       $breakpoints,
       largest-breakpoint-name($breakpoints)
     );
-    padding-inline: var(--cds-grid-margin);
+    padding-inline: var(--#{$prefix}-grid-margin);
   }
 
   // -----------------------------------------------------------------------------
@@ -122,13 +125,15 @@
     // grid-mode-start, grid-mode-end are meant to capture the "grid settings"
     // so that subgrids can correctly fit in parent grids by reverting the
     // grid's outer padding
-    --cds-grid-mode-start: var(--cds-grid-gutter-start);
-    --cds-grid-mode-end: var(--cds-grid-gutter-end);
+    --#{$prefix}-grid-mode-start: var(--#{$prefix}-grid-gutter-start);
+    --#{$prefix}-grid-mode-end: var(--#{$prefix}-grid-gutter-end);
 
-    margin-inline: var(--cds-grid-gutter-start) var(--cds-grid-gutter-end);
+    margin-inline: var(--#{$prefix}-grid-gutter-start)
+      var(--#{$prefix}-grid-gutter-end);
 
     [dir='rtl'] & {
-      margin-inline: var(--cds-grid-gutter-end) var(--cds-grid-gutter-start);
+      margin-inline: var(--#{$prefix}-grid-gutter-end)
+        var(--#{$prefix}-grid-gutter-start);
     }
   }
 
@@ -138,13 +143,13 @@
 
   // Narrow
   .#{$prefix}--css-grid--narrow {
-    --cds-grid-gutter-start: 0rem; /* stylelint-disable-line length-zero-no-unit */
+    --#{$prefix}-grid-gutter-start: 0rem; /* stylelint-disable-line length-zero-no-unit */
   }
 
   // Condensed
   .#{$prefix}--css-grid--condensed {
-    --cds-grid-gutter: #{$grid-gutter-condensed};
-    --cds-grid-column-hang: #{math.div($grid-gutter, 2) - math.div(
+    --#{$prefix}-grid-gutter: #{$grid-gutter-condensed};
+    --#{$prefix}-grid-column-hang: #{math.div($grid-gutter, 2) - math.div(
         $grid-gutter-condensed,
         2
       )};
@@ -169,33 +174,36 @@
   // -----------------------------------------------------------------------------
   .#{$prefix}--subgrid {
     display: grid;
-    grid-template-columns: repeat(var(--cds-grid-columns), minmax(0, 1fr));
-    margin-inline: calc(var(--cds-grid-mode-start) * -1)
-      calc(var(--cds-grid-mode-end) * -1);
+    grid-template-columns: repeat(
+      var(--#{$prefix}-grid-columns),
+      minmax(0, 1fr)
+    );
+    margin-inline: calc(var(--#{$prefix}-grid-mode-start) * -1)
+      calc(var(--#{$prefix}-grid-mode-end) * -1);
 
     [dir='rtl'] & {
-      margin-inline: calc(var(--cds-grid-mode-end) * -1)
-        calc(var(--cds-grid-mode-start) * -1);
+      margin-inline: calc(var(--#{$prefix}-grid-mode-end) * -1)
+        calc(var(--#{$prefix}-grid-mode-start) * -1);
     }
   }
 
   // Support the gutter modes in subgrids
   .#{$prefix}--subgrid--wide {
-    --cds-grid-gutter-start: #{math.div($grid-gutter, 2)};
-    --cds-grid-gutter-end: #{math.div($grid-gutter, 2)};
-    --cds-grid-column-hang: 0;
+    --#{$prefix}-grid-gutter-start: #{math.div($grid-gutter, 2)};
+    --#{$prefix}-grid-gutter-end: #{math.div($grid-gutter, 2)};
+    --#{$prefix}-grid-column-hang: 0;
   }
 
   .#{$prefix}--subgrid--narrow {
-    --cds-grid-gutter-start: 0rem; /* stylelint-disable-line length-zero-no-unit */
-    --cds-grid-gutter-end: #{math.div($grid-gutter, 2)};
-    --cds-grid-column-hang: #{math.div($grid-gutter, 2)};
+    --#{$prefix}-grid-gutter-start: 0rem; /* stylelint-disable-line length-zero-no-unit */
+    --#{$prefix}-grid-gutter-end: #{math.div($grid-gutter, 2)};
+    --#{$prefix}-grid-column-hang: #{math.div($grid-gutter, 2)};
   }
 
   .#{$prefix}--subgrid--condensed {
-    --cds-grid-gutter-start: #{math.div($grid-gutter-condensed, 2)};
-    --cds-grid-gutter-end: #{math.div($grid-gutter-condensed, 2)};
-    --cds-grid-column-hang: #{math.div($grid-gutter, 2) - math.div(
+    --#{$prefix}-grid-gutter-start: #{math.div($grid-gutter-condensed, 2)};
+    --#{$prefix}-grid-gutter-end: #{math.div($grid-gutter-condensed, 2)};
+    --#{$prefix}-grid-column-hang: #{math.div($grid-gutter, 2) - math.div(
         $grid-gutter-condensed,
         2
       )};
@@ -208,10 +216,10 @@
   // Helper class to allow for text alignment in columns where the leading
   // gutter is missing (like narrow) or is reduced (like in condensed).
   .#{$prefix}--grid-column-hang {
-    margin-inline-start: var(--cds-grid-column-hang);
+    margin-inline-start: var(--#{$prefix}-grid-column-hang);
 
     [dir='rtl'] & {
-      margin-inline: initial var(--cds-grid-column-hang);
+      margin-inline: initial var(--#{$prefix}-grid-column-hang);
     }
   }
 
@@ -258,21 +266,21 @@
 
       .#{$prefix}--#{$name}\:col-span-75 {
         $span: $columns * 0.75;
-        --cds-grid-columns: #{$span};
+        --#{$prefix}-grid-columns: #{$span};
 
         grid-column: span list.slash($span, span) #{$span};
       }
 
       .#{$prefix}--#{$name}\:col-span-50 {
         $span: $columns * 0.5;
-        --cds-grid-columns: #{$span};
+        --#{$prefix}-grid-columns: #{$span};
 
         grid-column: span list.slash($span, span) #{$span};
       }
 
       .#{$prefix}--#{$name}\:col-span-25 {
         $span: $columns * 0.25;
-        --cds-grid-columns: #{$span};
+        --#{$prefix}-grid-columns: #{$span};
 
         grid-column: span list.slash($span, span) #{$span};
       }
@@ -290,21 +298,21 @@
 
         .#{$prefix}--#{$name}\:col-span-75 {
           $span: $columns * 0.75;
-          --cds-grid-columns: #{$span};
+          --#{$prefix}-grid-columns: #{$span};
 
           grid-column: span list.slash($span, span) #{$span};
         }
 
         .#{$prefix}--#{$name}\:col-span-50 {
           $span: $columns * 0.5;
-          --cds-grid-columns: #{$span};
+          --#{$prefix}-grid-columns: #{$span};
 
           grid-column: span list.slash($span, span) #{$span};
         }
 
         .#{$prefix}--#{$name}\:col-span-25 {
           $span: $columns * 0.25;
-          --cds-grid-columns: #{$span};
+          --#{$prefix}-grid-columns: #{$span};
 
           grid-column: span list.slash($span, span) #{$span};
         }
@@ -422,7 +430,7 @@
   @if $i == 0 {
     display: none;
   } @else {
-    --cds-grid-columns: #{$i};
+    --#{$prefix}-grid-columns: #{$i};
 
     display: block;
     grid-column: span $i / span $i;
@@ -437,7 +445,7 @@
     $span: $columns * $percent;
 
     @if is-smallest-breakpoint($key, $breakpoints) {
-      --cds-grid-columns: #{$span};
+      --#{$prefix}-grid-columns: #{$span};
 
       grid-column: span list.slash($span, span) #{$span};
     } @else {
@@ -450,7 +458,7 @@
 
       @if $span != $previous-span {
         @include breakpoint($key) {
-          --cds-grid-columns: #{$span};
+          --#{$prefix}-grid-columns: #{$span};
 
           grid-column: span list.slash($span, span) #{$span};
         }


### PR DESCRIPTION
Closes # — N/A, drive-by fix; happy to file an issue first if preferred.

Roughly forty CSS custom-property names in
`packages/grid/scss/_css-grid.scss` are emitted with a hard-coded
`--cds-` literal instead of interpolating `$prefix`
(`--cds-grid-gutter`, `--cds-grid-columns`, `--cds-grid-margin`,
`--cds-grid-gutter-start/end`, `--cds-grid-column-hang`, the
`--cds-#{$name}` interpolation inside the breakpoint loop, and the
matching `var(...)` references). `$prefix` is otherwise honoured
throughout `@carbon/grid` and is documented as a configurable hook for
forks and white-labels, so the literals make the module internally
inconsistent: a consumer who sets `$prefix: 'foo'` ends up with
`.foo--css-grid` selectors that reference variables under
`--cds-grid-*` which are never declared, and the grid quietly stops
laying out.

### Changelog

**New**

- N/A

**Changed**

- Every `--cds-grid-*` custom property declared or referenced in
  `_css-grid.scss` (and the `--cds-#{$name}` interpolation inside the
  breakpoint loop) now interpolates `$prefix`, matching the rest of
  `@carbon/grid`.

**Removed**

- N/A

#### Testing / Reviewing

- `yarn jest packages/grid/__tests__` passes. A new
  `packages/grid/__tests__/css-grid-prefix-test.js` compiles the
  `css-grid` mixin with `$prefix: 'test'` and asserts the emitted CSS
  contains `--test-grid-gutter`, `--test-grid-columns`,
  `--test-grid-margin`, `--test-grid-gutter-start`,
  `--test-grid-gutter-end`, `--test-grid-column-hang`,
  `--test-grid-mode-start` and `--test-grid-mode-end`, while no
  `--cds-` substring remains.
- The existing snapshot test in `packages/grid/__tests__/scss-test.js`
  is unaffected (the public Sass API is unchanged).
- `yarn workspace @carbon/grid build` passes.
