### PR TITLE
fix(time-picker): announce invalid/warn state message

### DIFF
--- a/packages/react/src/components/TimePicker/TimePicker-test.js
+++ b/packages/react/src/components/TimePicker/TimePicker-test.js
@@ -177,6 +177,15 @@ describe('TimePicker', () => {
       expect(
         container.querySelector('.cds--form-requirement')
       ).toHaveTextContent('Invalid time');
+      const invalidText = screen.getByText('Invalid time');
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-describedby',
+        invalidText.id
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
     });
 
     it('should show warning state when warning is true', () => {
@@ -192,6 +201,12 @@ describe('TimePicker', () => {
       expect(
         container.querySelector('.cds--form-requirement')
       ).toHaveTextContent('Warning message');
+      const warningText = screen.getByText('Warning message');
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-describedby',
+        warningText.id
+      );
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
     });
 
     it('should not show invalid state when disabled', () => {
@@ -288,6 +303,35 @@ describe('TimePicker', () => {
       expect(
         container.querySelector('.cds--time-picker__input-field-error')
       ).not.toBeInTheDocument();
+    });
+
+    it('should preserve provided aria-describedby when not invalid or warning', () => {
+      render(<TimePicker id="time-picker" aria-describedby="custom-hint" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-describedby',
+        'custom-hint'
+      );
+    });
+
+    it('should apply invalid aria attributes over conflicting consumer props', () => {
+      render(
+        <TimePicker
+          id="time-picker"
+          invalid
+          invalidText="Invalid time"
+          aria-describedby="custom-hint"
+          aria-invalid={false}
+        />
+      );
+      const invalidText = screen.getByText('Invalid time');
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-describedby',
+        invalidText.id
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
     });
   });
 });

--- a/packages/react/src/components/TimePicker/TimePicker-test.js
+++ b/packages/react/src/components/TimePicker/TimePicker-test.js
@@ -313,7 +313,7 @@ describe('TimePicker', () => {
       );
     });
 
-    it('should apply invalid aria attributes over conflicting consumer props', () => {
+    it('should merge invalid aria attributes with consumer-provided aria-describedby', () => {
       render(
         <TimePicker
           id="time-picker"
@@ -326,12 +326,29 @@ describe('TimePicker', () => {
       const invalidText = screen.getByText('Invalid time');
       expect(screen.getByRole('textbox')).toHaveAttribute(
         'aria-describedby',
-        invalidText.id
+        `${invalidText.id} custom-hint`
       );
       expect(screen.getByRole('textbox')).toHaveAttribute(
         'aria-invalid',
         'true'
       );
+    });
+
+    it('should merge warning aria attributes with consumer-provided aria-describedby', () => {
+      render(
+        <TimePicker
+          id="time-picker"
+          warning
+          warningText="Warning message"
+          aria-describedby="custom-hint"
+        />
+      );
+      const warningText = screen.getByText('Warning message');
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-describedby',
+        `${warningText.id} custom-hint`
+      );
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
     });
   });
 });

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -269,11 +269,17 @@ const TimePicker = frFn((props, ref) => {
   const readOnlyProps = {
     readOnly: readOnly,
   };
-  const describedBy = normalizedProps.invalid
-    ? normalizedProps.invalidId
-    : normalizedProps.warn
-      ? normalizedProps.warnId
-      : ariaDescribedBy;
+  const describedBy =
+    [
+      normalizedProps.invalid
+        ? normalizedProps.invalidId
+        : normalizedProps.warn
+          ? normalizedProps.warnId
+          : null,
+      ariaDescribedBy,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   return (
     <div className={cx(`${prefix}--form-item`, className)}>

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -142,6 +142,7 @@ const frFn = forwardRef<HTMLInputElement, TimePickerProps>;
 
 const TimePicker = frFn((props, ref) => {
   const {
+    ['aria-describedby']: ariaDescribedBy,
     children,
     className,
     inputClassName,
@@ -268,6 +269,11 @@ const TimePicker = frFn((props, ref) => {
   const readOnlyProps = {
     readOnly: readOnly,
   };
+  const describedBy = normalizedProps.invalid
+    ? normalizedProps.invalidId
+    : normalizedProps.warn
+      ? normalizedProps.warnId
+      : ariaDescribedBy;
 
   return (
     <div className={cx(`${prefix}--form-item`, className)}>
@@ -290,6 +296,8 @@ const TimePicker = frFn((props, ref) => {
             value={value}
             {...rest}
             {...readOnlyProps}
+            aria-describedby={describedBy}
+            aria-invalid={normalizedProps.invalid ? true : undefined}
           />
           {(normalizedProps.invalid || normalizedProps.warn) &&
             normalizedProps.icon && (


### PR DESCRIPTION
Closes #19596

Fixed `TimePicker` a11y so invalid and warning messages are announced by screen readers.

### Changelog

**New**

- ~None~

**Changed**

- Updated `TimePicker` accessibility wiring so `aria-describedby` points to the `invalid` text when invalid is true and `warning` text when warning is true
- Preserved any consumer-provided `aria-describedby` values by merging them with the generated validation message ID
- Added `aria-invalid="true"` when `TimePicker` is invalid
- Added tests for `TimePicker` invalid/warning, and merged `aria-describedby` behavior

**Removed**

- ~None~

#### Testing / Reviewing

- Go to `React Deploy Preview` > `TimePicker` > `Default`
- Turn on a screen reader, such as `VoiceOver` or `JAWS`
- Set `invalid to true` or `warning to true` and `provide invalidText` or `provide warningText`, for example `This is test message`
- Focus or re-navigate to the TimePicker input
- Confirm the screen reader announces the invalid or warn message

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)