### PR TITLE
feat(password-input): new `xs` size

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7978,6 +7978,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",

--- a/packages/react/src/components/TextInput/PasswordInput.stories.js
+++ b/packages/react/src/components/TextInput/PasswordInput.stories.js
@@ -113,7 +113,7 @@ Default.argTypes = {
     action: 'onClick',
   },
   size: {
-    options: ['sm', 'md', 'lg', 'xl'],
+    options: ['xs', 'sm', 'md', 'lg'],
     control: {
       type: 'select',
     },

--- a/packages/react/src/components/TextInput/PasswordInput.tsx
+++ b/packages/react/src/components/TextInput/PasswordInput.tsx
@@ -139,9 +139,9 @@ export interface PasswordInputProps
   showPasswordLabel?: string;
 
   /**
-   * Specify the size of the Text Input. Supports `sm`, `md`, or `lg`.
+   * Specify the size of the Text Input. Supports `xs`, `sm`, `md`, or `lg`.
    */
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 
   /**
    * Specify the alignment of the tooltip to the icon-only button.
@@ -195,7 +195,7 @@ const PasswordInput = forwardRef<unknown, PasswordInputProps>(
       onTogglePasswordVisibility,
       placeholder,
       readOnly,
-      size = 'md',
+      size,
       showPasswordLabel = 'Show password',
       tooltipPosition = 'bottom',
       tooltipAlignment = 'end',
@@ -233,7 +233,6 @@ const PasswordInput = forwardRef<unknown, PasswordInputProps>(
         [`${prefix}--text-input--invalid`]: normalizedProps.invalid,
         [`${prefix}--text-input--warning`]: normalizedProps.warn,
         [`${prefix}--text-input--${size}`]: size, // TODO: V12 - Remove this class
-        [`${prefix}--layout--size-${size}`]: size,
       }
     );
     const sharedTextInputProps = {
@@ -288,6 +287,7 @@ const PasswordInput = forwardRef<unknown, PasswordInputProps>(
       `${prefix}--text-input__field-wrapper`,
       {
         [`${prefix}--text-input__field-wrapper--warning`]: normalizedProps.warn,
+        [`${prefix}--layout--size-${size}`]: size,
       }
     );
     const iconClasses = classNames({
@@ -529,9 +529,9 @@ PasswordInput.propTypes = {
   showPasswordLabel: PropTypes.string,
 
   /**
-   * Specify the size of the Text Input. Supports `sm`, `md`, or `lg`.
+   * Specify the size of the Text Input. Supports `xs`, `sm`, `md`, or `lg`.
    */
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * Specify the alignment of the tooltip to the icon-only button.

--- a/packages/react/src/components/TextInput/__tests__/PasswordInput-test.js
+++ b/packages/react/src/components/TextInput/__tests__/PasswordInput-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -205,13 +205,18 @@ describe('PasswordInput', () => {
     });
 
     it('should respect size prop', () => {
-      render(
+      const { container } = render(
         <PasswordInput id="input-1" labelText="PasswordInput label" size="sm" />
       );
 
       expect(screen.getByLabelText('PasswordInput label')).toHaveClass(
         `${prefix}--text-input--sm`
       );
+
+      const fieldWrapper = container.querySelector(
+        `.${prefix}--text-input__field-wrapper`
+      );
+      expect(fieldWrapper).toHaveClass(`${prefix}--layout--size-sm`);
     });
 
     it('should respect type prop', () => {

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -61,15 +61,7 @@
   }
 
   .#{$prefix}--password-input {
-    padding-inline-end: $spacing-08;
-  }
-
-  .#{$prefix}--text-input--sm.#{$prefix}--password-input {
-    padding-inline-end: $spacing-07;
-  }
-
-  .#{$prefix}--text-input--lg.#{$prefix}--password-input {
-    padding-inline-end: $spacing-09;
+    padding-inline-end: layout.size('height');
   }
 
   .#{$prefix}--text-input::placeholder {
@@ -123,31 +115,24 @@
     justify-content: center;
     padding: 0;
     border: 0;
+    aspect-ratio: 1;
     background: none;
     block-size: 100%;
     cursor: pointer;
-    inline-size: convert.to-rem(40px);
     inset-inline-end: 0;
     min-block-size: auto;
     transition: outline $duration-fast-01 motion(standard, productive);
   }
 
   .#{$prefix}--toggle-password-tooltip .#{$prefix}--popover {
-    inset-inline-start: -($spacing-08);
+    @include layout.use('size', $default: 'md', $min: 'xs', $max: 'lg');
+
+    gap: $spacing-02;
+    inset-inline-start: calc(-1 * (layout.size('height')));
   }
 
   .#{$prefix}--toggle-password-tooltip .#{$prefix}--popover-content {
     min-inline-size: $spacing-08;
