### PR TITLE
feat: test Idiomatic lit life cycle pattern

### DIFF
--- a/packages/web-components/src/components/date-picker/date-picker-input.ts
+++ b/packages/web-components/src/components/date-picker/date-picker-input.ts
@@ -346,7 +346,7 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
     `;
   }
 
-  updated() {
+  updated(changedProperties) {
     this.toggleAttribute('ai-label', this._hasAILabel);
     const label = this.shadowRoot?.querySelector("slot[name='ai-label']");
 
@@ -362,6 +362,22 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
           `${prefix}--slug--revert`,
           this.querySelector(`${prefix}-slug`)?.hasAttribute('revert-active')
         );
+    }
+
+    // Notify parent date-picker when kind changes so it can reinitialize the calendar
+    if (changedProperties.has('kind')) {
+      this.dispatchEvent(
+        new CustomEvent(
+          (this.constructor as typeof CDSDatePickerInput).eventKindChanged,
+          {
+            bubbles: true,
+            composed: true,
+            detail: {
+              kind: this.kind,
+            },
+          }
+        )
+      );
     }
   }
 
@@ -396,6 +412,13 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
    */
   static get aiLabelItem() {
     return `${prefix}-ai-label`;
+  }
+
+  /**
+   * The name of the custom event fired when the kind attribute changes.
+   */
+  static get eventKindChanged() {
+    return `${prefix}-date-picker-input-kind-changed`;
   }
 
   static shadowRootOptions = {

--- a/packages/web-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.stories.ts
@@ -460,6 +460,74 @@ export const SingleWithCalendarWithLayer = {
   },
 };
 
+const setDatePickerKind =
+  (kind: 'simple' | 'single') =>
+  (event: Event & { currentTarget: Element }) => {
+    const container = event.currentTarget.closest(
+      '[data-date-picker-kind-switching]'
+    );
+    const input = container?.querySelector(
+      `${prefix}-date-picker-input`
+    ) as HTMLElement | null;
+    const status = container?.querySelector(
+      '[data-date-picker-kind-status]'
+    ) as HTMLElement | null;
+
+    input?.setAttribute('kind', kind);
+
+    if (status) {
+      status.textContent = `Current kind: ${kind}`;
+    }
+  };
+
+export const KindSwitchingRegression = {
+  args: { ...defaultArgs, placeholder: 'mm/dd/yyyy', size: INPUT_SIZE.MEDIUM },
+  argTypes: {
+    placeholder: controls.placeholder,
+    size: controls.size,
+  },
+  render: ({ placeholder, size }) => {
+    const switchToSimple = setDatePickerKind('simple');
+    const switchToSingle = setDatePickerKind('single');
+
+    return html`
+      <div
+        data-date-picker-kind-switching
+        style="display:grid;gap:1rem;max-width:20rem;">
+        <div style="display:flex;gap:0.75rem;align-items:center;">
+          <cds-button size="sm" kind="secondary" @click="${switchToSimple}">
+            Switch to simple
+          </cds-button>
+          <cds-button size="sm" @click="${switchToSingle}">
+            Switch to single
+          </cds-button>
+        </div>
+        <p
+          data-date-picker-kind-status
+          style="margin:0;color:#525252;font-size:0.875rem;">
+          Current kind: simple
+        </p>
+        <cds-date-picker>
+          <cds-date-picker-input
+            kind="simple"
+            label-text="Date Picker label"
+            placeholder="${placeholder}"
+            size="${size}">
+          </cds-date-picker-input>
+        </cds-date-picker>
+      </div>
+    `;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Manual regression case for dynamic `kind` switching. Toggle the same input between `simple` and `single` to verify that the calendar is created and destroyed correctly.',
+      },
+    },
+  },
+};
+
 const skeletonControls = {
   hideLabel: {
     control: 'boolean',

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -228,6 +228,18 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
       .join('/');
   };
 
+  /**
+   * Handles `${prefix}-date-picker-input-kind-changed` event on child input elements.
+   * Reinitializes the calendar when the kind attribute changes.
+   */
+  @HostListener('eventKindChanged')
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleKindChanged = () => {
+    // Reinitialize the date picker when kind changes
+    this._instantiateDatePicker();
+  };
+
   _handleFormdata(event: FormDataEvent) {
     const { formData } = event;
     const { disabled, name, value } = this;
@@ -699,6 +711,13 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
    */
   static get eventChange() {
     return `${prefix}-date-picker-changed`;
+  }
+
+  /**
+   * The name of the custom event fired when a child input's kind attribute changes.
+   */
+  static get eventKindChanged() {
+    return `${prefix}-date-picker-input-kind-changed`;
   }
 
   static styles = styles;


### PR DESCRIPTION
Contributes to #21905 

DO NOT MERGE
built for example
this pr uses the HostListener and event driven communication among child and parent components with lit's idiomatic lifecycle patterns to re-instantiate the date picker.
these patterns are already seen in existing dropdown/combobox etc.

[preview](https://deploy-preview-22101--v11-carbon-web-components.netlify.app/?path=/story/components-date-picker--kind-switching-regression)



### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
