### PR TITLE
fix(icon-build-helpers): preserve non-artboard rects, fix square--solid

### DIFF
--- a/packages/icon-build-helpers/src/metadata/extensions/output/optimizer.js
+++ b/packages/icon-build-helpers/src/metadata/extensions/output/optimizer.js
@@ -68,10 +68,20 @@ const plugins = [
             if (node.name === 'rect') {
               const width = node.attributes?.width;
               const height = node.attributes?.height;
+              const x = node.attributes?.x;
+              const y = node.attributes?.y;
+              const rx = node.attributes?.rx;
+              const ry = node.attributes?.ry;
+              const isZeroOrMissing = (value) =>
+                value === undefined || Number(value) === 0;
               if (
                 sizes.includes(width) &&
                 sizes.includes(height) &&
-                width === height
+                width === height &&
+                isZeroOrMissing(x) &&
+                isZeroOrMissing(y) &&
+                isZeroOrMissing(rx) &&
+                isZeroOrMissing(ry)
               ) {
                 if (parentNode && parentNode.children) {
                   parentNode.children = parentNode.children.filter(


### PR DESCRIPTION
Follow up to https://github.com/carbon-design-system/carbon/pull/17560

A `rect` in `square--solid` was being stripped when it should not have been causing the icon to not render at all. 

### Changelog

**Changed**

- Update svg optimizer's transparent-rectangle stripping to only remove square rects when x/y/rx/ry are zero-or-missing

#### Testing / Reviewing

1. Pull down and build, then confirm emitted output `packages/icons/es/square--solid/16.js` contains the rounded rect.
2. You can validate the same thing on the carbon elements preview deploy preview by cmd + f for the icon name, and inspect w/ devtools. 

<img width="2366" height="1396" alt="2026-04-27 at 13 59 09-16 js — monorepo-Code@2x" src="https://github.com/user-attachments/assets/ac8e8827-03a5-4671-a57e-f685342a37af" />

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