-  }
-
-  .#{$prefix}--text-input--sm
-    + .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger {
-    inline-size: convert.to-rem(32px);
-  }
-
-  .#{$prefix}--text-input--lg
-    + .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger {
-    inline-size: convert.to-rem(48px);
   }
 
   .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -149,17 +149,15 @@
     padding-inline-end: $spacing-08;
   }
 
-  .#{$prefix}--text-input--invalid.#{$prefix}--password-input {
-    padding-inline-end: convert.to-rem(64px);
-  }
-
-  .#{$prefix}--text-input--invalid
-    + .#{$prefix}--text-input--password__visibility__toggle {
-    inset-inline-end: $spacing-05;
+  .#{$prefix}--text-input--invalid.#{$prefix}--password-input,
+  .#{$prefix}--text-input--warning.#{$prefix}--password-input {
+    padding-inline-end: calc(layout.size('height') + 1.5rem);
   }
 
   .#{$prefix}--password-input-wrapper .#{$prefix}--text-input__invalid-icon {
-    inset-inline-end: $spacing-08;
+    @include layout.use('size', $default: 'md', $min: 'xs', $max: 'lg');
+
+    inset-inline-end: layout.size('height');
   }
 
   .#{$prefix}--text-input:disabled
@@ -236,10 +234,6 @@
     @include focus-outline('invalid');
 
     box-shadow: none;
-
-    .#{$prefix}--text-input--password__visibility__toggle {
-      inset-inline-end: $spacing-08;
-    }
   }
 
   //-----------------------------

--- a/packages/web-components/src/components/fluid-password-input/fluid-password-input.scss
+++ b/packages/web-components/src/components/fluid-password-input/fluid-password-input.scss
@@ -47,22 +47,7 @@ $css--plex: true !default;
     inline-size: 100%;
   }
 
-  .#{$prefix}--btn--icon-only {
-    border: none;
-    background-color: transparent;
-    block-size: 100%;
-    cursor: pointer;
-    inline-size: 100%;
-
-    &:focus {
-      @include focus-outline('outline');
-    }
-  }
-
   .#{$prefix}--text-input--password__visibility__toggle svg {
     pointer-events: none;
-  }
-  .#{$prefix}--toggle-password-tooltip {
-    block-size: 100%;
   }
 }

--- a/packages/web-components/src/components/password-input/__tests__/password-input-test.js
+++ b/packages/web-components/src/components/password-input/__tests__/password-input-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -146,6 +146,16 @@ describe('cds-password-input', () => {
     const classList = input?.classList || [];
     expect(
       Array.from(classList).some((cls) => cls.includes('--text-input--sm'))
+    ).to.be.true;
+
+    const fieldWrapper = el.shadowRoot.querySelector(
+      '.cds--text-input__field-wrapper'
+    );
+    const fieldWrapperClassList = fieldWrapper?.classList || [];
+    expect(
+      Array.from(fieldWrapperClassList).some((cls) =>
+        cls.includes('--layout--size-sm')
+      )
     ).to.be.true;
   });
 

--- a/packages/web-components/src/components/password-input/defs.ts
+++ b/packages/web-components/src/components/password-input/defs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,6 +11,11 @@ export { FORM_ELEMENT_COLOR_SCHEME as INPUT_COLOR_SCHEME } from '../../globals/s
  * Input size.
  */
 export enum INPUT_SIZE {
+  /**
+   * Extra small size.
+   */
+  EXTRA_SMALL = 'xs',
+
   /**
    * Small size.
    */

--- a/packages/web-components/src/components/password-input/password-input.scss
+++ b/packages/web-components/src/components/password-input/password-input.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2025
+// Copyright IBM Corp. 2025, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -42,18 +42,6 @@ $css--plex: true !default;
   #{$prefix}-tooltip::part(popover-container) {
     block-size: 100%;
     inline-size: 100%;
-  }
-
-  .#{$prefix}--btn--icon-only {
-    border: none;
-    background-color: transparent;
-    block-size: 100%;
-    cursor: pointer;
-    inline-size: 100%;
-
-    &:focus {
-      @include focus-outline('outline');
-    }
   }
 
   .#{$prefix}--text-input--password__visibility__toggle svg {

--- a/packages/web-components/src/components/password-input/password-input.scss
+++ b/packages/web-components/src/components/password-input/password-input.scss
@@ -20,10 +20,6 @@ $css--plex: true !default;
 
   inline-size: 100%;
   outline: none;
