### PR TITLE
feat: add tooltip position to pagination buttons

### DIFF
--- a/packages/web-components/src/components/pagination/__tests__/pagination-test.js
+++ b/packages/web-components/src/components/pagination/__tests__/pagination-test.js
@@ -24,6 +24,24 @@ describe('cds-pagination', () => {
     expect(buttons?.[1]?.getAttribute('tooltip-text')).to.equal('Next');
   });
 
+  it('should respect backward-text-tooltip-position and forward-text-tooltip-position attributes', async () => {
+    const el = await fixture(html`
+      <cds-pagination
+        total-items="20"
+        backward-text="Back"
+        backward-text-tooltip-position="bottom"
+        forward-text="Next"
+        forward-text-tooltip-position="left">
+        <cds-select-item value="10">10</cds-select-item>
+      </cds-pagination>
+    `);
+    await el.updateComplete;
+
+    const buttons = el.shadowRoot?.querySelectorAll('cds-button');
+    expect(buttons?.[0]?.getAttribute('tooltip-position')).to.equal('bottom');
+    expect(buttons?.[1]?.getAttribute('tooltip-position')).to.equal('left');
+  });
+
   it('should disable navigation buttons when disabled', async () => {
     const el = await fixture(html`
       <cds-pagination disabled total-items="20">

--- a/packages/web-components/src/components/pagination/defs.ts
+++ b/packages/web-components/src/components/pagination/defs.ts
@@ -24,3 +24,28 @@ export enum PAGINATION_SIZE {
    */
   LARGE = 'lg',
 }
+
+/**
+ * Backward/Forward button tooltip position.
+ */
+export enum PAGINATION_TOOLTIP_POSITION {
+  /**
+   * Positioned on the top.
+   */
+  TOP = 'top',
+
+  /**
+   * Positioned on the right.
+   */
+  RIGHT = 'right',
+
+  /**
+   * Positioned on the bottom.
+   */
+  BOTTOM = 'bottom',
+
+  /**
+   * Positioned on the left.
+   */
+  LEFT = 'left',
+}

--- a/packages/web-components/src/components/pagination/pagination.stories.ts
+++ b/packages/web-components/src/components/pagination/pagination.stories.ts
@@ -8,7 +8,7 @@
 import './index';
 import '../select/index';
 
-import { PAGINATION_SIZE } from './defs';
+import { PAGINATION_SIZE, PAGINATION_TOOLTIP_POSITION } from './defs';
 import { html } from 'lit';
 import { action } from 'storybook/actions';
 
@@ -20,8 +20,10 @@ const sizes = {
 
 const args = {
   backwardText: 'Previous',
+  backwardTextTooltipPosition: PAGINATION_TOOLTIP_POSITION.TOP,
   disabled: false,
   forwardText: 'Next',
+  forwardTextTooltipPosition: PAGINATION_TOOLTIP_POSITION.TOP,
   isLastPage: false,
   itemsPerPageText: 'Items per page:',
   page: 1,
@@ -38,6 +40,17 @@ const argTypes = {
     control: 'text',
     description: 'The description for the backward icon.',
   },
+  backwardTextTooltipPosition: {
+    control: 'radio',
+    description:
+      'Specify the position of the tooltip for the backward button. Can be one of: top, right, bottom, or left.',
+    options: [
+      PAGINATION_TOOLTIP_POSITION.TOP,
+      PAGINATION_TOOLTIP_POSITION.RIGHT,
+      PAGINATION_TOOLTIP_POSITION.BOTTOM,
+      PAGINATION_TOOLTIP_POSITION.LEFT,
+    ],
+  },
   disabled: {
     control: 'boolean',
     description:
@@ -46,6 +59,17 @@ const argTypes = {
   forwardText: {
     control: 'text',
     description: 'The description for the forward icon.',
+  },
+  forwardTextTooltipPosition: {
+    control: 'radio',
+    description:
+      'Specify the position of the tooltip for the forward button. Can be one of: top, right, bottom, or left.',
+    options: [
+      PAGINATION_TOOLTIP_POSITION.TOP,
+      PAGINATION_TOOLTIP_POSITION.RIGHT,
+      PAGINATION_TOOLTIP_POSITION.BOTTOM,
+      PAGINATION_TOOLTIP_POSITION.LEFT,
+    ],
   },
   isLastPage: {
     control: 'boolean',
@@ -95,8 +119,10 @@ export const Default = {
   render: (args) => {
     const {
       backwardText,
+      backwardTextTooltipPosition,
       disabled,
       forwardText,
+      forwardTextTooltipPosition,
       isLastPage,
       itemsPerPageText,
       page,
@@ -110,8 +136,10 @@ export const Default = {
     return html`
       <cds-pagination
         backward-text=${backwardText}
+        backward-text-tooltip-position=${backwardTextTooltipPosition}
         ?disabled=${disabled}
         forward-text=${forwardText}
+        forward-text-tooltip-position=${forwardTextTooltipPosition}
         ?is-last-page=${isLastPage}
         items-per-page-text=${itemsPerPageText}
         page=${page}
@@ -141,8 +169,10 @@ export const MultiplePaginationComponents = {
   render: (args) => {
     const {
       backwardText,
+      backwardTextTooltipPosition,
       disabled,
       forwardText,
+      forwardTextTooltipPosition,
       isLastPage,
       itemsPerPageText,
       page,
@@ -156,8 +186,10 @@ export const MultiplePaginationComponents = {
     return html`
       <cds-pagination
         backward-text=${backwardText}
+        backward-text-tooltip-position=${backwardTextTooltipPosition}
         ?disabled=${disabled}
         forward-text=${forwardText}
+        forward-text-tooltip-position=${forwardTextTooltipPosition}
         ?is-last-page=${isLastPage}
         items-per-page-text=${itemsPerPageText}
         page=${page}
@@ -181,8 +213,10 @@ export const MultiplePaginationComponents = {
       </cds-pagination>
       <cds-pagination
         backward-text=${backwardText}
+        backward-text-tooltip-position=${backwardTextTooltipPosition}
         ?disabled=${disabled}
         forward-text=${forwardText}
+        forward-text-tooltip-position=${forwardTextTooltipPosition}
         ?is-last-page=${isLastPage}
         items-per-page-text=${itemsPerPageText}
         page=${page}
@@ -217,8 +251,10 @@ export const PaginationUnknownPages = {
   render: (args) => {
     const {
       backwardText,
+      backwardTextTooltipPosition,
       disabled,
       forwardText,
+      forwardTextTooltipPosition,
       isLastPage,
       itemsPerPageText,
       page,
@@ -233,8 +269,10 @@ export const PaginationUnknownPages = {
     return html`
       <cds-pagination
         backward-text=${backwardText}
+        backward-text-tooltip-position=${backwardTextTooltipPosition}
         ?disabled=${disabled}
         forward-text=${forwardText}
+        forward-text-tooltip-position=${forwardTextTooltipPosition}
         ?is-last-page=${isLastPage}
         items-per-page-text=${itemsPerPageText}
         page=${page}
@@ -264,8 +302,10 @@ export const PaginationWithCustomPageSizesLabel = {
   render: (args) => {
     const {
       backwardText,
+      backwardTextTooltipPosition,
       disabled,
       forwardText,
+      forwardTextTooltipPosition,
       isLastPage,
       itemsPerPageText,
       page,
@@ -279,8 +319,10 @@ export const PaginationWithCustomPageSizesLabel = {
     return html`
       <cds-pagination
         backward-text=${backwardText}
+        backward-text-tooltip-position=${backwardTextTooltipPosition}
         ?disabled=${disabled}
         forward-text=${forwardText}
+        forward-text-tooltip-position=${forwardTextTooltipPosition}
         ?is-last-page=${isLastPage}
         items-per-page-text=${itemsPerPageText}
         page=${page}

--- a/packages/web-components/src/components/pagination/pagination.ts
+++ b/packages/web-components/src/components/pagination/pagination.ts
@@ -16,7 +16,7 @@ import CaretRight16 from '@carbon/icons/es/caret--right/16.js';
 import FocusMixin from '../../globals/mixins/focus';
 import HostListener from '../../globals/decorators/host-listener';
 import HostListenerMixin from '../../globals/mixins/host-listener';
-import { PAGINATION_SIZE } from './defs';
+import { PAGINATION_SIZE, PAGINATION_TOOLTIP_POSITION } from './defs';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { iconLoader } from '../../globals/internal/icon-loader';
 import { prefix } from '../../globals/settings';
@@ -239,6 +239,12 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
   backwardText = 'Previous page';
 
   /**
+   * Specify the position of the tooltip for the backward button. Can be one of: top, right, bottom, or left.
+   */
+  @property({ attribute: 'backward-text-tooltip-position' })
+  backwardTextTooltipPosition = PAGINATION_TOOLTIP_POSITION.TOP;
+
+  /**
    * The current page
    */
   @property({ type: Number, reflect: true })
@@ -299,6 +305,12 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
    */
   @property({ attribute: 'forward-text' })
   forwardText = 'Next page';
+
+  /**
+   * Specify the position of the tooltip for the forward button. Can be one of: top, right, bottom, or left.
+   */
+  @property({ attribute: 'forward-text-tooltip-position' })
+  forwardTextTooltipPosition = PAGINATION_TOOLTIP_POSITION.TOP;
 
   /**
    * true if the select box to change the page should be disabled.
@@ -429,7 +441,9 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
       page,
       disabled,
       forwardText,
+      forwardTextTooltipPosition,
       backwardText,
+      backwardTextTooltipPosition,
       itemsPerPageText,
       pageInputDisabled,
       pageSize,
@@ -545,6 +559,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
 
         <div class="${prefix}--pagination__control-buttons">
           <cds-button
+            tooltip-position=${backwardTextTooltipPosition}
             pagination
             size="${size}"
             ?disabled="${prevButtonDisabled}"
@@ -554,7 +569,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
             ${iconLoader(CaretLeft16, { slot: 'icon' })}
           </cds-button>
           <cds-button
-            tooltip-position="top"
+            tooltip-position=${forwardTextTooltipPosition}
             pagination
             size="${size}"
             ?disabled="${nextButtonDisabled}"


### PR DESCRIPTION
Closes #22106 

adds tooltip position options to the pagination component api

### Changelog

**New**

- `backward-text-tooltip-position` in `pagination.ts`
- `forward-text-tooltip-position` in `pagination.ts`

#### Testing / Reviewing

added test in `pagination-test.js` and manual testing in storybook

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
