### PR TITLE
fix: adjust skeleton colors in high contrast popovers

### DIFF
--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -147,6 +147,20 @@ $popover-caret-height: custom-property.get-var(
   // High contrast modifier
   .#{$prefix}--popover--high-contrast .#{$prefix}--popover {
     @include popover-highcontrast-base;
+
+    .#{$prefix}--skeleton,
+    .#{$prefix}--skeleton__text,
+    .#{$prefix}--skeleton__placeholder,
+    .#{$prefix}--icon--skeleton {
+      background: theme.$background-inverse-hover;
+    }
+
+    .#{$prefix}--skeleton::before,
+    .#{$prefix}--skeleton__text::before,
+    .#{$prefix}--skeleton__placeholder::before,
+    .#{$prefix}--icon--skeleton::before {
+      background: theme.$background-inverse;
+    }
   }
 
   // Drop shadow modifier


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/20716

Adjusted skeleton colors in high contrast `Popover`s.

### Changelog

**Changed**

- Adjusted skeleton colors in high contrast `Popover`s.

#### Testing / Reviewing

Check out the branch and recreate the reproduction environment from the issue.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
