### PR TITLE
fix: close only the topmost modal on Escape

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -919,6 +919,64 @@ describe('state with presence context', () => {
     expect(siblingModal).not.toBeInTheDocument();
     expect(screen.queryByTestId('modal')).toBeInTheDocument();
   });
+
+  it('should close only the topmost modal when Escape is pressed', async () => {
+    const ModalExample = () => {
+      const [isSiblingOpen, setIsSiblingOpen] = useState(false);
+      const [isChildOpen, setIsChildOpen] = useState(false);
+
+      return (
+        <ComposedModalPresence open>
+          <ComposedModal data-testid="modal">
+            <ModalHeader>Modal Header</ModalHeader>
+            <ModalBody>
+              <button
+                type="button"
+                data-testid="launch-sibling-modal"
+                onClick={() => setIsSiblingOpen(true)}>
+                Launch sibling modal
+              </button>
+            </ModalBody>
+          </ComposedModal>
+          <ComposedModal
+            data-testid="sibling-modal"
+            open={isSiblingOpen}
+            onClose={() => setIsSiblingOpen(false)}>
+            <ModalHeader>Modal Header</ModalHeader>
+            <ModalBody>
+              <button
+                type="button"
+                data-testid="launch-child-modal"
+                onClick={() => setIsChildOpen(true)}>
+                Launch child modal
+              </button>
+              <ComposedModal
+                data-testid="child-modal"
+                open={isChildOpen}
+                onClose={() => setIsChildOpen(false)}>
+                <ModalHeader>Modal Header</ModalHeader>
+              </ComposedModal>
+            </ModalBody>
+          </ComposedModal>
+        </ComposedModalPresence>
+      );
+    };
+
+    render(<ModalExample />);
+
+    await userEvent.click(screen.getByTestId('launch-sibling-modal'));
+    await userEvent.click(screen.getByTestId('launch-child-modal'));
+
+    expect(screen.queryByTestId('modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('sibling-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('child-modal')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByTestId('modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('sibling-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('child-modal')).not.toBeInTheDocument();
+  });
 });
 
 const ComposedModalWithPresenceHof = withComposedModalPresence((props) => {

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -49,6 +49,7 @@ import {
 } from './ComposedModalPresence';
 import { useId } from '../../internal/useId';
 import { useComposedModalState } from './useComposedModalState';
+import { isTopmostVisibleModal } from '../Modal/isTopmostVisibleModal';
 
 export interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {
   /** Specify the content to be placed in the ModalBody. */
@@ -293,10 +294,15 @@ const ComposedModalDialog = React.forwardRef<
   const button = useRef<HTMLButtonElement>(null);
   const startSentinel = useRef<HTMLButtonElement>(null);
   const endSentinel = useRef<HTMLButtonElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
   const onMouseDownTarget = useRef<Node | null>(null);
 
   const presenceContext = useContext(ComposedModalPresenceContext);
-  const mergedRefs = useMergeRefs([ref, presenceContext?.presenceRef]);
+  const mergedRefs = useMergeRefs([
+    modalRef,
+    ref,
+    presenceContext?.presenceRef,
+  ]);
   const enablePresence =
     useFeatureFlag('enable-presence') || presenceContext?.autoEnablePresence;
 
@@ -486,7 +492,10 @@ const ComposedModalDialog = React.forwardRef<
     if (!open) return;
 
     const handleEscapeKey = (event) => {
-      if (match(event, keys.Escape)) {
+      if (
+        match(event, keys.Escape) &&
+        isTopmostVisibleModal(modalRef.current, prefix)
+      ) {
         event.preventDefault();
         event.stopPropagation();
         closeModal(event);

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -760,6 +760,57 @@ describe('state with presence context', () => {
     expect(siblingModal).not.toBeInTheDocument();
     expect(screen.queryByTestId('modal')).toBeInTheDocument();
   });
+
+  it('should close only the topmost modal when Escape is pressed', async () => {
+    const ModalExample = () => {
+      const [isSiblingOpen, setIsSiblingOpen] = useState(false);
+      const [isChildOpen, setIsChildOpen] = useState(false);
+
+      return (
+        <ModalPresence open>
+          <Modal data-testid="modal">
+            <button
+              type="button"
+              data-testid="launch-sibling-modal"
+              onClick={() => setIsSiblingOpen(true)}>
+              Launch sibling modal
+            </button>
+          </Modal>
+          <Modal
+            data-testid="sibling-modal"
+            open={isSiblingOpen}
+            onRequestClose={() => setIsSiblingOpen(false)}>
+            <button
+              type="button"
+              data-testid="launch-child-modal"
+              onClick={() => setIsChildOpen(true)}>
+              Launch child modal
+            </button>
+            <Modal
+              data-testid="child-modal"
+              open={isChildOpen}
+              onRequestClose={() => setIsChildOpen(false)}
+            />
+          </Modal>
+        </ModalPresence>
+      );
+    };
+
+    render(<ModalExample />);
+
+    await userEvent.click(screen.getByTestId('launch-sibling-modal'));
+    await userEvent.click(screen.getByTestId('launch-child-modal'));
+
+    expect(screen.queryByTestId('modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('sibling-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('child-modal')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByTestId('modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('sibling-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('child-modal')).not.toBeInTheDocument();
+  });
 });
 
 const ModalWithPresenceHof = withModalPresence((props) => {

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -51,6 +51,7 @@ import {
   ModalPresenceContext,
   useExclusiveModalPresenceContext,
 } from './ModalPresence';
+import { isTopmostVisibleModal } from './isTopmostVisibleModal';
 
 export const ModalSizes = ['xs', 'sm', 'md', 'lg'] as const;
 const invalidOutsideClickMessage =
@@ -318,6 +319,7 @@ const ModalDialog = React.forwardRef(function ModalDialog(
   const secondaryButton = useRef<HTMLButtonElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const innerModal = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
   const startTrap = useRef<HTMLSpanElement>(null);
   const endTrap = useRef<HTMLSpanElement>(null);
   const wrapFocusTimeout = useRef<NodeJS.Timeout>(null);
@@ -332,7 +334,11 @@ const ModalDialog = React.forwardRef(function ModalDialog(
   const loadingActive = loadingStatus !== 'inactive';
 
   const presenceContext = useContext(ModalPresenceContext);
-  const mergedRefs = useMergedRefs([ref, presenceContext?.presenceRef]);
+  const mergedRefs = useMergedRefs([
+    modalRef,
+    ref,
+    presenceContext?.presenceRef,
+  ]);
   const enablePresence =
     useFeatureFlag('enable-presence') || presenceContext?.autoEnablePresence;
 
@@ -553,7 +559,10 @@ const ModalDialog = React.forwardRef(function ModalDialog(
     if (!open) return;
 
     const handleEscapeKey = (event) => {
-      if (match(event, keys.Escape)) {
+      if (
+        match(event, keys.Escape) &&
+        isTopmostVisibleModal(modalRef.current, prefix)
+      ) {
         event.preventDefault();
         event.stopPropagation();
         onRequestClose(event);

--- a/packages/react/src/components/Modal/isTopmostVisibleModal.ts
+++ b/packages/react/src/components/Modal/isTopmostVisibleModal.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const isTopmostVisibleModal = (
+  node: HTMLElement | null,
+  prefix: string
+) => {
+  if (!node) return false;
+
+  const visibleModals = document.querySelectorAll(
+    `.${prefix}--modal.is-visible`
+  );
+
+  return visibleModals.item(visibleModals.length - 1) === node;
+};


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/20426

Closed only the topmost modal on Escape.

### Changelog

**Changed**

- Closed only the topmost modal on Escape.

#### Testing / Reviewing

I wasn't sure where to abstract the util to, so I put it in `packages/react/src/components/Modal/isTopmostVisibleModal.ts`. If there's a preference to put it in `packages/react/src/internal` or elsewhere, let me know.

```sh
yarn test packages/react/src/components/ComposedModal
yarn test packages/react/src/components/Modal
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