-  padding-inline-end: $spacing-08;
-  .#{$prefix}--text-input__invalid-icon {
-    inset-inline-end: $spacing-08;
-  }
   .#{$prefix}--icon-visibility-on,
   .#{$prefix}--icon-visibility-off {
     vertical-align: middle;

--- a/packages/web-components/src/components/password-input/password-input.stories.ts
+++ b/packages/web-components/src/components/password-input/password-input.stories.ts
@@ -17,6 +17,7 @@ import {
 } from './password-input';
 
 const sizes = {
+  [`Extra small size (${INPUT_SIZE.EXTRA_SMALL})`]: INPUT_SIZE.EXTRA_SMALL,
   [`Small size (${INPUT_SIZE.SMALL})`]: INPUT_SIZE.SMALL,
   [`Medium size (${INPUT_SIZE.MEDIUM})`]: INPUT_SIZE.MEDIUM,
   [`Large size (${INPUT_SIZE.LARGE})`]: INPUT_SIZE.LARGE,

--- a/packages/web-components/src/components/password-input/password-input.ts
+++ b/packages/web-components/src/components/password-input/password-input.ts
@@ -195,7 +195,6 @@ class CDSPasswordInput extends CDSTextInput {
       [`${prefix}--text-input--invalid`]: normalizedProps.invalid,
       [`${prefix}--text-input--warning`]: normalizedProps.warn,
       [`${prefix}--text-input--${size}`]: size !== undefined, // TODO v12 - remove this class
-      [`${prefix}--layout--size-${size}`]: size !== undefined,
       [`${prefix}--password-input`]: true,
     });
 
