### PR TITLE
fix: restore displayName fallback for child components

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -178,7 +178,9 @@ const Checkbox = React.forwardRef(
     });
 
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, {
           size: candidate.props.kind === 'inline' ? 'md' : 'mini',

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -103,7 +103,9 @@ const CheckboxGroup = ({
 
   // AILabel always size `mini`
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'mini', kind: 'default' })
     : candidate;

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -828,7 +828,9 @@ const ComboBox = forwardRef(
 
     // AILabel always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini' })
       : candidate;

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -559,7 +559,9 @@ const ComposedModalDialog = React.forwardRef<
 
   // AILabel is always size `sm`
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'sm' })
     : candidate;

--- a/packages/react/src/components/ContainedList/ContainedList.tsx
+++ b/packages/react/src/components/ContainedList/ContainedList.tsx
@@ -21,8 +21,12 @@ const variants = ['on-page', 'disclosed'] as const;
 export type Variants = (typeof variants)[number];
 
 const isSearchComponent = (node: ReactNode) =>
-  isComponentElement(node, Search) ||
-  isComponentElement(node, ExpandableSearch);
+  isComponentElement(node, Search, {
+    allowDisplayNameFallback: true,
+  }) ||
+  isComponentElement(node, ExpandableSearch, {
+    allowDisplayNameFallback: true,
+  });
 
 export interface ContainedListProps {
   /**

--- a/packages/react/src/components/ContainedList/__tests__/ContainedList-test.js
+++ b/packages/react/src/components/ContainedList/__tests__/ContainedList-test.js
@@ -172,7 +172,7 @@ describe('ContainedList', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should not treat components with `displayName` "Search" as `Search`', () => {
+  it('should treat components with `displayName` "Search" as `Search`', () => {
     const FauxSearch = () => (
       <button data-testid="faux-search-action">Action</button>
     );
@@ -185,7 +185,7 @@ describe('ContainedList', () => {
     );
 
     expect(screen.getByTestId('faux-search-action')).toBeInTheDocument();
-    expect(screen.getByTestId('search-child-id')).toBeInTheDocument();
+    expect(screen.queryByTestId('search-child-id')).not.toBeInTheDocument();
   });
 
   it('should render Search as the first child', () => {

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -140,7 +140,9 @@ export const ContentSwitcher = ({
 
         if (
           isComponentElement(child, Switch) ||
-          isComponentElement(child, IconSwitch)
+          isComponentElement(child, IconSwitch, {
+            allowDisplayNameFallback: true,
+          })
         ) {
           onChange({
             ...event,
@@ -163,7 +165,9 @@ export const ContentSwitcher = ({
   };
 
   const isIconOnly = Children.map(children, (child) => {
-    return isComponentElement(child, IconSwitch);
+    return isComponentElement(child, IconSwitch, {
+      allowDisplayNameFallback: true,
+    });
   })?.every((val) => val === true);
 
   const classes = classNames(`${prefix}--content-switcher`, className, {
@@ -184,7 +188,9 @@ export const ContentSwitcher = ({
       {Children.map(children, (child, index) => {
         if (
           !isComponentElement(child, Switch) &&
-          !isComponentElement(child, IconSwitch)
+          !isComponentElement(child, IconSwitch, {
+            allowDisplayNameFallback: true,
+          })
         )
           return child;
 
@@ -204,7 +210,11 @@ export const ContentSwitcher = ({
 
         return cloneElement(child, {
           ...sharedProps,
-          ...(isComponentElement(child, IconSwitch) ? { size } : {}),
+          ...(isComponentElement(child, IconSwitch, {
+            allowDisplayNameFallback: true,
+          })
+            ? { size }
+            : {}),
         });
       })}
     </LayoutConstraint>

--- a/packages/react/src/components/DataTable/TableDecoratorRow.tsx
+++ b/packages/react/src/components/DataTable/TableDecoratorRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,7 +35,9 @@ const TableDecoratorRow = ({
     [`${prefix}--table-column-decorator--active`]: decorator,
   });
 
-  const decoratorIsAILabel = isComponentElement(decorator, AILabel);
+  const decoratorIsAILabel = isComponentElement(decorator, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = decoratorIsAILabel
     ? cloneElement(decorator, { size: 'mini' })
     : null;

--- a/packages/react/src/components/DataTable/TableExpandRow.tsx
+++ b/packages/react/src/components/DataTable/TableExpandRow.tsx
@@ -123,14 +123,26 @@ const TableExpandRow = forwardRef<HTMLTableCellElement, TableExpandRowProps>(
     // We need to put the AILabel and Decorator before the expansion arrow and all other table cells after the arrow.
     let rowHasAILabel;
     const decorator = Children.toArray(children).map((child) => {
-      if (isComponentElement(child, TableSlugRow)) {
+      if (
+        isComponentElement(child, TableSlugRow, {
+          allowDisplayNameFallback: true,
+        })
+      ) {
         if (child.props.slug) {
           rowHasAILabel = true;
         }
 
         return child;
-      } else if (isComponentElement(child, TableDecoratorRow)) {
-        if (isComponentElement(child.props.decorator, AILabel)) {
+      } else if (
+        isComponentElement(child, TableDecoratorRow, {
+          allowDisplayNameFallback: true,
+        })
+      ) {
+        if (
+          isComponentElement(child.props.decorator, AILabel, {
+            allowDisplayNameFallback: true,
+          })
+        ) {
           rowHasAILabel = true;
         }
 
@@ -140,8 +152,12 @@ const TableExpandRow = forwardRef<HTMLTableCellElement, TableExpandRowProps>(
 
     const normalizedChildren = Children.toArray(children).map((child) => {
       if (
-        !isComponentElement(child, TableSlugRow) &&
-        !isComponentElement(child, TableDecoratorRow)
+        !isComponentElement(child, TableSlugRow, {
+          allowDisplayNameFallback: true,
+        }) &&
+        !isComponentElement(child, TableDecoratorRow, {
+          allowDisplayNameFallback: true,
+        })
       ) {
         return child;
       }

--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -171,7 +171,9 @@ const TableHeader = frFn((props, ref) => {
   const AILableRef = useRef<HTMLInputElement>(null);
 
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const colHasAILabel = candidateIsAILabel;
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'mini', ref: AILableRef })

--- a/packages/react/src/components/DataTable/TableRow.tsx
+++ b/packages/react/src/components/DataTable/TableRow.tsx
@@ -43,13 +43,21 @@ const TableRow = frFn((props, ref) => {
   const prefix = usePrefix();
 
   const rowHasAILabel = Children.toArray(props.children).some((child) => {
-    if (isComponentElement(child, TableSlugRow)) {
+    if (
+      isComponentElement(child, TableSlugRow, {
+        allowDisplayNameFallback: true,
+      })
+    ) {
       return !!child.props.slug;
     }
 
     return (
-      isComponentElement(child, TableDecoratorRow) &&
-      isComponentElement(child.props.decorator, AILabel)
+      isComponentElement(child, TableDecoratorRow, {
+        allowDisplayNameFallback: true,
+      }) &&
+      isComponentElement(child.props.decorator, AILabel, {
+        allowDisplayNameFallback: true,
+      })
     );
   });
 

--- a/packages/react/src/components/DataTable/tools/normalize.js
+++ b/packages/react/src/components/DataTable/tools/normalize.js
@@ -57,7 +57,12 @@ const normalize = (rows, headers, prevState = {}) => {
         isEditing: false,
         isValid: true,
         errors: null,
-        hasAILabelHeader: !!(slug || isComponentElement(decorator, AILabel)),
+        hasAILabelHeader: !!(
+          slug ||
+          isComponentElement(decorator, AILabel, {
+            allowDisplayNameFallback: true,
+          })
+        ),
         info: {
           header: key,
         },

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -269,7 +269,9 @@ const DatePickerInput = frFn((props, ref) => {
 
   // AILabel always size `mini`
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'mini' })
     : candidate;

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -608,7 +608,9 @@ const Dropdown = React.forwardRef(
 
     // AILabel is always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini' })
       : candidate;

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -667,7 +667,9 @@ const ModalDialog = React.forwardRef(function ModalDialog(
 
   // AILabel always size `sm`
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'sm' })
     : candidate;

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -835,7 +835,9 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
 
   // AILabel always size `mini`
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'mini' })
     : candidate;

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -692,7 +692,9 @@ export const MultiSelect = React.forwardRef(
 
     // AILabel always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini' })
       : candidate;

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -881,13 +881,17 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
 
     // AILabel always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini' })
       : candidate;
 
     // Need to update the internal value when the revert button is clicked
-    const isRevertActive = isComponentElement(normalizedDecorator, AILabel)
+    const isRevertActive = isComponentElement(normalizedDecorator, AILabel, {
+      allowDisplayNameFallback: true,
+    })
       ? normalizedDecorator.props.revertActive
       : undefined;
 

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -532,7 +532,11 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
     );
 
     const childrenWithProps = Children.toArray(children).map((child, index) => {
-      if (isComponentElement(child, OverflowMenuItem)) {
+      if (
+        isComponentElement(child, OverflowMenuItem, {
+          allowDisplayNameFallback: true,
+        })
+      ) {
         return cloneElement(child, {
           closeMenu: child.props.closeMenu || closeMenuAndFocus,
           handleOverflowMenuItemFocus,

--- a/packages/react/src/components/RadioButton/RadioButton.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -197,7 +197,9 @@ const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
     const inputRef = useRef<HTMLInputElement>(null);
 
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, {
           size: candidate.props?.['kind'] === 'inline' ? 'md' : 'mini',

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -251,7 +251,9 @@ const RadioButtonGroup = React.forwardRef(
 
     // AILabel is always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini', kind: 'default' })
       : candidate;

--- a/packages/react/src/components/RadioTile/RadioTile.tsx
+++ b/packages/react/src/components/RadioTile/RadioTile.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -181,7 +181,9 @@ const RadioTile = React.forwardRef(
 
     // AILabel is always size `xs`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'xs' })
       : candidate;

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -283,7 +283,9 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
 
     // AILabel always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini' })
       : candidate;

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -153,7 +153,9 @@ const DismissibleTag = forwardRef(
     };
 
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'sm', kind: 'inline' })
       : candidate;

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -211,7 +211,9 @@ const TagBase = React.forwardRef<
 
     // AILabel is always size `sm` and `inline`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator =
       candidateIsAILabel && !isInteractiveTag
         ? cloneElement(candidate, { size: 'sm', kind: 'inline' })

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -524,7 +524,9 @@ const TextArea = frFn((props, forwardRef) => {
 
   // AILabel is always size `mini`
   const candidate = slug ?? decorator;
-  const candidateIsAILabel = isComponentElement(candidate, AILabel);
+  const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+    allowDisplayNameFallback: true,
+  });
   const normalizedDecorator = candidateIsAILabel
     ? cloneElement(candidate, { size: 'mini' })
     : candidate;

--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -378,7 +378,9 @@ const TextInput = forwardRef<unknown, TextInputProps>(
 
     // AILabel is always size `mini`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'mini' })
       : candidate;

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -551,7 +551,9 @@ export const SelectableTile = React.forwardRef<
     // AILabel is always size `xs`
     const decoratorRef = useRef<HTMLInputElement>(null);
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'xs', ref: decoratorRef })
       : candidate;
@@ -912,7 +914,9 @@ export const ExpandableTile = forwardRef<HTMLElement, ExpandableTileProps>(
 
     // AILabel is always size `xs`
     const candidate = slug ?? decorator;
-    const candidateIsAILabel = isComponentElement(candidate, AILabel);
+    const candidateIsAILabel = isComponentElement(candidate, AILabel, {
+      allowDisplayNameFallback: true,
+    });
     const normalizedDecorator = candidateIsAILabel
       ? cloneElement(candidate, { size: 'xs' })
       : candidate;

--- a/packages/react/src/components/UIShell/HeaderPanel.tsx
+++ b/packages/react/src/components/UIShell/HeaderPanel.tsx
@@ -118,7 +118,9 @@ const HeaderPanel = React.forwardRef<HTMLDivElement, HeaderPanelProps>(
       if (!(target instanceof Element)) return;
       setLastClickedElement(target);
 
-      const isChildASwitcher = isComponentElement(children, Switcher);
+      const isChildASwitcher = isComponentElement(children, Switcher, {
+        allowDisplayNameFallback: true,
+      });
 
       if (
         isChildASwitcher &&

--- a/packages/react/src/internal/__tests__/utils.js
+++ b/packages/react/src/internal/__tests__/utils.js
@@ -59,4 +59,39 @@ describe('isComponentElement', () => {
     expect(isComponentElement(ComponentB, ComponentB)).toBe(false);
     expect(isComponentElement(ComponentA, ComponentB)).toBe(false);
   });
+
+  it('should return `false` when `displayName` matches without fallback enabled', () => {
+    const WrappedComponent = () => <div>wrapped</div>;
+
+    TestComponent.displayName = 'TestComponent';
+    WrappedComponent.displayName = 'TestComponent';
+
+    const element = <WrappedComponent />;
+
+    expect(isComponentElement(element, TestComponent)).toBe(false);
+  });
+
+  it('should return `true` when `displayName` matches and fallback is enabled', () => {
+    const WrappedComponent = () => <div>wrapped</div>;
+
+    TestComponent.displayName = 'TestComponent';
+    WrappedComponent.displayName = 'TestComponent';
+
+    const element = <WrappedComponent />;
+
+    expect(
+      isComponentElement(element, TestComponent, {
+        allowDisplayNameFallback: true,
+      })
+    ).toBe(true);
+  });
+
+  it('should return `false` when only the compared component has `displayName`', () => {
+    TestComponent.displayName = 'TestComponent';
+
+    const OtherComponent = () => <div>other</div>;
+    const element = <OtherComponent />;
+
+    expect(isComponentElement(element, TestComponent)).toBe(false);
+  });
 });

--- a/packages/react/src/internal/utils.ts
+++ b/packages/react/src/internal/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,6 +12,20 @@ import {
   type ReactNode,
 } from 'react';
 
+type ComponentWithDisplayName = {
+  displayName?: string;
+};
+
+const getDisplayName = (component: unknown) => {
+  if (
+    !component ||
+    (typeof component !== 'function' && typeof component !== 'object')
+  )
+    return;
+
+  return (component as ComponentWithDisplayName).displayName;
+};
+
 /**
  * Checks if an element is a valid React element of a given component type.
  *
@@ -20,6 +34,22 @@ import {
  */
 export const isComponentElement = <P>(
   element: ReactNode,
-  component: ComponentType<P>
-): element is ReactElement<P> =>
-  isValidElement<P>(element) && element.type === component;
+  component: ComponentType<P>,
+  options?: {
+    allowDisplayNameFallback?: boolean;
+  }
+): element is ReactElement<P> => {
+  if (!isValidElement<P>(element)) return false;
+
+  if (element.type === component) return true;
+
+  if (!options?.allowDisplayNameFallback) return false;
+
+  const elementDisplayName = getDisplayName(element.type);
+  const componentDisplayName = getDisplayName(component);
+
+  return (
+    typeof elementDisplayName === 'string' &&
+    elementDisplayName === componentDisplayName
+  );
+};


### PR DESCRIPTION
No issue. These changes are meant to address an issue reported internally.

Restored `displayName` fallbacks for child components.

### Changelog

**Changed**

- Restored `displayName` fallbacks for child components.

#### Testing / Reviewing

The main reason I added `isComponentElement` was to ensure type safety. However, that util as orignally written, didn't consider `displayName`. I've updated it to take that into account. Needless to say, oops.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
