### PR TITLE
fix(web-components): add stylelint plugin for wc scss

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -81,6 +81,7 @@ at version `v1.16.0`):
 
 - [Using components in a form](./docs/form.md)
 - [Using custom styles in components](./docs/styling.md)
+- [Stylelint best practices for web components](./docs/stylelint-best-practices.md)
 
 ## 📖 API Documentation
 

--- a/packages/web-components/docs/stylelint-best-practices.md
+++ b/packages/web-components/docs/stylelint-best-practices.md
@@ -1,0 +1,48 @@
+# Stylelint best practices for web components
+
+`@carbon/web-components` uses an additional stylelint rule to keep shadow-DOM
+styling patterns consistent and prevent regressions from known pitfalls.
+
+## Rules
+
+### Prefer `:dir(rtl)` over `[dir=rtl]`
+
+- Use `:dir(rtl)` when writing RTL direction selectors
+- Avoid `[dir=rtl]` because attribute selectors do not cross shadow boundaries
+
+Example:
+
+```scss
+// Good
+:host(cds-button:dir(rtl)) { ... }
+
+// Avoid
+:host(cds-button[dir=rtl]) { ... }
+```
+
+### Shared custom properties need host/custom-element boundaries
+
+Shared CSS custom properties (currently prefixes `--cds-` and `--tabs-`) should
+be declared on:
+
+- `:host(...)`, or
+- a child custom-element selector (including `::slotted(...)` selectors that
+  target a custom element)
+
+This keeps shared tokens available across component boundaries and avoids
+leaking boundary-sensitive contract values into implementation-only class
+selectors.
+
+Example:
+
+```scss
+// Good
+:host(cds-page-header) ::slotted(cds-tabs) {
+  --tabs-overflow-button-background: #262626;
+}
+
+// Avoid
+.#{$prefix}--page-header-tabs {
+  --tabs-overflow-button-background: #262626;
+}
+```

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -59,6 +59,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "test": "web-test-runner \"src/components/**/__tests__/**/*.js\" --node-resolve --concurrency=1",
+    "test:stylelint-plugin": "node --test ./tools/stylelint/web-component-best-practices.test.js",
     "test:updateSnapshots": "yarn test --update-snapshots",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "wca": "web-component-analyzer analyze src --outFile custom-elements.json",
@@ -102,6 +103,7 @@
     "sass": "^1.93.2",
     "storybook": "^9.1.8",
     "storybook-addon-accessibility-checker": "^9.2.0-rc.3",
+    "stylelint": "^16.0.0",
     "tsdown": "^0.21.0",
     "typescript-config-carbon": "workspace:^0.9.0",
     "vite": "^7.2.4",
@@ -115,13 +117,25 @@
     "extends": [
       "../../config/stylelint-config-carbon"
     ],
+    "plugins": [
+      "./tools/stylelint/web-component-best-practices.js"
+    ],
     "overrides": [
       {
         "files": [
           "src/components/**/*.scss"
         ],
         "rules": {
-          "max-nesting-depth": null
+          "max-nesting-depth": null,
+          "carbon/web-component-best-practices": [
+            true,
+            {
+              "sharedCustomPropertyPrefixes": [
+                "--cds-",
+                "--tabs-"
+              ]
+            }
+          ]
         }
       }
     ]

