### PR TITLE
fix(docs-multiselect): unnecessary type assertion

### DIFF
--- a/packages/web-components/src/components/multi-select/multi-select.mdx
+++ b/packages/web-components/src/components/multi-select/multi-select.mdx
@@ -69,42 +69,45 @@ alphabetically by default.
 <Canvas of={MultiSelectStories.WithCustomSorting} />
 
 ```typescript
- const customSortItems = (
-      menuItems: NodeList,
-      {
-        values,
-        compareItems,
-        locale,
-      }: {
-        values: string[];
-        compareItems: (
-          itemA: string,
-          itemB: string,
-          options: { locale: string }
-        ) => number;
-        locale: string;
-      }
-    ) => {
-      const menuItemsArray = Array.from(menuItems);
+const getItemValue = (item: Node) =>
+  item instanceof Element ? (item.getAttribute('value') ?? '') : '';
 
-      return menuItemsArray.sort((itemA, itemB) => {
-        const hasItemA = values.includes((itemA as HTMLInputElement).value);
-        const hasItemB = values.includes((itemB as HTMLInputElement).value);
+const customSortItems = (
+  menuItems: NodeList,
+  {
+    values,
+    compareItems,
+    locale,
+  }: {
+    values: string[];
+    compareItems: (
+      itemA: string,
+      itemB: string,
+      options: { locale: string }
+    ) => number;
+    locale: string;
+  }
+) => {
+  const menuItemsArray = Array.from(menuItems);
 
-        if (hasItemA && !hasItemB) {
-          return 1;
-        }
-        if (hasItemB && !hasItemA) {
-          return -1;
-        }
+  return menuItemsArray.sort((itemA, itemB) => {
+    const hasItemA = values.includes(getItemValue(itemA));
+    const hasItemB = values.includes(getItemValue(itemB));
 
-        return compareItems(
-          itemA.textContent?.trim() ?? '',
-          itemB.textContent?.trim() ?? '',
-          { locale }
-        );
-      });
-    };
+    if (hasItemA && !hasItemB) {
+      return 1;
+    }
+    if (hasItemB && !hasItemA) {
+      return -1;
+    }
+
+    return compareItems(
+      itemA.textContent?.trim() ?? '',
+      itemB.textContent?.trim() ?? '',
+      { locale }
+    );
+  });
+};
 
 ...
 

--- a/packages/web-components/src/components/multi-select/multi-select.mdx
+++ b/packages/web-components/src/components/multi-select/multi-select.mdx
@@ -99,8 +99,8 @@ alphabetically by default.
         }
 
         return compareItems(
-          (itemA as HTMLElement).innerText.trim(),
-          (itemB as HTMLElement).innerText.trim(),
+          itemA.textContent?.trim() ?? '',
+          itemB.textContent?.trim() ?? '',
           { locale }
         );
       });

--- a/packages/web-components/src/components/multi-select/multi-select.stories.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.stories.ts
@@ -1107,8 +1107,8 @@ export const WithCustomSorting = {
         }
 
         return compareItems(
-          (itemA as HTMLElement).innerText.trim(),
-          (itemB as HTMLElement).innerText.trim(),
+          itemA.textContent?.trim() ?? '',
+          itemB.textContent?.trim() ?? '',
           { locale }
         );
       });

--- a/packages/web-components/src/components/multi-select/multi-select.stories.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.stories.ts
@@ -1077,6 +1077,9 @@ export const WithCustomSorting = {
       warnText,
     } = args ?? {};
 
+    const getItemValue = (item: Node) =>
+      item instanceof Element ? (item.getAttribute('value') ?? '') : '';
+
     const customSortItems = (
       menuItems: NodeList,
       {
@@ -1096,8 +1099,8 @@ export const WithCustomSorting = {
       const menuItemsArray = Array.from(menuItems);
 
       return menuItemsArray.sort((itemA, itemB) => {
-        const hasItemA = values.includes((itemA as HTMLInputElement).value);
-        const hasItemB = values.includes((itemB as HTMLInputElement).value);
+        const hasItemA = values.includes(getItemValue(itemA));
+        const hasItemB = values.includes(getItemValue(itemB));
 
         if (hasItemA && !hasItemB) {
           return 1;

--- a/packages/web-components/src/components/multi-select/multi-select.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.ts
@@ -703,6 +703,9 @@ class CDSMultiSelect extends CDSDropdown {
     options: { locale: string }
   ) => number = this.defaultCompareItems;
 
+  private getItemValue = (item: Node) =>
+    item instanceof Element ? (item.getAttribute('value') ?? '') : '';
+
   protected defaultSortItems = (
     menuItems: NodeList,
     { values, compareItems, locale = 'en' }
@@ -710,8 +713,8 @@ class CDSMultiSelect extends CDSDropdown {
     const menuItemsArray = Array.from(menuItems);
 
     const sortedArray = menuItemsArray.sort((itemA, itemB) => {
-      const hasItemA = values.includes((itemA as HTMLInputElement).value);
-      const hasItemB = values.includes((itemB as HTMLInputElement).value);
+      const hasItemA = values.includes(this.getItemValue(itemA));
+      const hasItemB = values.includes(this.getItemValue(itemB));
 
       // Prefer whichever item is in the `value` array first
       if (hasItemA && !hasItemB) {


### PR DESCRIPTION
No issue

Removes an unnecessary type assertion from the "Custom Sorting" story for `cds-multi-select` and from the `mdx` Overview Page, similar to https://github.com/carbon-design-system/carbon/commit/57cbca6aa446b3dbd34a192e5a5d6a2529fda5cf

https://github.com/carbon-design-system/carbon/pull/22090#discussion_r3150372811


### Changelog

**Changed**

- Changed `(itemX as HTMLElement).innerText.trim(),` to `itemX.textContent?.trim() ?? '',`

#### Testing / Reviewing

- "Custom Sorting" story should still work fine
- All stories should have no behavioural/functional changes from this PR

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
