### PR TITLE
test(data-table): add data-table unit tests

### DIFF
--- a/packages/web-components/src/components/data-table/__tests__/table-batch-actions-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-batch-actions-test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-batch-actions', () => {
+  it('should render singular and plural selected item messages', async () => {
+    const singular = await fixture(html`
+      <cds-table-batch-actions
+        active
+        selected-rows-count="1"></cds-table-batch-actions>
+    `);
+
+    const plural = await fixture(html`
+      <cds-table-batch-actions
+        active
+        selected-rows-count="2"></cds-table-batch-actions>
+    `);
+
+    expect(
+      singular.shadowRoot?.querySelector('.cds--batch-summary__para')
+        ?.textContent
+    ).to.contain('1 item selected');
+    expect(
+      plural.shadowRoot?.querySelector('.cds--batch-summary__para')?.textContent
+    ).to.contain('2 items selected');
+  });
+
+  it('should fire cancel click event', async () => {
+    const el = await fixture(html`
+      <cds-table-batch-actions
+        active
+        selected-rows-count="2"></cds-table-batch-actions>
+    `);
+
+    const listener = oneEvent(el, 'cds-table-batch-actions-cancel-clicked');
+    const cancel = el.shadowRoot?.querySelector('.cds--batch-summary__cancel');
+    cancel?.click();
+    await listener;
+  });
+
+  it('should fire select all click event when select all button is rendered', async () => {
+    const el = await fixture(html`
+      <cds-table-batch-actions
+        active
+        selected-rows-count="2"
+        total-rows-count="10"></cds-table-batch-actions>
+    `);
+
+    const listener = oneEvent(el, 'cds-table-batch-actions-select-all-clicked');
+    const selectAll = el.shadowRoot?.querySelector(
+      '.cds--batch-summary__select-all'
+    );
+    selectAll?.click();
+    await listener;
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-body-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-body-test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-body', () => {
+  it('should set a default rowgroup role', async () => {
+    const el = await fixture(html`<cds-table-body></cds-table-body>`);
+    expect(el.getAttribute('role')).to.equal('rowgroup');
+  });
+
+  it('should fire content change event on slot change', async () => {
+    const el = await fixture(html`<cds-table-body></cds-table-body>`);
+
+    const listener = oneEvent(el, 'cds-table-body-content-change');
+    const row = document.createElement('cds-table-row');
+    el.append(row);
+
+    await listener;
+  });
+
+  it('should apply zebra even/odd flags to rows', async () => {
+    const el = await fixture(html`
+      <cds-table-body use-zebra-styles>
+        <cds-table-row></cds-table-row>
+        <cds-table-row></cds-table-row>
+      </cds-table-body>
+    `);
+
+    await el.updateComplete;
+
+    const rows = el.querySelectorAll('cds-table-row');
+    expect(rows[0].odd).to.equal(true);
+    expect(rows[0].even).to.equal(false);
+    expect(rows[1].even).to.equal(true);
+    expect(rows[1].odd).to.equal(false);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-cell-content-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-cell-content-test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-cell-content', () => {
+  it('should render slotted content', async () => {
+    const el = await fixture(html`
+      <cds-table-cell-content>Austin, Tx</cds-table-cell-content>
+    `);
+
+    expect(el.textContent?.trim()).to.equal('Austin, Tx');
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-cell-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-cell-test.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-cell', () => {
+  it('should set a default cell role', async () => {
+    const el = await fixture(html`<cds-table-cell></cds-table-cell>`);
+    expect(el.getAttribute('role')).to.equal('cell');
+  });
+
+  it('should reflect overflow-menu-on-hover attribute', async () => {
+    const el = await fixture(
+      html`<cds-table-cell overflow-menu-on-hover></cds-table-cell>`
+    );
+
+    expect(el.overflowMenuOnHover).to.equal(true);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-expanded-row-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-expanded-row-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-expanded-row', () => {
+  it('should render with a default colspan of 1', async () => {
+    const el = await fixture(
+      html`<cds-table-expanded-row></cds-table-expanded-row>`
+    );
+
+    const cell = el.shadowRoot?.querySelector('td');
+    expect(cell?.getAttribute('colspan')).to.equal('1');
+  });
+
+  it('should toggle previous row highlight on mouse events', async () => {
+    const el = await fixture(html`
+      <cds-table>
+        <cds-table-body>
+          <cds-table-row></cds-table-row>
+          <cds-table-expanded-row></cds-table-expanded-row>
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const row = el.querySelector('cds-table-row');
+    const expanded = el.querySelector('cds-table-expanded-row');
+
+    expanded?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    expect(row?.highlighted).to.equal(true);
+
+    expanded?.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+    expect(row?.highlighted).to.equal(false);
+  });
+
+  it('should not throw when there is no previous sibling row', async () => {
+    const expanded = await fixture(
+      html`<cds-table-expanded-row></cds-table-expanded-row>`
+    );
+
+    expect(() =>
+      expanded.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    ).to.not.throw();
+    expect(() =>
+      expanded.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }))
+    ).to.not.throw();
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-head-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-head-test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-head', () => {
+  it('should set a default rowgroup role', async () => {
+    const el = await fixture(html`<cds-table-head></cds-table-head>`);
+    expect(el.getAttribute('role')).to.equal('rowgroup');
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-header-cell-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-header-cell-test.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+import {
+  TABLE_SORT_CYCLE,
+  TABLE_SORT_DIRECTION,
+} from '@carbon/web-components/es/components/data-table/table-header-cell.js';
+
+describe('cds-table-header-cell', () => {
+  it('should set a default columnheader role', async () => {
+    const el = await fixture(
+      html`<cds-table-header-cell></cds-table-header-cell>`
+    );
+    expect(el.getAttribute('role')).to.equal('columnheader');
+  });
+
+  it('should render slotted children text', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell>Header</cds-table-header-cell>
+    `);
+
+    expect(el).to.have.text('Header');
+  });
+
+  it('should respect colspan attribute', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell colspan="4"></cds-table-header-cell>
+    `);
+
+    expect(el.getAttribute('colspan')).to.equal('4');
+  });
+
+  it('should respect id attribute', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell id="header-id"></cds-table-header-cell>
+    `);
+
+    expect(el.getAttribute('id')).to.equal('header-id');
+  });
+
+  it('should respect scope attribute', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell scope="row"></cds-table-header-cell>
+    `);
+
+    expect(el.getAttribute('scope')).to.equal('row');
+  });
+
+  it('should initialize sort direction to none when sortable', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell is-sortable></cds-table-header-cell>
+    `);
+
+    await el.updateComplete;
+
+    expect(el.sortDirection).to.equal(TABLE_SORT_DIRECTION.NONE);
+  });
+
+  it('should render sort button when sortable', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell is-sortable></cds-table-header-cell>
+    `);
+
+    const button = el.shadowRoot?.querySelector('.cds--table-sort');
+    expect(button).to.exist;
+  });
+
+  it('should update sort direction when sort button is clicked', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell
+        is-sortable
+        sort-active
+        sort-cycle="${TABLE_SORT_CYCLE.BI_STATES_FROM_ASCENDING}"
+        sort-direction="${TABLE_SORT_DIRECTION.NONE}">
+        Name
+      </cds-table-header-cell>
+    `);
+
+    const button = el.shadowRoot?.querySelector('.cds--table-sort');
+    button?.click();
+    await el.updateComplete;
+
+    expect(el.sortDirection).to.equal(TABLE_SORT_DIRECTION.ASCENDING);
+  });
+
+  it('should keep sort direction when sort event is canceled', async () => {
+    const el = await fixture(html`
+      <cds-table-header-cell
+        is-sortable
+        sort-active
+        sort-cycle="${TABLE_SORT_CYCLE.BI_STATES_FROM_ASCENDING}"
+        sort-direction="${TABLE_SORT_DIRECTION.NONE}">
+        Name
+      </cds-table-header-cell>
+    `);
+
+    el.addEventListener('cds-table-header-cell-sort', (event) => {
+      event.preventDefault();
+    });
+
+    const button = el.shadowRoot?.querySelector('.cds--table-sort');
+    button?.click();
+    await el.updateComplete;
+
+    expect(el.sortDirection).to.equal(TABLE_SORT_DIRECTION.NONE);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-header-description-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-header-description-test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-header-description', () => {
+  it('should render slotted content', async () => {
+    const el = await fixture(html`
+      <cds-table-header-description
+        >Data table description</cds-table-header-description
+      >
+    `);
+
+    expect(el.textContent?.trim()).to.equal('Data table description');
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-header-row-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-header-row-test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-header-row', () => {
+  it('should fire select-all event namespace used by table', async () => {
+    const row = await fixture(html`
+      <cds-table-header-row
+        selection-name="selection-name-foo"></cds-table-header-row>
+    `);
+
+    const listener = oneEvent(row, 'cds-table-change-selection-all');
+    const checkbox = row.shadowRoot?.querySelector('cds-checkbox');
+    checkbox?.dispatchEvent(
+      new CustomEvent('cds-checkbox-changed', {
+        bubbles: true,
+        composed: true,
+        detail: { checked: true },
+      })
+    );
+
+    const event = await listener;
+    expect(event.detail.selected).to.equal(true);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-header-title-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-header-title-test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-header-title', () => {
+  it('should render slotted content', async () => {
+    const el = await fixture(html`
+      <cds-table-header-title>Data table title</cds-table-header-title>
+    `);
+
+    expect(el.textContent?.trim()).to.equal('Data table title');
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-row-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-row-test.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-row', () => {
+  it('should set a default row role', async () => {
+    const row = await fixture(html`<cds-table-row></cds-table-row>`);
+    expect(row.getAttribute('role')).to.equal('row');
+  });
+
+  it('should support custom classes on the host element', async () => {
+    const row = await fixture(html`
+      <cds-table-row class="custom-class"></cds-table-row>
+    `);
+
+    expect(row).to.have.class('custom-class');
+  });
+
+  it('should render radio selection control when radio is set', async () => {
+    const row = await fixture(html`
+      <cds-table-row radio selection-name="selection-name-foo"></cds-table-row>
+    `);
+
+    const radio = row.shadowRoot?.querySelector('cds-radio-button');
+    expect(radio).to.exist;
+  });
+
+  it('should fire selection event and update selected state', async () => {
+    const row = await fixture(html`
+      <cds-table-row selection-name="selection-name-foo"></cds-table-row>
+    `);
+
+    const listener = oneEvent(row, 'cds-table-row-change-selection');
+    const checkbox = row.shadowRoot?.querySelector('cds-checkbox');
+    checkbox?.dispatchEvent(
+      new CustomEvent('cds-checkbox-changed', {
+        bubbles: true,
+        composed: true,
+        detail: { checked: true },
+      })
+    );
+
+    const event = await listener;
+    expect(event.detail.selected).to.equal(true);
+    expect(row.selected).to.equal(true);
+  });
+
+  it('should not update selected state if selection event is canceled', async () => {
+    const row = await fixture(html`
+      <cds-table-row selection-name="selection-name-foo"></cds-table-row>
+    `);
+
+    row.addEventListener('cds-table-row-change-selection', (event) => {
+      event.preventDefault();
+    });
+
+    const checkbox = row.shadowRoot?.querySelector('cds-checkbox');
+    checkbox?.dispatchEvent(
+      new CustomEvent('cds-checkbox-changed', {
+        bubbles: true,
+        composed: true,
+        detail: { checked: true },
+      })
+    );
+
+    await row.updateComplete;
+    expect(row.selected).to.equal(false);
+  });
+
+  it('should expand row and paired expanded row on toggle button click', async () => {
+    const el = await fixture(html`
+      <cds-table expandable>
+        <cds-table-body>
+          <cds-table-row expandable></cds-table-row>
+          <cds-table-expanded-row></cds-table-expanded-row>
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const row = el.querySelector('cds-table-row');
+    const expandedRow = el.querySelector('cds-table-expanded-row');
+    const button = row?.shadowRoot?.querySelector('.cds--table-expand__button');
+
+    button?.click();
+    await row?.updateComplete;
+    await expandedRow?.updateComplete;
+
+    expect(row?.expanded).to.equal(true);
+    expect(expandedRow?.expanded).to.equal(true);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-skeleton-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-skeleton-test.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-skeleton', () => {
+  describe('renders as expected - Component API', () => {
+    it('should set a default table role', async () => {
+      const el = await fixture(html`<cds-table-skeleton></cds-table-skeleton>`);
+      expect(el.getAttribute('role')).to.equal('table');
+    });
+
+    it('should render with skeleton and data-table classes', async () => {
+      const el = await fixture(html`<cds-table-skeleton></cds-table-skeleton>`);
+      const table = el.shadowRoot?.querySelector('table');
+      expect(table?.classList.contains('cds--skeleton')).to.equal(true);
+      expect(table?.classList.contains('cds--data-table')).to.equal(true);
+    });
+
+    it('should support custom class and extra attributes on the host', async () => {
+      const el = await fixture(html`
+        <cds-table-skeleton
+          class="custom-class"
+          data-testid="test-id"></cds-table-skeleton>
+      `);
+      expect(el.classList.contains('custom-class')).to.equal(true);
+      expect(el.getAttribute('data-testid')).to.equal('test-id');
+    });
+
+    it('should respect row-count and column-count', async () => {
+      const el = await fixture(html`
+        <cds-table-skeleton row-count="3" column-count="4"></cds-table-skeleton>
+      `);
+
+      await el.updateComplete;
+
+      const rows = el.shadowRoot?.querySelectorAll('tbody tr');
+      const cols = el.shadowRoot?.querySelectorAll('thead th');
+
+      expect(rows?.length).to.equal(3);
+      expect(cols?.length).to.equal(4);
+    });
+
+    it('should respect the zebra prop', async () => {
+      const el = await fixture(
+        html`<cds-table-skeleton zebra></cds-table-skeleton>`
+      );
+      const table = el.shadowRoot?.querySelector('table');
+      expect(table?.classList.contains('cds--data-table--zebra')).to.equal(
+        true
+      );
+    });
+
+    it('should respect show-header=false', async () => {
+      const el = await fixture(html`<cds-table-skeleton></cds-table-skeleton>`);
+      el.showHeader = false;
+      await el.updateComplete;
+
+      const header = el.shadowRoot?.querySelector('.cds--data-table-header');
+      expect(header).to.equal(null);
+    });
+
+    it('should respect show-toolbar=false', async () => {
+      const el = await fixture(html`<cds-table-skeleton></cds-table-skeleton>`);
+      el.showToolbar = false;
+      await el.updateComplete;
+
+      const toolbar = el.shadowRoot?.querySelector('.cds--table-toolbar');
+      expect(toolbar).to.equal(null);
+    });
+
+    it('should respect headers property', async () => {
+      const el = await fixture(html`<cds-table-skeleton></cds-table-skeleton>`);
+      el.headers = ['Name', 'Protocol', 'Port'];
+      await el.updateComplete;
+
+      const headerLabels = Array.from(
+        el.shadowRoot?.querySelectorAll('thead th .cds--table-header-label') ??
+          []
+      ).map((node) => node.textContent?.trim());
+
+      expect(headerLabels.slice(0, 3)).to.deep.equal([
+        'Name',
+        'Protocol',
+        'Port',
+      ]);
+    });
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-test.js
@@ -1,0 +1,504 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table', () => {
+  it('should set a default table role', async () => {
+    const el = await fixture(html`
+      <cds-table>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body></cds-table-body>
+      </cds-table>
+    `);
+    expect(el.getAttribute('role')).to.equal('table');
+  });
+
+  it('should propagate size to rows and toolbar', async () => {
+    const el = await fixture(html`
+      <cds-table size="sm">
+        <cds-table-toolbar></cds-table-toolbar>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row></cds-table-row>
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    await el.updateComplete;
+
+    const row = el.querySelector('cds-table-row');
+    const toolbar = el.querySelector('cds-table-toolbar');
+
+    expect(row?.getAttribute('size')).to.equal('sm');
+    expect(toolbar?.getAttribute('size')).to.equal('sm');
+  });
+
+  it('should propagate zebra mode to table body', async () => {
+    const el = await fixture(html`
+      <cds-table use-zebra-styles>
+        <cds-table-body>
+          <cds-table-row></cds-table-row>
+          <cds-table-row></cds-table-row>
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    await el.updateComplete;
+
+    const body = el.querySelector('cds-table-body');
+    expect(body?.useZebraStyles).to.equal(true);
+  });
+
+  it('should sort rows when header sort event is fired', async () => {
+    const el = await fixture(html`
+      <cds-table is-sortable>
+        <cds-table-head>
+          <cds-table-header-row>
+            <cds-table-header-cell>Name</cds-table-header-cell>
+          </cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const headerCell = el.querySelector('cds-table-header-cell');
+    const sortedListener = oneEvent(el, 'cds-table-sorted');
+
+    headerCell?.dispatchEvent(
+      new CustomEvent('cds-table-header-cell-sort', {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        detail: {
+          oldSortDirection: 'none',
+          sortDirection: 'ascending',
+        },
+      })
+    );
+
+    await sortedListener;
+    await el.updateComplete;
+
+    const firstCellText = el
+      .querySelector('cds-table-body')
+      ?.querySelector('cds-table-row cds-table-cell')
+      ?.textContent?.trim();
+    expect(firstCellText).to.equal('Field 1');
+  });
+
+  it('should filter rows when search input event is fired', async () => {
+    const el = await fixture(html`
+      <cds-table>
+        <cds-table-toolbar>
+          <cds-table-toolbar-content>
+            <cds-table-toolbar-search></cds-table-toolbar-search>
+          </cds-table-toolbar-content>
+        </cds-table-toolbar>
+        <cds-table-head>
+          <cds-table-header-row>
+            <cds-table-header-cell>Name</cds-table-header-cell>
+          </cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const search = el.querySelector('cds-table-toolbar-search');
+    const filteredListener = oneEvent(el, 'cds-table-filtered');
+
+    search?.dispatchEvent(
+      new CustomEvent('cds-search-input', {
+        bubbles: true,
+        composed: true,
+        detail: { value: 'Field 1' },
+      })
+    );
+
+    await filteredListener;
+    await el.updateComplete;
+
+    const rows = el.querySelectorAll('cds-table-row');
+    expect(rows[0].filtered).to.equal(true);
+    expect(rows[1].filtered).to.equal(false);
+  });
+
+  it('should reset to ascending ordering when another header is sorted', async () => {
+    const el = await fixture(html`
+      <cds-table is-sortable>
+        <cds-table-head>
+          <cds-table-header-row>
+            <cds-table-header-cell sort-direction="ascending">
+              Field A
+            </cds-table-header-cell>
+            <cds-table-header-cell sort-direction="none">
+              Field B
+            </cds-table-header-cell>
+          </cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row>
+            <cds-table-cell>Field 2:A</cds-table-cell>
+            <cds-table-cell>Field 2:B</cds-table-cell>
+          </cds-table-row>
+          <cds-table-row>
+            <cds-table-cell>Field 1:A</cds-table-cell>
+            <cds-table-cell>Field 1:B</cds-table-cell>
+          </cds-table-row>
+          <cds-table-row>
+            <cds-table-cell>Field 3:A</cds-table-cell>
+            <cds-table-cell>Field 3:B</cds-table-cell>
+          </cds-table-row>
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const headerCells = el.querySelectorAll('cds-table-header-cell');
+    const firstHeader = headerCells[0];
+    const secondHeader = headerCells[1];
+    const sortedListener = oneEvent(el, 'cds-table-sorted');
+
+    const secondSortButton =
+      secondHeader?.shadowRoot?.querySelector('.cds--table-sort');
+    secondSortButton?.click();
+
+    await sortedListener;
+    await el.updateComplete;
+
+    expect(firstHeader?.getAttribute('sort-direction')).to.equal('none');
+    expect(secondHeader?.getAttribute('sort-direction')).to.equal('ascending');
+  });
+
+  it('should have select-all default to unchecked if no rows are present', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body></cds-table-body>
+      </cds-table>
+    `);
+
+    await el.updateComplete;
+
+    const headerCheckbox = el
+      .querySelector('cds-table-header-row')
+      ?.shadowRoot?.querySelector('cds-checkbox')
+      ?.shadowRoot?.querySelector('.cds--checkbox');
+
+    expect(headerCheckbox?.checked).to.equal(false);
+    expect(headerCheckbox?.indeterminate).to.equal(false);
+  });
+
+  it('should select all rows when header row selection event is fired', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const headerRow = el.querySelector('cds-table-header-row');
+    const selectAllListener = oneEvent(el, 'cds-table-row-all-selected');
+
+    headerRow?.dispatchEvent(
+      new CustomEvent('cds-table-change-selection-all', {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        detail: { selected: true },
+      })
+    );
+
+    await selectAllListener;
+    await el.updateComplete;
+
+    const rows = el.querySelectorAll('cds-table-row');
+    expect(rows[0].selected).to.equal(true);
+    expect(rows[1].selected).to.equal(true);
+  });
+
+  it('should select a specific row when row selection event is fired', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const row = el.querySelector('cds-table-row');
+    const rowSelectedListener = oneEvent(el, 'cds-table-row-selected');
+    const rowCheckbox = row?.shadowRoot?.querySelector('cds-checkbox');
+    rowCheckbox?.dispatchEvent(
+      new CustomEvent('cds-checkbox-changed', {
+        bubbles: true,
+        composed: true,
+        detail: { checked: true },
+      })
+    );
+
+    await rowSelectedListener;
+    await el.updateComplete;
+
+    const headerCheckbox = el
+      .querySelector('cds-table-header-row')
+      ?.shadowRoot?.querySelector('cds-checkbox')
+      ?.shadowRoot?.querySelector('.cds--checkbox');
+
+    expect(row?.selected).to.equal(true);
+    expect(headerCheckbox?.checked).to.equal(true);
+    expect(headerCheckbox?.indeterminate).to.equal(true);
+  });
+
+  it('should only select all unfiltered rows', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable>
+        <cds-table-toolbar>
+          <cds-table-toolbar-content>
+            <cds-table-toolbar-search></cds-table-toolbar-search>
+          </cds-table-toolbar-content>
+        </cds-table-toolbar>
+        <cds-table-head>
+          <cds-table-header-row>
+            <cds-table-header-cell>Name</cds-table-header-cell>
+          </cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 3</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const search = el.querySelector('cds-table-toolbar-search');
+    const headerRow = el.querySelector('cds-table-header-row');
+
+    const filteredListener = oneEvent(el, 'cds-table-filtered');
+    search?.dispatchEvent(
+      new CustomEvent('cds-search-input', {
+        bubbles: true,
+        composed: true,
+        detail: { value: 'Field 1' },
+      })
+    );
+    await filteredListener;
+
+    const selectAllListener = oneEvent(el, 'cds-table-row-all-selected');
+    headerRow?.dispatchEvent(
+      new CustomEvent('cds-table-change-selection-all', {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        detail: { selected: true },
+      })
+    );
+
+    await selectAllListener;
+    await el.updateComplete;
+
+    const rows = el.querySelectorAll('cds-table-row');
+    expect(rows[0].selected).to.equal(false);
+    expect(rows[1].selected).to.equal(true);
+    expect(rows[2].selected).to.equal(false);
+  });
+
+  it('should only select rows that are not disabled even when filtered', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable>
+        <cds-table-toolbar>
+          <cds-table-toolbar-content>
+            <cds-table-toolbar-search></cds-table-toolbar-search>
+          </cds-table-toolbar-content>
+        </cds-table-toolbar>
+        <cds-table-head>
+          <cds-table-header-row>
+            <cds-table-header-cell>Name</cds-table-header-cell>
+          </cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+          <cds-table-row disabled
+            ><cds-table-cell>Field 1 disabled</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const search = el.querySelector('cds-table-toolbar-search');
+    const headerRow = el.querySelector('cds-table-header-row');
+    const filteredListener = oneEvent(el, 'cds-table-filtered');
+
+    search?.dispatchEvent(
+      new CustomEvent('cds-search-input', {
+        bubbles: true,
+        composed: true,
+        detail: { value: 'Field 1' },
+      })
+    );
+    await filteredListener;
+
+    const headerCheckbox = headerRow?.shadowRoot
+      ?.querySelector('cds-checkbox')
+      ?.shadowRoot?.querySelector('.cds--checkbox');
+
+    const selectAllListener = oneEvent(el, 'cds-table-row-all-selected');
+    headerCheckbox?.click();
+
+    await selectAllListener;
+    await el.updateComplete;
+
+    const rows = el.querySelectorAll('cds-table-row');
+    expect(rows[0].selected).to.equal(false);
+    expect(rows[1].selected).to.equal(true);
+    expect(rows[2].selected).to.equal(false);
+    expect(headerCheckbox?.checked).to.equal(true);
+    expect(headerCheckbox?.indeterminate).to.equal(false);
+  });
+
+  it('should deselect all other rows in radio mode when a row is selected', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable radio>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const rows = el.querySelectorAll('cds-table-row');
+
+    const firstRadio = rows[0]?.shadowRoot?.querySelector('cds-radio-button');
+    const secondRadio = rows[1]?.shadowRoot?.querySelector('cds-radio-button');
+
+    const firstSelectionListener = oneEvent(el, 'cds-table-row-selected');
+    firstRadio?.dispatchEvent(
+      new CustomEvent('cds-radio-button-changed', {
+        bubbles: true,
+        composed: true,
+        detail: { checked: true },
+      })
+    );
+    await firstSelectionListener;
+
+    const secondSelectionListener = oneEvent(el, 'cds-table-row-selected');
+    secondRadio?.dispatchEvent(
+      new CustomEvent('cds-radio-button-changed', {
+        bubbles: true,
+        composed: true,
+        detail: { checked: true },
+      })
+    );
+    await secondSelectionListener;
+    await el.updateComplete;
+
+    expect(rows[0].selected).to.equal(false);
+    expect(rows[1].selected).to.equal(true);
+  });
+
+  it('should clear selected rows when batch action cancel is fired', async () => {
+    const el = await fixture(html`
+      <cds-table is-selectable>
+        <cds-table-toolbar>
+          <cds-table-toolbar-content></cds-table-toolbar-content>
+          <cds-table-batch-actions></cds-table-batch-actions>
+        </cds-table-toolbar>
+        <cds-table-head>
+          <cds-table-header-row></cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body>
+          <cds-table-row
+            ><cds-table-cell>Field 2</cds-table-cell></cds-table-row
+          >
+          <cds-table-row
+            ><cds-table-cell>Field 1</cds-table-cell></cds-table-row
+          >
+        </cds-table-body>
+      </cds-table>
+    `);
+
+    const headerRow = el.querySelector('cds-table-header-row');
+    const batchActions = el.querySelector('cds-table-batch-actions');
+    const headerCheckbox = headerRow?.shadowRoot
+      ?.querySelector('cds-checkbox')
+      ?.shadowRoot?.querySelector('.cds--checkbox');
+
+    const selectAllListener = oneEvent(el, 'cds-table-row-all-selected');
+    headerCheckbox?.click();
+    await selectAllListener;
+
+    const cancelListener = oneEvent(el, 'cds-table-row-all-selected');
+    batchActions?.dispatchEvent(
+      new CustomEvent('cds-table-batch-actions-cancel-clicked', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await cancelListener;
+    await el.updateComplete;
+
+    const rows = el.querySelectorAll('cds-table-row');
+    expect(rows[0].selected).to.equal(false);
+    expect(rows[1].selected).to.equal(false);
+    expect(batchActions?.selectedRowsCount).to.equal(0);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-toolbar-content-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-toolbar-content-test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-toolbar-content', () => {
+  it('should set tabindex when batch actions are active', async () => {
+    const el = await fixture(html`
+      <cds-table-toolbar-content has-batch-actions>
+        <cds-button></cds-button>
+      </cds-table-toolbar-content>
+    `);
+
+    await el.updateComplete;
+
+    expect(el.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('should propagate normalized size to children', async () => {
+    const el = await fixture(html`
+      <cds-table-toolbar-content size="xs">
+        <cds-button></cds-button>
+      </cds-table-toolbar-content>
+    `);
+
+    await el.updateComplete;
+
+    const button = el.querySelector('cds-button');
+    expect(button?.getAttribute('size')).to.equal('sm');
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-toolbar-search-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-toolbar-search-test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-toolbar-search', () => {
+  it('should set a default search role', async () => {
+    const el = await fixture(
+      html`<cds-table-toolbar-search></cds-table-toolbar-search>`
+    );
+
+    expect(el.getAttribute('role')).to.equal('search');
+  });
+
+  it('should reflect size attribute', async () => {
+    const el = await fixture(html`
+      <cds-table-toolbar-search size="sm"></cds-table-toolbar-search>
+    `);
+
+    expect(el.getAttribute('size')).to.equal('sm');
+  });
+
+  it('should expand on focus in', async () => {
+    const el = await fixture(
+      html`<cds-table-toolbar-search></cds-table-toolbar-search>`
+    );
+
+    el.dispatchEvent(new CustomEvent('focusin', { bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.expanded).to.equal(true);
+  });
+
+  it('should collapse on focus out when empty and not persistent', async () => {
+    const el = await fixture(
+      html`<cds-table-toolbar-search expanded></cds-table-toolbar-search>`
+    );
+
+    el.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.expanded).to.equal(false);
+  });
+
+  it('should stay expanded when persistent', async () => {
+    const el = await fixture(
+      html`<cds-table-toolbar-search persistent></cds-table-toolbar-search>`
+    );
+
+    await el.updateComplete;
+
+    expect(el.expanded).to.equal(true);
+  });
+});

--- a/packages/web-components/src/components/data-table/__tests__/table-toolbar-test.js
+++ b/packages/web-components/src/components/data-table/__tests__/table-toolbar-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '@carbon/web-components/es/components/data-table/index.js';
+
+describe('cds-table-toolbar', () => {
+  it('should set a default toolbar role', async () => {
+    const el = await fixture(html`<cds-table-toolbar></cds-table-toolbar>`);
+    expect(el.getAttribute('role')).to.equal('toolbar');
+  });
+
+  it('should propagate size to toolbar content and batch actions', async () => {
+    const el = await fixture(html`
+      <cds-table-toolbar size="sm">
+        <cds-table-toolbar-content></cds-table-toolbar-content>
+        <cds-table-batch-actions></cds-table-batch-actions>
+      </cds-table-toolbar>
+    `);
+
+    await el.updateComplete;
+
+    const content = el.querySelector('cds-table-toolbar-content');
+    const actions = el.querySelector('cds-table-batch-actions');
+
+    expect(content?.getAttribute('size')).to.equal('sm');
+    expect(actions?.getAttribute('size')).to.equal('sm');
+  });
+});


### PR DESCRIPTION
Closes #20050 

Add unit tests for `cds-table` and related `data-table` Web Components for parity with React DataTable behavior where applicable.

### Changelog

**New**

- Added unit test files under `packages/web-components/src/components/data-table/__tests__/`

**Changed**

- ~None~

**Removed**

- ~None~

#### Testing / Reviewing

- Run `yarn test` in `packages/web-components` to make sure tests pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)