@@ -207,6 +206,7 @@ class CDSPasswordInput extends CDSTextInput {
     const fieldWrapperClasses = classMap({
       [`${prefix}--text-input__field-wrapper`]: true,
       [`${prefix}--text-input__field-wrapper--warning`]: normalizedProps.warn,
+      [`${prefix}--layout--size-${size}`]: size !== undefined,
     });
 
     const labelClasses = classMap({
@@ -241,10 +241,9 @@ class CDSPasswordInput extends CDSTextInput {
 
     const passwordVisibilityButtonClasses = classMap({
       [`${prefix}--text-input--password__visibility__toggle`]: true,
-      [`${prefix}--btn--icon-only`]: true,
+      [`${prefix}--btn`]: true,
       [`${prefix}--tooltip__trigger`]: true,
       [`${prefix}--tooltip--a11y`]: true,
-      [`${prefix}--toggle-password-tooltip`]: true,
       [`${prefix}--btn--disabled`]: normalizedProps.disabled || readonly,
     });
 

--- a/packages/web-components/src/components/password-input/password-input.ts
+++ b/packages/web-components/src/components/password-input/password-input.ts
@@ -228,12 +228,7 @@ class CDSPasswordInput extends CDSTextInput {
       : iconLoader(View16, { class: `${prefix}--icon-visibility-on` });
 
     const passwordVisibilityTooltipClasses = classMap({
-      [`${prefix}--text-input--password__visibility__toggle`]: true,
-      [`${prefix}--btn`]: true,
-      [`${prefix}--tooltip__trigger`]: true,
-      [`${prefix}--tooltip--a11y`]: true,
       [`${prefix}--toggle-password-tooltip`]: true,
-      [`${prefix}--btn--disabled`]: normalizedProps.disabled || readonly,
       [`${prefix}--tooltip--${this.tooltipDirection}`]: this.tooltipDirection,
       [`${prefix}--tooltip--align-${this.tooltipAlignment}`]:
         this.tooltipAlignment,
@@ -241,8 +236,7 @@ class CDSPasswordInput extends CDSTextInput {
 
     const passwordVisibilityButtonClasses = classMap({
       [`${prefix}--text-input--password__visibility__toggle`]: true,
-      [`${prefix}--btn`]: !isFluid,
-      [`${prefix}--btn--icon-only`]: isFluid,
+      [`${prefix}--btn`]: true,
       [`${prefix}--tooltip__trigger`]: true,
       [`${prefix}--tooltip--a11y`]: true,
       [`${prefix}--btn--disabled`]: normalizedProps.disabled || readonly,
@@ -335,6 +329,7 @@ class CDSPasswordInput extends CDSTextInput {
               </button>
               <cds-tooltip-content
                 id="content"
+                ?password-toggle-tooltip-content="${!isFluid}"
                 ?hidden="${normalizedProps.disabled}">
                 ${passwordIsVisible
                   ? this.hidePasswordLabel

--- a/packages/web-components/src/components/password-input/password-input.ts
+++ b/packages/web-components/src/components/password-input/password-input.ts
@@ -329,7 +329,7 @@ class CDSPasswordInput extends CDSTextInput {
               </button>
               <cds-tooltip-content
                 id="content"
-                ?password-toggle-tooltip-content="${!isFluid}"
+                ?toggle-password-tooltip-content="${!isFluid}"
                 ?hidden="${normalizedProps.disabled}">
                 ${passwordIsVisible
                   ? this.hidePasswordLabel

--- a/packages/web-components/src/components/password-input/password-input.ts
+++ b/packages/web-components/src/components/password-input/password-input.ts
@@ -241,7 +241,8 @@ class CDSPasswordInput extends CDSTextInput {
 
     const passwordVisibilityButtonClasses = classMap({
       [`${prefix}--text-input--password__visibility__toggle`]: true,
-      [`${prefix}--btn`]: true,
+      [`${prefix}--btn`]: !isFluid,
+      [`${prefix}--btn--icon-only`]: isFluid,
       [`${prefix}--tooltip__trigger`]: true,
       [`${prefix}--tooltip--a11y`]: true,
       [`${prefix}--btn--disabled`]: normalizedProps.disabled || readonly,

--- a/packages/web-components/src/components/tooltip/tooltip.scss
+++ b/packages/web-components/src/components/tooltip/tooltip.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,6 +7,8 @@
 
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/components/tooltip';
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/utilities/layout';
 @use '@carbon/styles/scss/theme' as *;
 
 // For some reason `#{prefix}-tooltip` doesn't work here, will need to investigate
@@ -47,4 +49,14 @@
 // Definition tooltip
 :host(#{$prefix}-definition-tooltip) #{$prefix}-popover-content::part(content) {
   @extend .#{$prefix}--definition-tooltip;
+}
+
+// Password input "Show/Hide Password" tooltip
+:host(#{$prefix}-tooltip-content[password-toggle-tooltip-content]) {
+  .#{$prefix}--popover {
+    @include layout.use('size', $default: 'md', $min: 'xs', $max: 'lg');
+
+    gap: $spacing-02;
+    inset-inline-start: calc(-1 * layout.size('height'));
+  }
 }

--- a/packages/web-components/src/components/tooltip/tooltip.scss
+++ b/packages/web-components/src/components/tooltip/tooltip.scss
@@ -52,7 +52,7 @@
 }
 
 // Password input "Show/Hide Password" tooltip
-:host(#{$prefix}-tooltip-content[password-toggle-tooltip-content]) {
+:host(#{$prefix}-tooltip-content[toggle-password-tooltip-content]) {
   .#{$prefix}--popover {
     @include layout.use('size', $default: 'md', $min: 'xs', $max: 'lg');
 


### PR DESCRIPTION
Closes #21786
Partially addresses https://github.com/carbon-design-system/carbon/issues/21969

Adds `xs` size to PasswordInput in React and Web Components.

### Changelog

**New**

- Added `xs` size and updated storybook controls and tests accordingly

**Changed**

- Moved `cds--layout--size-${size}` class from the input field to the field wrapper so that both the input and toggle visibility button can use the tokens
- Fixed an issue with the `<input>` field not having enough padding in some sizes, causing text to overflow into the toggle password visibiity button
- Changed the toggle password visibility button to have an equal height & width in all sizes
    - Currently, the `size` prop only vertically stretches/compresses the button but the width is always 40px ([example](https://react.carbondesignsystem.com/?path=/story/components-passwordinput--default&args=size:lg)). So `xs = 40x24` `sm = 40x32`, `...` . The issue description says to just follow the same approach used currently in code since the design spec is TBD, but I applied an equal height & width for all sizes anyway in the meantime until the spec is finalized, as it seems this was the intended behaviour [here](https://github.com/carbon-design-system/carbon/blob/main/packages/styles/scss/components/text-input/_text-input.scss#L143-L152), the selectors just didn't work.

**Removed**

- Removed size classes (e.g. text-input--sm) and size related style blocks in favour of using contextual layout tokens
    - This should not cause any breaking visual changes to PasswordInput/TextInput, nor any other components
- _Web Components:_ 
    - Scoped `cds--btn--icon-only` class to the fluid variant, and `cds--btn` to default variant
    - Removed `cds--toggle-password-tooltip` since it's not needed on the button 
- Removed `xl` size option from Storybook since it is not supported
- Removed a bunch of style blocks that didn't work since the selector doesn't capture anything (e.g `.cds--text-input--invalid + .cds--text-input--password__visibility__toggle`, these aren't adjacent siblings)

#### Testing / Reviewing

- Check PasswordInput stories in React and WC
- `xs`, `sm`, `md`, and `lg` should render as expected
- There should be no regressions to PasswordInput or any other related components

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass