### PR TITLE
docs(storybook): add section overview pages

### DIFF
--- a/packages/react/src/components/Heading/Section.mdx
+++ b/packages/react/src/components/Heading/Section.mdx
@@ -1,0 +1,12 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/Section/Overview" />
+
+# Section
+
+The `Section` component is documented with `Heading` because `Heading` uses the
+nearest `Section` to infer the correct heading level.
+
+Review the
+[Heading component overview](../?path=/docs/components-heading--overview) for
+usage guidance and examples.

--- a/packages/web-components/src/components/heading/section.mdx
+++ b/packages/web-components/src/components/heading/section.mdx
@@ -1,0 +1,12 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/Section/Overview" />
+
+# Section
+
+The `section` component is documented with `heading` because `heading` uses the
+nearest `section` to infer the correct heading level.
+
+Review the
+[Heading component overview](../?path=/docs/components-heading--overview) for
+usage guidance and examples.


### PR DESCRIPTION
Adds docs-only Section overview pages for React and web components Storybook. These pages create a dedicated Components/Section sidebar entry and direct readers to the Heading overview where Section behavior and examples are documented.

### Changelog

**New**

- React Storybook docs page for Section under Components/Section/Overview
- Web components Storybook docs page for section under Components/Section/Overview

#### Testing / Reviewing

- In React Storybook, search for "Section" and verify the Section docs result appears.
- Open Components > Section > Overview and verify it links to Components > Heading > Overview.
- Repeat the same search and navigation check in web components Storybook.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)