### PR TITLE
fix: use controls exclude for fixed story props

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.stories.js
+++ b/packages/react/src/components/Accordion/Accordion.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -251,6 +251,11 @@ Skeleton.args = {
   isFlush: false,
   ordered: false,
 };
+Skeleton.parameters = {
+  controls: {
+    exclude: ['disabled', 'size'],
+  },
+};
 
 Skeleton.argTypes = {
   align: {
@@ -263,19 +268,9 @@ Skeleton.argTypes = {
   className: {
     control: false,
   },
-  disabled: {
-    table: {
-      disable: true,
-    },
-  },
   isFlush: {
     control: {
       type: 'boolean',
-    },
-  },
-  size: {
-    table: {
-      disable: true,
     },
   },
 };

--- a/packages/react/src/components/ComposedModal/ComposedModalPresence.featureflag.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModalPresence.featureflag.stories.js
@@ -99,8 +99,6 @@ EnablePresence.storyName = 'enable-presence';
 EnablePresence.parameters = {
   controls: {
     exclude: [
-      'children',
-      'className',
       'containerClassName',
       'launcherButtonRef',
       'selectorPrimaryFocus',

--- a/packages/react/src/components/ComposedModal/ComposedModalPresence.featureflag.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModalPresence.featureflag.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -96,41 +96,23 @@ export const EnablePresence = (args) => {
   );
 };
 EnablePresence.storyName = 'enable-presence';
+EnablePresence.parameters = {
+  controls: {
+    exclude: [
+      'children',
+      'className',
+      'containerClassName',
+      'launcherButtonRef',
+      'selectorPrimaryFocus',
+      'selectorsFloatingMenus',
+    ],
+  },
+};
 EnablePresence.argTypes = {
-  children: {
-    table: {
-      disable: true,
-    },
-  },
-  className: {
-    table: {
-      disable: true,
-    },
-  },
-  containerClassName: {
-    table: {
-      disable: true,
-    },
-  },
-  launcherButtonRef: {
-    table: {
-      disable: true,
-    },
-  },
   onClose: {
     action: 'onClose',
   },
   onKeyDown: {
     action: 'onKeyDown',
-  },
-  selectorPrimaryFocus: {
-    table: {
-      disable: true,
-    },
-  },
-  selectorsFloatingMenus: {
-    table: {
-      disable: true,
-    },
   },
 };

--- a/packages/react/src/components/Modal/ModalPresence.featureflag.stories.js
+++ b/packages/react/src/components/Modal/ModalPresence.featureflag.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,11 +23,9 @@ export default {
   title: 'Components/Modal/Feature Flags',
   component: Modal,
   tags: ['!autodocs'],
-  argTypes: {
-    launcherButtonRef: {
-      table: {
-        disable: true,
-      },
+  parameters: {
+    controls: {
+      exclude: ['launcherButtonRef'],
     },
   },
 };

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -193,9 +193,6 @@ const sharedArgs = {
 const filterableArgTypes = {
   label: {
     control: false,
-    table: {
-      disable: true,
-    },
   },
   placeholder: {
     control: {
@@ -380,6 +377,11 @@ FilterableWithSelectAll.args = { ...sharedArgs };
 FilterableWithSelectAll.argTypes = {
   ...filterableArgTypes,
 };
+FilterableWithSelectAll.parameters = {
+  controls: {
+    exclude: ['label'],
+  },
+};
 Filterable.argTypes = {
   ...filterableArgTypes,
   onChange: {
@@ -387,6 +389,11 @@ Filterable.argTypes = {
   },
   onMenuChange: {
     action: 'onMenuChange',
+  },
+};
+Filterable.parameters = {
+  controls: {
+    exclude: ['label'],
   },
 };
 
@@ -431,6 +438,11 @@ _FilterableWithLayer.args = { ...sharedArgs };
 
 _FilterableWithLayer.argTypes = {
   ...filterableArgTypes,
+};
+_FilterableWithLayer.parameters = {
+  controls: {
+    exclude: ['label'],
+  },
 };
 export const _Controlled = (args) => {
   const [selectedItems, setSelectedItems] = useState(
@@ -600,6 +612,11 @@ export const FilterableWithAILabel = (args) => (
 FilterableWithAILabel.args = { ...sharedArgs };
 FilterableWithAILabel.argTypes = {
   ...filterableArgTypes,
+};
+FilterableWithAILabel.parameters = {
+  controls: {
+    exclude: ['label'],
+  },
 };
 export const ExperimentalAutoAlign = (args) => {
   const ref = useRef();

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -191,9 +191,6 @@ const sharedArgs = {
 };
 
 const filterableArgTypes = {
-  label: {
-    control: false,
-  },
   placeholder: {
     control: {
       type: 'text',

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -161,26 +161,9 @@ export const TabTip = (args) => {
   );
 };
 
-TabTip.argTypes = {
-  align: {
-    table: {
-      disable: true,
-    },
-  },
-  autoAlign: {
-    table: {
-      disable: true,
-    },
-  },
-  highContrast: {
-    table: {
-      disable: true,
-    },
-  },
-  caret: {
-    table: {
-      disable: true,
-    },
+TabTip.parameters = {
+  controls: {
+    exclude: ['align', 'autoAlign', 'caret', 'highContrast'],
   },
 };
 
@@ -192,13 +175,13 @@ Default.args = {
   highContrast: false,
   open: true,
 };
+Default.parameters = {
+  controls: {
+    exclude: ['isTabTip'],
+  },
+};
 
 Default.argTypes = {
-  isTabTip: {
-    table: {
-      disable: true,
-    },
-  },
   align: {
     options: [
       'top',
@@ -255,21 +238,6 @@ Default.story = {
 };
 
 const autoAlignArgTypes = {
-  autoAlign: {
-    table: {
-      disable: true,
-    },
-  },
-  highContrast: {
-    table: {
-      disable: true,
-    },
-  },
-  isTabTip: {
-    table: {
-      disable: true,
-    },
-  },
   caret: {
     control: {
       type: 'boolean',
@@ -350,6 +318,11 @@ export const ExperimentalAutoAlign = (args) => {
 };
 
 ExperimentalAutoAlign.argTypes = autoAlignArgTypes;
+ExperimentalAutoAlign.parameters = {
+  controls: {
+    exclude: ['autoAlign', 'highContrast', 'isTabTip'],
+  },
+};
 export const ExperimentalAutoAlignBoundary = (args) => {
   const [open, setOpen] = useState(true);
   const ref = useRef();
@@ -424,6 +397,11 @@ export const ExperimentalAutoAlignBoundary = (args) => {
 };
 
 ExperimentalAutoAlignBoundary.argTypes = autoAlignArgTypes;
+ExperimentalAutoAlignBoundary.parameters = {
+  controls: {
+    exclude: ['autoAlign', 'highContrast', 'isTabTip'],
+  },
+};
 
 export const TabTipExperimentalAutoAlign = () => {
   const [open, setOpen] = useState(true);

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.stories.js
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.stories.js
@@ -165,22 +165,9 @@ WithLargeText.argTypes = {
       type: 'text',
     },
   },
-  id: {
-    table: { disable: true },
-  },
   openOnHover: {
     control: {
       type: 'boolean',
-    },
-  },
-  tooltipText: {
-    table: {
-      disable: true,
-    },
-  },
-  triggerClassName: {
-    table: {
-      disable: true,
     },
   },
 };

--- a/packages/web-components/src/components/accordion/accordion.stories.ts
+++ b/packages/web-components/src/components/accordion/accordion.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -50,21 +50,20 @@ const argTypes = {
   },
   onBeforeToggle: {
     action: `${prefix}-accordion-item-beingtoggled`,
-    table: {
-      disable: true,
-    },
   },
   onToggle: {
     action: `${prefix}-accordion-item-toggled`,
-    table: {
-      disable: true,
-    },
   },
 };
 
 export const Default = {
   args,
   argTypes,
+  parameters: {
+    controls: {
+      exclude: ['onBeforeToggle', 'onToggle'],
+    },
+  },
   render: ({
     alignment,
     isFlush,

--- a/packages/web-components/src/components/ai-label/ai-label.stories.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.stories.ts
@@ -199,20 +199,13 @@ export const Inline = {
     // hence the arg value is set even though the prop can’t be updated from controls.
     kind: 'inline',
   },
+  parameters: {
+    controls: {
+      exclude: ['defaultOpen', 'kind'],
+    },
+  },
   argTypes: {
     ...argTypes,
-    kind: {
-      ...argTypes.kind,
-      table: {
-        disable: true,
-      },
-    },
-    defaultOpen: {
-      ...argTypes.kind,
-      table: {
-        disable: true,
-      },
-    },
     size: {
       control: 'select',
       description:
@@ -261,20 +254,13 @@ export const InlineWithContent = {
     kind: 'inline',
     aiTextLabel: 'Text goes here',
   },
+  parameters: {
+    controls: {
+      exclude: ['defaultOpen', 'kind'],
+    },
+  },
   argTypes: {
     ...argTypes,
-    kind: {
-      ...argTypes.kind,
-      table: {
-        disable: true,
-      },
-    },
-    defaultOpen: {
-      ...argTypes.kind,
-      table: {
-        disable: true,
-      },
-    },
     size: {
       control: 'select',
       description:

--- a/packages/web-components/src/components/ai-skeleton/ai-skeleton-icon.stories.ts
+++ b/packages/web-components/src/components/ai-skeleton/ai-skeleton-icon.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,7 +12,6 @@ import mdx from './ai-skeleton.mdx';
 export const AISkeletonIcon = {
   // This story doesn't accept any args.
   args: {},
-  argTypes: {},
   parameters: {
     docs: {
       page: mdx,

--- a/packages/web-components/src/components/ai-skeleton/ai-skeleton-placeholder.stories.ts
+++ b/packages/web-components/src/components/ai-skeleton/ai-skeleton-placeholder.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,7 +12,6 @@ import mdx from './ai-skeleton.mdx';
 export const AISkeletonPlaceholder = {
   // This story doesn't accept any args.
   args: {},
-  argTypes: {},
   parameters: {
     docs: {
       page: mdx,

--- a/packages/web-components/src/components/fluid-text-input/fluid-text-input.stories.ts
+++ b/packages/web-components/src/components/fluid-text-input/fluid-text-input.stories.ts
@@ -54,11 +54,9 @@ const argTypes = {
   },
   onInput: {
     action: `input`,
-    table: { disable: true },
   },
   onClick: {
     action: `click`,
-    table: { disable: true },
   },
   maxCount: {
     control: 'text',
@@ -77,6 +75,11 @@ const argTypes = {
 export const Default = {
   args,
   argTypes,
+  parameters: {
+    controls: {
+      exclude: ['onClick', 'onInput'],
+    },
+  },
   render: ({
     defaultWidth,
     placeholder,

--- a/packages/web-components/src/components/fluid-textarea/fluid-textarea.stories.ts
+++ b/packages/web-components/src/components/fluid-textarea/fluid-textarea.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -72,9 +72,6 @@ const argTypes = {
   },
   onInput: {
     action: `input`,
-    table: {
-      disable: true,
-    },
   },
   placeholder: {
     control: 'text',
@@ -105,6 +102,11 @@ const argTypes = {
 export const Default = {
   args,
   argTypes,
+  parameters: {
+    controls: {
+      exclude: ['onInput'],
+    },
+  },
   render: ({
     cols,
     counterMode,

--- a/packages/web-components/src/components/number-input/number-input.stories.ts
+++ b/packages/web-components/src/components/number-input/number-input.stories.ts
@@ -170,9 +170,6 @@ const argTypes = {
   },
   onInput: {
     action: `${prefix}-number-input`,
-    table: {
-      disable: true,
-    },
   },
   type: {
     control: 'select',
@@ -214,6 +211,11 @@ const argTypes = {
 export const Default = {
   args,
   argTypes,
+  parameters: {
+    controls: {
+      exclude: ['onInput'],
+    },
+  },
   render: (args) => {
     const {
       allowEmpty,

--- a/packages/web-components/src/components/slider/slider.stories.ts
+++ b/packages/web-components/src/components/slider/slider.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -159,9 +159,6 @@ const argTypes = {
   },
   onAfterChange: {
     action: `${prefix}-slider-changed`,
-    table: {
-      disable: true,
-    },
   },
 };
 const argTypesSkelton = {
@@ -251,6 +248,11 @@ const argTypesSkelton = {
 
 export const Default = {
   args,
+  parameters: {
+    controls: {
+      exclude: ['onAfterChange'],
+    },
+  },
   argTypes: {
     ...argTypes,
     formatLabel: {

--- a/packages/web-components/src/components/text-input/text-input.stories.ts
+++ b/packages/web-components/src/components/text-input/text-input.stories.ts
@@ -179,9 +179,6 @@ const sharedArgTypes = {
   },
   onInput: {
     action: `${prefix}-select-selected`,
-    table: {
-      disable: true,
-    },
   },
 };
 
@@ -324,4 +321,9 @@ export const WithLayer = {
 export default {
   title: 'Components/Text Input',
   actions: { argTypesRegex: '^on.*' },
+  parameters: {
+    controls: {
+      exclude: ['onInput'],
+    },
+  },
 };

--- a/packages/web-components/src/components/textarea/textarea.stories.ts
+++ b/packages/web-components/src/components/textarea/textarea.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -114,9 +114,6 @@ const argTypes = {
   },
   onInput: {
     action: `input`,
-    table: {
-      disable: true,
-    },
   },
   placeholder: {
     control: 'text',
@@ -147,6 +144,11 @@ const argTypes = {
 export const Default = {
   args,
   argTypes,
+  parameters: {
+    controls: {
+      exclude: ['onInput'],
+    },
+  },
   render: ({
     cols,
     counterMode,


### PR DESCRIPTION
No issue. https://github.com/carbon-design-system/carbon/pull/22008#issuecomment-4283591057

Used `parameters.controls.exclude` for fixed story props instead of `argTypes.table.disable`.

### Changelog

**Changed**

- Used `parameters.controls.exclude` for fixed story props instead of `argTypes.table.disable`.

#### Testing / Reviewing

I updated the Storybook stories to use `parameters.controls.exclude` for props that are fixed by the story and only need to be hidden from the Controls panel. I kept, what seemed to be, intentionally undocumented, deprecated, or otherwise unusable props on `argTypes.table.disable`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
