### PR TITLE
fix(datepicker): add weekday to calendar aria-labels

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -653,6 +653,28 @@ describe('Single date picker', () => {
     expect(screen.getByRole('application')).toBeInTheDocument();
   });
 
+  it('should include the weekday in the calendar day aria-label', async () => {
+    render(
+      <DatePicker
+        onChange={() => {}}
+        datePickerType="single"
+        value="04/15/2026">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          placeholder="mm/dd/yyyy"
+          labelText="Start date"
+          data-testid="input"
+        />
+      </DatePicker>
+    );
+
+    await userEvent.click(screen.getByTestId('input'));
+
+    expect(
+      screen.getByLabelText('Wednesday, April 15, 2026')
+    ).toBeInTheDocument();
+  });
+
   it('should update the calendar classnames when open', async () => {
     render(
       <DatePicker
@@ -806,7 +828,7 @@ describe('Single date picker', () => {
 
     // eslint-disable-next-line testing-library/no-node-access
     const belowMinDate = document.querySelector(
-      '[aria-label="November 26, 2023"]'
+      '[aria-label="Sunday, November 26, 2023"]'
     );
     await userEvent.click(belowMinDate);
 
@@ -1689,7 +1711,7 @@ describe('Date picker with minDate and maxDate', () => {
     await userEvent.click(screen.getByTestId('input'));
 
     const disabledDate = document.querySelector(
-      '[aria-label="January 2, 2018"]'
+      '[aria-label="Tuesday, January 2, 2018"]'
     );
 
     expect(disabledDate).toHaveClass('flatpickr-disabled');
@@ -1744,7 +1766,7 @@ describe('Date picker with minDate and maxDate', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access
     const belowMinDate = document.querySelector(
-      '[aria-label="December 31, 2017"]'
+      '[aria-label="Sunday, December 31, 2017"]'
     );
     await userEvent.click(screen.getByTestId('input-min-max'));
     await userEvent.click(belowMinDate);
@@ -1772,7 +1794,7 @@ describe('Date picker with minDate and maxDate', () => {
 
     // eslint-disable-next-line testing-library/no-node-access
     const aboveMaxDate = document.querySelector(
-      '[aria-label="January 4, 2018"]'
+      '[aria-label="Thursday, January 4, 2018"]'
     );
 
     await userEvent.click(screen.getByTestId('input-min-max-2'));

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -54,6 +54,7 @@ function initializeWeekdayShorthand() {
 }
 
 const forEach = Array.prototype.forEach;
+const defaultAriaDateFormat = 'l, F j, Y';
 
 /**
  * @param {number} monthNumber The month number.
@@ -603,6 +604,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((props, ref) => {
       inline: inline ?? false,
       onClose: onCalendarClose,
       disableMobile: true,
+      ariaDateFormat: defaultAriaDateFormat,
       defaultDate: value,
       closeOnSelect: closeOnSelect,
       mode: datePickerType,

--- a/packages/web-components/src/components/date-picker/__tests__/date-picker-test.js
+++ b/packages/web-components/src/components/date-picker/__tests__/date-picker-test.js
@@ -126,6 +126,25 @@ describe('cds-date-picker', () => {
       expect(el).to.exist;
     });
 
+    it('should include the weekday in the calendar day aria-label', async () => {
+      const el = await fixture(html`
+        <cds-date-picker value="2026-04-15">
+          <cds-date-picker-input
+            kind="single"
+            label-text="Date"
+            placeholder="mm/dd/yyyy">
+          </cds-date-picker-input>
+        </cds-date-picker>
+      `);
+      await el.updateComplete;
+
+      const day = el.calendar?.calendarContainer?.querySelector(
+        '[aria-label="Wednesday, April 15, 2026"]'
+      );
+
+      expect(day).to.exist;
+    });
+
     it('should handle value changes', async () => {
       const el = await fixture(html`
         <cds-date-picker value="2024-01-15">

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -202,6 +202,8 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
       : enabledRange.split('/');
     return {
       allowInput: this.allowInput,
+      ariaDateFormat: (this.constructor as typeof CDSDatePicker)
+        .defaultAriaDateFormat,
       closeOnSelect: this.closeOnSelect,
       dateFormat:
         this.dateFormat ??
@@ -662,6 +664,11 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
    * The CSS class applied to the "today" highlight if there are any dates selected.
    */
   static classNoBorder = 'no-border';
+
+  /**
+   * The default aria date format.
+   */
+  static defaultAriaDateFormat = 'l, F j, Y';
 
   /**
    * The default date format.


### PR DESCRIPTION
Closes #22044
Closes #15254

This PR updates the `DatePicker` calendar so screen readers announce the weekday with the full date. It keeps the same behavior in React and Web Components.

### Changelog

**New**

- ~None~

**Changed**

- Updated `DatePicker` day `aria-labels` to include the weekday
- Added tests for React and Web Components

**Removed**

- ~None~

#### Testing / Reviewing

- Go to the `React` and `Web Components Deploy Preview` > DatePicker > Default and Range with calendar
- Turn on a screen reader, such as `VoiceOver` or `JAWS`
- Tab to the input, then press Tab again to move to the current date
- Check if announce the weekday, for example: `Wednesday, April 29, 2026`

<img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/a22c60a9-bc5b-4cd0-91af-0b338201eb4b" />

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)