### PR TITLE
fix: avoid stale FloatingMenu position updates

### DIFF
--- a/packages/react/src/internal/FloatingMenu.tsx
+++ b/packages/react/src/internal/FloatingMenu.tsx
@@ -314,13 +314,17 @@ export const FloatingMenu = ({
         });
 
         // Only update if the position has actually changed.
-        if (
-          !floatingPosition ||
-          floatingPosition.left !== newFloatingPosition.left ||
-          floatingPosition.top !== newFloatingPosition.top
-        ) {
-          setFloatingPosition(newFloatingPosition);
-        }
+        setFloatingPosition((prev) => {
+          if (
+            prev &&
+            prev.left === newFloatingPosition.left &&
+            prev.top === newFloatingPosition.top
+          ) {
+            return prev;
+          }
+
+          return newFloatingPosition;
+        });
 
         // Re-check after setting the position if not already adjusting.
         if (!isAdjustment) {
@@ -334,15 +338,7 @@ export const FloatingMenu = ({
         }
       }
     },
-    [
-      triggerRef,
-      menuOffset,
-      menuDirection,
-      flipped,
-      target,
-      updateOrientation,
-      floatingPosition,
-    ]
+    [triggerRef, menuOffset, menuDirection, flipped, target, updateOrientation]
   );
 
   const focusMenuContent = (menuBody: HTMLElement) => {

--- a/packages/react/src/internal/__tests__/FloatingMenu-test.js
+++ b/packages/react/src/internal/__tests__/FloatingMenu-test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { Profiler } from 'react';
 import {
   act,
   fireEvent,
@@ -388,5 +388,64 @@ describe('FloatingMenu', () => {
       expect(menu.style.left).toBe('-40px');
       expect(menu.style.top).toBe('60px');
     });
+  });
+
+  it('should not commit again when repeated resizes keep the same updated menu position', async () => {
+    const remove = jest.fn();
+    let resizeCallback;
+    const onRender = jest.fn();
+    const trigger = document.createElement('button');
+    const triggerRef = { current: trigger };
+    const target = () => document.body;
+
+    trigger.setAttribute('data-testid', 'trigger');
+    document.body.appendChild(trigger);
+
+    jest.spyOn(OptimizedResize, 'add').mockImplementation((callback) => {
+      resizeCallback = callback;
+      return { remove };
+    });
+
+    render(
+      <Profiler id="floating-menu" onRender={onRender}>
+        <FloatingMenu
+          triggerRef={triggerRef}
+          menuOffset={defaultMenuOffset}
+          target={target}>
+          {defaultMenuChildren}
+        </FloatingMenu>
+      </Profiler>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('menu').style.left).toBe('-23px');
+      expect(screen.getByTestId('menu').style.top).toBe('65px');
+    });
+
+    triggerRect = createRect({
+      left: 50,
+      top: 20,
+      right: 70,
+      bottom: 60,
+      width: 20,
+      height: 40,
+    });
+
+    act(() => {
+      resizeCallback();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('menu').style.left).toBe('17px');
+      expect(screen.getByTestId('menu').style.top).toBe('65px');
+    });
+
+    const commitCountAfterPositionChange = onRender.mock.calls.length;
+
+    act(() => {
+      resizeCallback();
+    });
+
+    expect(onRender).toHaveBeenCalledTimes(commitCountAfterPositionChange);
   });
 });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/22276

Avoided stale `FloatingMenu` position updates.

### Changelog

**Changed**

- Avoided stale `FloatingMenu` position updates.

#### Testing / Reviewing

Despite an existing pull request already being open for this issue, I'm opening a new one. I'm not sure the changes in the existing pull request are appropriate, and I don’t see a response to the concern raised here: https://github.com/carbon-design-system/carbon/pull/22277#discussion_r3252969403.


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
