### PR TITLE
fix(menu-button): shrink-wrap container for Firefox layout

### DIFF
--- a/packages/styles/scss/components/menu-button/_menu-button.scss
+++ b/packages/styles/scss/components/menu-button/_menu-button.scss
@@ -16,7 +16,8 @@
 /// @group menu-button
 @mixin menu-button {
   .#{$prefix}--menu-button__container {
-    display: contents;
+    display: inline-flex;
+    inline-size: fit-content;
   }
 
   .#{$prefix}--menu-button__trigger:not(.#{$prefix}--btn--ghost) {


### PR DESCRIPTION
closes : #22088

- Fix Firefox MenuButton sizing by changing the wrapper from display: contents to a shrink-wrapping layout so the container width matches the visible button.

### Changed

- @carbon/styles: update .cds--menu-button__container to prevent extra right-side space in Firefox.

### Testing / Reviewing

- Verified MenuButton in Firefox: wrapper width now matches trigger.
- Confirmed no visual regression in Chrome/Safari.