### PR TITLE
feat(react): add hidden story for Pagination tooltip hover VRT

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -154,6 +154,9 @@ Default.argTypes = {
 export const TooltipHover = {
   ...Default,
   tags: ['!autodocs', '!dev'],
+  parameters: {
+    chromatic: { delay: 100 },
+  },
   play: async ({ canvasElement }) => {
     const nextButton = canvasElement.querySelector(
       '.cds--pagination__button--forward'

--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -9,6 +9,7 @@ import Pagination from './Pagination';
 import React from 'react';
 import { action } from 'storybook/actions';
 import mdx from './Pagination.mdx';
+import userEvent from '@testing-library/user-event';
 
 const props = () => ({
   disabled: false,
@@ -147,6 +148,17 @@ Default.argTypes = {
     control: {
       type: 'number',
     },
+  },
+};
+
+export const TooltipHover = {
+  ...Default,
+  tags: ['!autodocs', '!dev'],
+  play: async ({ canvasElement }) => {
+    const nextButton = canvasElement.querySelector(
+      '.cds--pagination__button--forward'
+    );
+    await userEvent.hover(nextButton);
   },
 };
 


### PR DESCRIPTION
Closes #21930 

Add hidden story for Pagination tooltip hover VRT snapshot in Chromatic

### Changelog

**New**

- Added hidden `TooltipHover` story for `Pagination` component to capture tooltip hover state as a Chromatic VRT snapshot

**Changed**
- N/A

**Removed**
- N/A

#### Testing / Reviewing

Verify the story appears as a Chromatic snapshot and not in storybokk sidebar

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