--- a/packages/web-components/src/components/ai-label/ai-label.scss
+++ b/packages/web-components/src/components/ai-label/ai-label.scss
@@ -35,6 +35,7 @@ $colorMap: (
 
 :host(#{$prefix}-ai-label) {
   @extend .#{$prefix}--slug;
+  --cds-button-focus-color: var(--cds-focus);
 
   .#{$prefix}--slug__text {
     @include font-family('sans');
@@ -71,7 +72,6 @@ $colorMap: (
     // This sets the max size to the size of the action bar with 3 buttons
     padding-block: $spacing-06 $spacing-11;
     padding-inline: $spacing-06;
-    --cds-button-focus-color: var(--cds-focus);
   }
 
   .#{$prefix}--slug__button.#{$prefix}--slug__button--mini:focus,

--- a/packages/web-components/src/components/slug/slug.scss
+++ b/packages/web-components/src/components/slug/slug.scss
@@ -35,6 +35,7 @@ $colorMap: (
 
 :host(#{$prefix}-slug) {
   @extend .#{$prefix}--slug;
+  --cds-button-focus-color: var(--cds-focus);
 
   .#{$prefix}--slug__text {
     @include font-family('sans');
@@ -71,7 +72,6 @@ $colorMap: (
     // This sets the max size to the size of the action bar with 3 buttons
     padding-block: $spacing-06 $spacing-11;
     padding-inline: $spacing-06;
-    --cds-button-focus-color: var(--cds-focus);
   }
 
   .#{$prefix}--popover-caret {

--- a/packages/web-components/tools/stylelint/web-component-best-practices.js
+++ b/packages/web-components/tools/stylelint/web-component-best-practices.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import stylelint from 'stylelint';
+
+const ruleName = 'carbon/web-component-best-practices';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  preferDirPseudoClass:
+    'Use `:dir(ltr)` or `:dir(rtl)` instead of `[dir=ltr]` / `[dir=rtl]` so direction-aware selectors work across shadow boundaries.',
+  invalidCustomPropertyPlacement: (propertyName) =>
+    `Declare shared custom property \`${propertyName}\` on \`:host(...)\` or directly on a child custom-element selector.`,
+});
+
+const defaultPrefixes = ['--cds-', '--tabs-'];
+
+function splitSelectors(selector) {
+  if (typeof selector !== 'string') {
+    return [];
+  }
+
+  return selector.split(/,(?![^(]*\))/g).map((entry) => entry.trim());
+}
+
+function isCustomElementSelector(selector) {
+  if (typeof selector !== 'string') {
+    return false;
+  }
+
+  const nativeCustomElementPattern =
+    /(^|[\s>+~(])([a-z][a-z0-9]*-[a-z0-9-]*)(?=[\s#.:,[\]>+~)]|$)/i;
+  const carbonPrefixInterpolationPattern =
+    /(^|[\s>+~(])#\{\$[^}]+\}-[a-z0-9-]+(?=[\s#.:,[\]>+~)]|$)/i;
+
+  return (
+    nativeCustomElementPattern.test(selector) ||
+    carbonPrefixInterpolationPattern.test(selector)
+  );
+}
+
+function selectorAllowsSharedProperty(selector) {
+  if (typeof selector !== 'string') {
+    return false;
+  }
+
+  if (selector.includes(':host')) {
+    return true;
+  }
+
+  return isCustomElementSelector(selector);
+}
+
+function selectorListAllowsSharedProperty(selector) {
+  const selectors = splitSelectors(selector);
+
+  return selectors.some((entry) => selectorAllowsSharedProperty(entry));
+}
+
+function shouldValidateProperty(propertyName, prefixes) {
+  return prefixes.some((prefix) => propertyName.startsWith(prefix));
+}
+
+const rule = (primaryOption, secondaryOptions = {}, context = {}) => {
+  const {
+    sharedCustomPropertyPrefixes = defaultPrefixes,
+    validateDirectionSelector = true,
+  } = secondaryOptions;
+  const { fix = false } = context;
+
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primaryOption,
+      possible: [true],
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    if (validateDirectionSelector) {
+      const dirAttributePattern =
+        /\[(\s*)dir\s*=\s*(['"]?)(rtl|ltr)\2(\s*)\]/gi;
+
+      root.walkRules((ruleNode) => {
+        const { selector } = ruleNode;
+
+        if (fix) {
+          ruleNode.selector = selector.replace(
+            dirAttributePattern,
+            (_, _space, _quote, dir) => `:dir(${dir.toLowerCase()})`
+          );
+          return;
+        }
+
+        const re = new RegExp(
+          dirAttributePattern.source,
+          dirAttributePattern.flags
+        );
+        let match;
+
+        while ((match = re.exec(selector)) !== null) {
+          stylelint.utils.report({
+            result,
+            ruleName,
+            message: messages.preferDirPseudoClass,
+            node: ruleNode,
+            index: match.index,
+            endIndex: match.index + match[0].length,
+          });
+        }
+      });
+    }
+
+    root.walkDecls((declaration) => {
+      const propertyName = declaration.prop;
+
+      if (
+        typeof propertyName !== 'string' ||
+        !shouldValidateProperty(propertyName, sharedCustomPropertyPrefixes)
+      ) {
+        return;
+      }
+
+      let parentRule = declaration.parent;
+      while (parentRule && parentRule.type !== 'rule') {
+        parentRule = parentRule.parent;
+      }
+
+      if (
+        !parentRule ||
+        selectorListAllowsSharedProperty(parentRule.selector)
+      ) {
+        return;
+      }
+
+      stylelint.utils.report({
+        result,
+        ruleName,
+        message: messages.invalidCustomPropertyPlacement(propertyName),
+        node: declaration,
+        word: propertyName,
+      });
+    });
+  };
+};
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+
+export default stylelint.createPlugin(ruleName, rule);

--- a/packages/web-components/tools/stylelint/web-component-best-practices.test.js
+++ b/packages/web-components/tools/stylelint/web-component-best-practices.test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import stylelint from 'stylelint';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const pkgRoot = path.resolve(__dirname, '../..');
+const configFile = path.join(pkgRoot, 'package.json');
+const componentScssPath = path.join(
+  pkgRoot,
+  'src/components/button/button.scss'
+);
+
+function warningsForCarbonRule(result) {
+  const list = result.results[0]?.warnings ?? [];
+
+  return list.filter((w) => w.rule === 'carbon/web-component-best-practices');
+}
+
+async function lint(code) {
+  return stylelint.lint({
+    code,
+    codeFilename: componentScssPath,
+    configFile,
+  });
+}
+
+test('fails when using [dir=rtl] selector', async () => {
+  const result = await lint(':host([dir=rtl]) { display: block; }');
+  const [warning] = warningsForCarbonRule(result);
+
+  assert.equal(warning.rule, 'carbon/web-component-best-practices');
+  assert.match(warning.text, /:dir/);
+});
+
+test('allows :dir(rtl) selector', async () => {
+  const result = await lint(':host(:dir(rtl)) { display: block; }');
+
+  assert.equal(warningsForCarbonRule(result).length, 0);
+});
+
+test('fails shared custom property declared on class selector', async () => {
+  const result = await lint('.wrapper { --cds-focus-ring: #0f62fe; }');
+  const [warning] = warningsForCarbonRule(result);
+
+  assert.equal(warning.rule, 'carbon/web-component-best-practices');
+  assert.match(warning.text, /Declare shared custom property/);
+});
+
+test('allows shared custom property on :host selector', async () => {
+  const result = await lint(':host(cds-button) { --cds-focus-ring: #0f62fe; }');
+
+  assert.equal(warningsForCarbonRule(result).length, 0);
+});
+
+test('allows shared custom property on child custom-element selector', async () => {
+  const result = await lint(
+    ':host(cds-page-header) ::slotted(cds-tabs) { --tabs-overflow-button-background: #262626; }'
+  );
+
+  assert.equal(warningsForCarbonRule(result).length, 0);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,6 +2177,7 @@ __metadata:
     sass: "npm:^1.93.2"
     storybook: "npm:^9.1.8"
     storybook-addon-accessibility-checker: "npm:^9.2.0-rc.3"
+    stylelint: "npm:^16.0.0"
     tsdown: "npm:^0.21.0"
     tslib: "npm:^2.6.3"
     typescript-config-carbon: "workspace:^0.9.0"


### PR DESCRIPTION
### short description

- Adds Stylelint checks for web-component SCSS (:dir() instead of [dir=…]; shared --cds- / --tabs- props on :host or custom-element selectors), plus plugin tests and docs.

### Changelog

- New: Stylelint plugin + tests + docs/stylelint-best-practices.md
- Changed: ai-label / slug — --cds-button-focus-color on :host
- Removed: n/a
- Testing: yarn stylelint packages/web-components/src/components/**/*.scss · yarn workspace @carbon/web-components run test:stylelint-plugin


fix : #22114