### PR TITLE
Revert "fix(menu): nested menu closes unexpectedly when hovering back from submenu item to parent menu item"

### DIFF
--- a/packages/react/src/components/Menu/Menu-test.js
+++ b/packages/react/src/components/Menu/Menu-test.js
@@ -131,20 +131,6 @@ describe('Menu', () => {
       expect(document.querySelector('.custom-class')).toBeInTheDocument();
       document.body.removeChild(el);
     });
-
-    it('should not call onClose when relatedTarget is null on blur', () => {
-      const onClose = jest.fn();
-      render(
-        <Menu open onClose={onClose} label="Test Menu">
-          <MenuItem label="item" />
-        </Menu>
-      );
-
-      const menu = screen.getByRole('menu');
-      fireEvent.blur(menu, { relatedTarget: null });
-
-      expect(onClose).not.toHaveBeenCalled();
-    });
   });
 
   describe('Submenu behavior', () => {

--- a/packages/react/src/components/Menu/Menu-test.js
+++ b/packages/react/src/components/Menu/Menu-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2025
+ * Copyright IBM Corp. 2023, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -83,6 +83,21 @@ describe('Menu', () => {
       );
 
       await userEvent.click(screen.getByRole('menuitem'));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should call onClose when clicking outside of the Menu', async () => {
+      const onClose = jest.fn();
+      render(
+        <div data-testid="container">
+          <Menu open onClose={onClose}>
+            <MenuItem label="item" />
+          </Menu>
+        </div>
+      );
+
+      await userEvent.click(screen.getByTestId('container'));
 
       expect(onClose).toHaveBeenCalled();
     });

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -287,13 +287,7 @@ const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
   }
 
   function handleBlur(e: React.FocusEvent<HTMLUListElement>) {
-    if (
-      open &&
-      onClose &&
-      isRoot &&
-      e.relatedTarget &&
-      !menu.current?.contains(e.relatedTarget)
-    ) {
+    if (open && onClose && isRoot && !menu.current?.contains(e.relatedTarget)) {
       handleClose();
     }
   }


### PR DESCRIPTION
Reverts carbon-design-system/carbon#20881
Closes #21380


Some more context:
https://github.com/carbon-design-system/carbon/issues/21380#issuecomment-4332866378
https://github.com/carbon-design-system/carbon/issues/21380#issuecomment-4345701857