### PR TITLE
fix: remove unnecessary TypeScript ignores

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { type ReactNode } from 'react';
+import React from 'react';
 import { IconButton, IconButtonKind, IconButtonKinds } from '../IconButton';
 import { PopoverAlignment } from '../Popover';
 import ButtonBase from './ButtonBase';
@@ -125,8 +125,11 @@ export type ButtonProps<T extends React.ElementType> =
   PolymorphicComponentPropWithRef<T, ButtonBaseProps>;
 
 export type ButtonComponent = <T extends React.ElementType = 'button'>(
-  props: ButtonProps<T>
-) => ReactNode;
+  props: ButtonProps<T>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
+  context?: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
+) => React.ReactElement | any;
 
 function isIconOnlyButton(
   hasIconOnly: ButtonBaseProps['hasIconOnly'],

--- a/packages/react/src/components/DataTable/TableExpandRow.tsx
+++ b/packages/react/src/components/DataTable/TableExpandRow.tsx
@@ -197,8 +197,6 @@ TableExpandRow.propTypes = {
    * Specify the string read by a voice reader when the expand trigger is
    * focused
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-  /**@ts-ignore*/
   'aria-label': PropTypes.string,
 
   /**

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -424,8 +424,6 @@ const DialogControls = React.forwardRef<HTMLDivElement, DialogControlsProps>(
   ({ children, ...rest }, ref) => {
     const prefix = usePrefix();
     return (
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-      // @ts-ignore
       <div className={`${prefix}--dialog__header-controls`} ref={ref} {...rest}>
         {children}
       </div>

--- a/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.tsx
+++ b/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.tsx
@@ -178,8 +178,6 @@ const FluidMultiSelect = React.forwardRef(function FluidMultiSelect<ItemType>(
           {...other}
         />
       ) : (
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-        // @ts-ignore
         <MultiSelect ref={ref} className={classNames} {...other} />
       )}
     </FormContext.Provider>

--- a/packages/react/src/components/MenuButton/index.tsx
+++ b/packages/react/src/components/MenuButton/index.tsx
@@ -265,8 +265,6 @@ MenuButton.propTypes = {
   /**
    * Specify the type of button to be used as the base for the trigger button.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-  // @ts-ignore-next-line -- avoid spurious (?) TS2322 error
   kind: PropTypes.oneOf(validButtonKinds),
 
   /**
@@ -289,15 +287,11 @@ MenuButton.propTypes = {
   /**
    * Specify the size of the button and menu.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-  // @ts-ignore-next-line -- avoid spurious (?) TS2322 error
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * Specify the tabIndex of the button.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-  // @ts-ignore-next-line -- avoid spurious (?) TS2322 error
   tabIndex: PropTypes.number,
 
   /**

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -1221,8 +1221,6 @@ FilterableMultiSelect.propTypes = {
    * change, and in some cases they can not be shimmed by Carbon to shield you
    * from potentially breaking changes.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
-  // @ts-ignore
   downshiftProps: PropTypes.shape(Downshift.propTypes),
 
   /**


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Removed unnecessary TypeScript ignores.

### Changelog

**Changed**

- Reverted the changes in `Button.tsx` from https://github.com/carbon-design-system/carbon/pull/21477 while I investigate whether there's a better solution to support polymorphism.

**Removed**

- Removed unnecessary TypeScript ignores.

#### Testing / Reviewing

```sh
yarn lint
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
