### PR TITLE
fix(file-uploader): align accept parsing with native file input

### DIFF
--- a/packages/web-components/src/components/file-uploader/file-uploader-button.ts
+++ b/packages/web-components/src/components/file-uploader/file-uploader-button.ts
@@ -84,7 +84,9 @@ class CDSFileUploaderButton extends HostListenerMixin(LitElement) {
     if (!accept || !/^(change|drop)$/.test(event.type)) {
       return Array.from(files ?? []);
     }
-    const acceptedTypes = new Set(accept.split(' '));
+    const acceptedTypes = new Set(
+      accept.split(/[\s,]+/).filter(Boolean)
+    );
     return Array.prototype.filter.call(
       files,
       ({ name, type: mimeType = '' }) => {
@@ -155,6 +157,9 @@ class CDSFileUploaderButton extends HostListenerMixin(LitElement) {
       size,
       _handleChange: handleChange,
     } = this;
+    const acceptForInput = accept
+      ? accept.split(/[\s,]+/).filter(Boolean).join(',')
+      : '';
 
     const labelClasses = classMap({
       [`${prefix}--file-browse-btn`]: true,
@@ -181,7 +186,7 @@ class CDSFileUploaderButton extends HostListenerMixin(LitElement) {
         type="file"
         class="${prefix}--file-input"
         tabindex="-1"
-        accept="${ifNonEmpty(accept)}"
+        accept="${ifNonEmpty(acceptForInput)}"
         ?disabled="${disabled}"
         ?multiple="${multiple}"
         name="${ifNonEmpty(name)}"

--- a/packages/web-components/src/components/file-uploader/file-uploader-drop-container.ts
+++ b/packages/web-components/src/components/file-uploader/file-uploader-drop-container.ts
@@ -104,7 +104,9 @@ class CDSFileUploaderDropContainer extends HostListenerMixin(LitElement) {
     if (!accept || !/^(change|drop)$/.test(event.type)) {
       return Array.from(files ?? []);
     }
-    const acceptedTypes = new Set(accept.split(' '));
+    const acceptedTypes = new Set(
+      accept.split(/[\s,]+/).filter(Boolean)
+    );
     return Array.prototype.filter.call(
       files,
       ({ name, type: mimeType = '' }) => {
@@ -123,7 +125,7 @@ class CDSFileUploaderDropContainer extends HostListenerMixin(LitElement) {
   }
 
   /**
-   * The file types the file input should accept, separated by space.
+   * The file types the file input should accept, separated by spaces and/or commas.
    */
   @property()
   accept = '';
@@ -162,6 +164,9 @@ class CDSFileUploaderDropContainer extends HostListenerMixin(LitElement) {
       _active: active,
       _handleChange: handleChange,
     } = this;
+    const acceptForInput = accept
+      ? accept.split(/[\s,]+/).filter(Boolean).join(',')
+      : '';
     const labelClasses = classMap({
       [`${prefix}--file-browse-btn`]: true,
       [`${prefix}--file-browse-btn--disabled`]: disabled,
@@ -180,7 +185,7 @@ class CDSFileUploaderDropContainer extends HostListenerMixin(LitElement) {
             name="${ifNonEmpty(name)}"
             class="${prefix}--file-input"
             tabindex="-1"
-            accept="${ifNonEmpty(accept)}"
+            accept="${ifNonEmpty(acceptForInput)}"
             ?disabled="${disabled}"
             ?multiple="${multiple}"
             @change="${handleChange}" />


### PR DESCRIPTION
### closes 

- Fixes multi-value accept parsing in file uploader components.

### Changelog

New
- None.

Changed
- Parse accept with spaces and commas.
- Normalize native input accept to comma-separated tokens.

Removed
- None.

>  Reviewing

Test accept="image/jpeg image/png".
Test accept="image/jpeg,image/png".
Confirm unsupported files are not added.
Confirm single-value and extension-only still work.

### PR Checklist
<!--
Do not remove checklist items.
If some are incomplete, create a draft pull request using the create button dropdown.
If some do not apply, ~strike through the item text with tildes~.
-->


fix : #22111
