### PR TITLE
fix: remove CSS side effects from layout Sass module

### DIFF
--- a/packages/styles/index.scss
+++ b/packages/styles/index.scss
@@ -13,6 +13,7 @@
 @forward 'scss/themes';
 @forward 'scss/theme';
 
+@use 'scss/layout';
 @use 'scss/reset';
 @forward 'scss/fonts';
 @forward 'scss/grid';
@@ -20,3 +21,9 @@
 @forward 'scss/layout';
 @forward 'scss/zone';
 @use 'scss/components';
+
+:root {
+  @include layout.emit-layout-tokens();
+}
+
+@include layout.emit-layout-classes();

--- a/packages/styles/scss/__tests__/layout-test.js
+++ b/packages/styles/scss/__tests__/layout-test.js
@@ -22,6 +22,7 @@ describe('@carbon/styles/scss/layout', () => {
 
       $_: get('api', (
         mixins: (
+          emit-layout-classes: meta.mixin-exists('emit-layout-classes', 'layout'),
           emit-layout-tokens: meta.mixin-exists('emit-layout-tokens', 'layout'),
           emit-layout-tokens-to-shadow-host: meta.mixin-exists('emit-layout-tokens-to-shadow-host', 'layout'),
         ),
@@ -31,6 +32,7 @@ describe('@carbon/styles/scss/layout', () => {
     const { value: api } = get('api');
     expect(api).toEqual({
       mixins: {
+        'emit-layout-classes': true,
         'emit-layout-tokens': true,
         'emit-layout-tokens-to-shadow-host': true,
       },
@@ -85,6 +87,7 @@ describe('@carbon/styles/scss/layout', () => {
   test('layout size classes set size context token', async () => {
     const { result } = await render(`
       @use '../layout';
+      @include layout.emit-layout-classes();
     `);
 
     const { stylesheet } = css.parse(result.css.toString());
@@ -115,6 +118,7 @@ describe('@carbon/styles/scss/layout', () => {
   test('layout density classes set density context token', async () => {
     const { result } = await render(`
       @use '../layout';
+      @include layout.emit-layout-classes();
     `);
 
     const { stylesheet } = css.parse(result.css.toString());
@@ -145,6 +149,7 @@ describe('@carbon/styles/scss/layout', () => {
   test('layout constraint classes are generated for default, min and max', async () => {
     const { result } = await render(`
       @use '../layout';
+      @include layout.emit-layout-classes();
     `);
 
     const output = result.css.toString();
@@ -189,6 +194,9 @@ describe('@carbon/styles/scss/layout', () => {
   test(':root emits layout tokens globally', async () => {
     const { result } = await render(`
       @use '../layout';
+      :root {
+        @include layout.emit-layout-tokens();
+      }
     `);
 
     const { stylesheet } = css.parse(result.css.toString());
@@ -202,5 +210,13 @@ describe('@carbon/styles/scss/layout', () => {
         d.property.includes('--cds-layout-size-height-xs')
       )
     ).toBe(true);
+  });
+
+  test('should not emit CSS when only using the module', async () => {
+    const { result } = await render(`
+      @use '../layout';
+    `);
+
+    expect(result.css.toString().trim()).toBe('');
   });
 });

--- a/packages/styles/scss/_layout.scss
+++ b/packages/styles/scss/_layout.scss
@@ -58,45 +58,47 @@ $layout-tokens: (
   }
 }
 
-@each $group, $properties in $layout-tokens {
-  @each $property, $steps in $properties {
-    @each $step, $value in $steps {
-      .#{$prefix}--layout--#{$group}-#{$step} {
-        @include custom-property.declaration(
-          'layout-#{$group}-#{$property}-context',
-          custom-property.get-var(
-            'layout-#{$group}-#{$property}-#{$step}',
-            $value
-          )
-        );
-        @include custom-property.declaration(
-          'layout-#{$group}-#{$property}',
-          custom-property.get-var('layout-#{$group}-#{$property}-context')
-        );
-      }
-
-      .#{$prefix}--layout-constraint--#{$group}__default-#{$step} {
-        @include custom-property.declaration(
-          'layout-#{$group}-#{$property}',
-          custom-property.get-var(
+@mixin emit-layout-classes {
+  @each $group, $properties in $layout-tokens {
+    @each $property, $steps in $properties {
+      @each $step, $value in $steps {
+        .#{$prefix}--layout--#{$group}-#{$step} {
+          @include custom-property.declaration(
             'layout-#{$group}-#{$property}-context',
             custom-property.get-var(
               'layout-#{$group}-#{$property}-#{$step}',
               $value
             )
-          )
-        );
-      }
-
-      @each $constraint in ('min', 'max') {
-        .#{$prefix}--layout-constraint--#{$group}__#{$constraint}-#{$step} {
+          );
           @include custom-property.declaration(
-            'layout-#{$group}-#{$property}-#{$constraint}',
+            'layout-#{$group}-#{$property}',
+            custom-property.get-var('layout-#{$group}-#{$property}-context')
+          );
+        }
+
+        .#{$prefix}--layout-constraint--#{$group}__default-#{$step} {
+          @include custom-property.declaration(
+            'layout-#{$group}-#{$property}',
             custom-property.get-var(
-              'layout-#{$group}-#{$property}-#{$step}',
-              $value
+              'layout-#{$group}-#{$property}-context',
+              custom-property.get-var(
+                'layout-#{$group}-#{$property}-#{$step}',
+                $value
+              )
             )
           );
+        }
+
+        @each $constraint in ('min', 'max') {
+          .#{$prefix}--layout-constraint--#{$group}__#{$constraint}-#{$step} {
+            @include custom-property.declaration(
+              'layout-#{$group}-#{$property}-#{$constraint}',
+              custom-property.get-var(
+                'layout-#{$group}-#{$property}-#{$step}',
+                $value
+              )
+            );
+          }
         }
       }
     }
@@ -124,8 +126,4 @@ $layout-tokens: (
       }
     }
   }
-}
-
-:root {
-  @include emit-layout-tokens();
 }

--- a/packages/web-components/src/components/accordion/accordion.scss
+++ b/packages/web-components/src/components/accordion/accordion.scss
@@ -17,6 +17,8 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/components/button/tokens' as button-tokens;
 
+@include emit-layout-classes();
+
 :host(#{$prefix}-accordion),
 :host(#{$prefix}-accordion-skeleton) {
   @extend .#{$prefix}--accordion;

--- a/packages/web-components/src/components/content-switcher/content-switcher.scss
+++ b/packages/web-components/src/components/content-switcher/content-switcher.scss
@@ -17,6 +17,7 @@ $css--plex: true !default;
 
 // https://github.com/carbon-design-system/carbon/issues/11408
 @include content-switcher;
+@include emit-layout-classes();
 
 :host(#{$prefix}-content-switcher) {
   @extend .#{$prefix}--content-switcher;

--- a/packages/web-components/src/components/search/search.scss
+++ b/packages/web-components/src/components/search/search.scss
@@ -17,6 +17,7 @@ $css--plex: true !default;
 
 // https://github.com/carbon-design-system/carbon/issues/11408
 @include search;
+@include emit-layout-classes();
 
 :host(#{$prefix}-search) {
   @include emit-layout-tokens();

--- a/packages/web-components/src/components/tag/tag.scss
+++ b/packages/web-components/src/components/tag/tag.scss
@@ -17,6 +17,8 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/components/tag/mixins' as *;
 @use '@carbon/styles/scss/layout' as *;
 
+@include emit-layout-classes();
+
 :host(#{$prefix}-tag),
 :host(#{$prefix}-dismissible-tag) {
   @extend .#{$prefix}--tag;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/21317

Removed CSS side effects from the `layout` Sass module.

### Changelog

**New**

- Added an `emit-layout-classes` layout mixin.

**Changed**

- Moved global layout token and class emission out of `scss/_layout.scss` side effects and into explicit includes from `packages/styles/index.scss`.
- Updated web components to include layout classes where they extend layout size utils.

**Removed**

- Removed implicit CSS side effects from importing the layout Sass module.

#### Testing / Reviewing

`@use '@carbon/styles/scss/layout'` was emitting CSS as a side effect on import, including global `:root` layout tokens and layout utility classes.

I moved that output behind mixins so the layout module no longer emits CSS by default. `@use '@carbon/styles/scss/layout'` is now opt-in, while the top level `@use '@carbon/styles'` explicitly re-emits the global tokens and layout classes to preserve existing behavior.

Because that change removed implicit selector generation, `web-components` stylesheets that compile in isolation and `@extend` layout size classes now explicitly call `@include emit-layout-classes()`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
