### PR TITLE
chore(wc): remove unneeded type annotation

### DIFF
--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -1070,7 +1070,7 @@ class CDSDropdown extends ValidityMixin(
    * The value of the selected item.
    */
   @property({ reflect: true })
-  value = '';
+  accessor value = '';
 
   /**
    * Specify whether the control is currently in warning state

--- a/packages/web-components/src/globals/mixins/validity.ts
+++ b/packages/web-components/src/globals/mixins/validity.ts
@@ -35,7 +35,8 @@ const ValidityMixin = <T extends Constructor<HTMLElement>>(
     required: boolean;
     requiredValidityMessage: string;
     validityMessage: string;
-    value: string;
+    get value(): string;
+    set value(v: string);
     checkValidity(): boolean;
     setCustomValidity(validityMessage: string): void;
   };

--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["es2017", "esnext.array", "dom", "dom.iterable"],
     "typeRoots": [
       "src/typings",


### PR DESCRIPTION
Fixes a web components build error introduced in [2de346](https://github.com/carbon-design-system/carbon/pull/21924/changes/2de34657a9c60ad449617fc986bbff638ec92f74#diff-7356ae0090d2d3393a3aae9200862bdbbbf87e2cf6f6117b4d4b89a1ac71cc44R38). This return type annotation is unneeded, since it's already covered in [validity.ts:95](https://github.com/carbon-design-system/carbon/blob/main/packages/web-components/src/globals/mixins/validity.ts#L96).

```bash
src/components/text-input/text-input.ts:292:7 - error TS2611: 'value' is defined as a property in class '{ _getValidityMessage(state: string): string | undefined; _testValidity(): string; invalid: boolean; required: boolean; requiredValidityMessage: string; validityMessage: string; value: string; checkValidity(): boolean; setCustomValidity(validityMessage: string): void; } & { ...; } & LitElement', but is overridden here in 'CDSTextInput' as an accessor.

292   get value() {
```

Also changes module resolution in `tsconfig.json` from `node` to `bundler`. Storybook 10 moved to subpath exports, which `moduleResolution: node` can't resolve.

```bash
src/components/textarea/stories/helpers.ts:8:24 - error TS2307: Cannot find module 'storybook/actions' or its corresponding type declarations.
  There are types at '/Users/kennylam/dev/c/node_modules/storybook/dist/actions/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

8 import { action } from 'storybook/actions';
```


### Changelog

**Changed**

- add `accessor` to `dropdown` reactive property
- change module bundler from `node` to `bundler`

**Removed**

- remove unneeded type annotation

#### Testing / Reviewing

The web components package should no longer build with the above errors.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
