### PR TITLE
Quality: Future copyright year in source code

### DIFF
--- a/packages/web-components/src/components/fluid-form/index.ts
+++ b/packages/web-components/src/components/fluid-form/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2026
+ * Copyright IBM Corp. 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
## Problem

Several files contain copyright years in the future (2025, 2026), which appears to be incorrect or premature. This includes files like fluid-form, pagination-nav, menu-button, combo-button, and others.

**Severity**: `medium`
**File**: `packages/web-components/src/components/fluid-form/index.ts`

## Solution

Update copyright year to current year (2024) or remove if this is intentional for planned future changes

## Changes

- `packages/web-components/src/components/fluid-form/index.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
