### PR TITLE
feat: Added sm and md sizes for contained tabs

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -40,6 +40,18 @@ import {
   Icon,
 } from '@carbon/icons-react';
 
+const containedTabsSizeArgType = {
+  size: {
+    control: { type: 'select' },
+    options: ['sm', 'md', 'lg'],
+    description: 'Specify the size of the contained tabs',
+  },
+};
+
+const containedTabsSizeArgs = {
+  size: 'lg',
+};
+
 export default {
   title: 'Components/Tabs',
   component: Tabs,
@@ -199,7 +211,7 @@ export const Dismissable = () => {
     </>
   );
 };
-export const DismissableContained = () => {
+export const DismissableContained = (args) => {
   const tabs = [
     {
       label: 'Dashboard',
@@ -257,7 +269,7 @@ export const DismissableContained = () => {
         onChange={handleTabChange}
         dismissable
         onTabCloseRequest={handleCloseTabRequest}>
-        <TabList contained>
+        <TabList contained size={args.size}>
           {renderedTabs.map((tab, index) => (
             <Tab key={index} disabled={tab.disabled}>
               {tab.label}
@@ -269,6 +281,9 @@ export const DismissableContained = () => {
     </>
   );
 };
+
+DismissableContained.argTypes = containedTabsSizeArgType;
+DismissableContained.args = containedTabsSizeArgs;
 
 export const DismissableWithIcons = ({ contained }) => {
   const tabs = [
@@ -491,10 +506,10 @@ IconOnly.argTypes = {
   },
 };
 
-export const Contained = () => {
+export const Contained = (args) => {
   return (
     <Tabs>
-      <TabList contained>
+      <TabList contained size={args.size}>
         <Tab>Dashboard</Tab>
         <Tab>Monitoring</Tab>
         <Tab>Activity</Tab>
@@ -529,10 +544,13 @@ export const Contained = () => {
   );
 };
 
-export const ContainedWithIcons = () => {
+Contained.argTypes = containedTabsSizeArgType;
+Contained.args = containedTabsSizeArgs;
+
+export const ContainedWithIcons = (args) => {
   return (
     <Tabs>
-      <TabList contained>
+      <TabList contained size={args.size}>
         <Tab renderIcon={Dashboard}>Dashboard</Tab>
         <Tab renderIcon={CloudMonitoring}>Monitoring</Tab>
         <Tab renderIcon={Activity}>Activity</Tab>
@@ -568,6 +586,9 @@ export const ContainedWithIcons = () => {
     </Tabs>
   );
 };
+
+ContainedWithIcons.argTypes = containedTabsSizeArgType;
+ContainedWithIcons.args = containedTabsSizeArgs;
 
 export const ContainedWithSecondaryLabels = () => {
   return (
@@ -613,7 +634,7 @@ export const ContainedWithSecondaryLabelsAndIcons = () => {
   return (
     <Tabs>
       <TabList contained>
-        <Tab renderIcon={Task} secondaryLabel="(21/25">
+        <Tab renderIcon={Task} secondaryLabel="(21/25)">
           Engage
         </Tab>
         <Tab renderIcon={IbmWatsonDiscovery} secondaryLabel="(12/16)">
@@ -657,12 +678,12 @@ export const ContainedWithSecondaryLabelsAndIcons = () => {
   );
 };
 
-export const ContainedFullWidth = () => {
+export const ContainedFullWidth = (args) => {
   return (
     <Grid condensed>
       <Column lg={16} md={8} sm={4}>
         <Tabs>
-          <TabList contained fullWidth>
+          <TabList contained fullWidth size={args.size}>
             <Tab>TLS</Tab>
             <Tab>Origin</Tab>
             <Tab disabled>Rate limiting</Tab>
@@ -875,3 +896,6 @@ IconOnlyVisualSnapshots.play = async ({ userEvent }) => {
 };
 
 IconOnlyVisualSnapshots.tags = ['!dev', '!autodocs'];
+
+ContainedFullWidth.argTypes = containedTabsSizeArgType;
+ContainedFullWidth.args = containedTabsSizeArgs;

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -436,6 +436,11 @@ export interface TabListProps extends DivAttributes {
    * on component rerender
    */
   scrollIntoView?: boolean;
+
+  /**
+   * Specify the size of the tabs.
+   */
+  size?: 'sm' | 'md' | 'lg';
 }
 type TabElement = HTMLElement & { disabled?: boolean };
 
@@ -452,6 +457,7 @@ function TabList({
   rightOverflowButtonProps,
   scrollDebounceWait = 200,
   scrollIntoView,
+  size,
   ...rest
 }: TabListProps) {
   const {
@@ -492,6 +498,8 @@ function TabList({
       [`${prefix}--tabs__icon--default`]: iconSize === 'default',
       [`${prefix}--tabs__icon--lg`]: iconSize === 'lg', // TODO: V12 - Remove this class
       [`${prefix}--layout--size-lg`]: iconSize === 'lg',
+      [`${prefix}--layout--size-${size}`]:
+        size && contained && !hasSecondaryLabelTabs,
       [`${prefix}--tabs--tall`]: hasSecondaryLabelTabs,
       [`${prefix}--tabs--full-width`]: distributeWidth,
       [`${prefix}--tabs--dismissable`]: dismissable,

--- a/packages/web-components/src/components/tabs/defs.ts
+++ b/packages/web-components/src/components/tabs/defs.ts
@@ -69,3 +69,23 @@ export enum TABS_ICON_SIZE {
    */
   LARGE = 'lg',
 }
+
+/**
+ * Tabs size.
+ */
+export enum TABS_SIZE {
+  /**
+   * Small size.
+   */
+  SMALL = 'sm',
+
+  /**
+   * Medium size.
+   */
+  MEDIUM = 'md',
+
+  /**
+   * Large size.
+   */
+  LARGE = 'lg',
+}

--- a/packages/web-components/src/components/tabs/stories/tabs-wrapper.ts
+++ b/packages/web-components/src/components/tabs/stories/tabs-wrapper.ts
@@ -10,6 +10,7 @@ import { property, state } from 'lit/decorators.js';
 import { carbonElement as customElement } from '../../../globals/decorators/carbon-element';
 import { prefix } from '../../../globals/settings';
 import { TABS_TYPE } from '../tabs';
+import { TABS_SIZE } from '../defs';
 import { iconLoader } from '../../../globals/internal/icon-loader';
 import Dashboard16 from '@carbon/icons/es/dashboard/16.js';
 import CloudMonitoring16 from '@carbon/icons/es/cloud--monitoring/16.js';
@@ -81,6 +82,12 @@ export class DismissableTabsWrapper extends LitElement {
   selectedIndex = 0;
 
   /**
+   * Size of the tabs
+   */
+  @property({ reflect: true })
+  size?: TABS_SIZE;
+
+  /**
    * Handle tab dismissed event
    */
   private _handleDismissed(event: CustomEvent) {
@@ -113,6 +120,7 @@ export class DismissableTabsWrapper extends LitElement {
         selected-index="${this.selectedIndex}"
         type="${this.contained ? TABS_TYPE.CONTAINED : TABS_TYPE.REGULAR}"
         ?dismissable="${this.dismissable}"
+        size="${this.size || TABS_SIZE.LARGE}"
         value="all"
         @cds-tab-closed="${this._handleDismissed}"
         @cds-tabs-beingselected="${this._handleBeforeSelected}">

--- a/packages/web-components/src/components/tabs/tabs.scss
+++ b/packages/web-components/src/components/tabs/tabs.scss
@@ -27,6 +27,7 @@ $inset-transition: inset 110ms motion(standard, productive);
 :host(#{$prefix}-tabs-skeleton) {
   @extend .#{$prefix}--tabs;
   @include emit-layout-tokens();
+
   .#{$prefix}--tabs-nav-content-container {
     position: relative;
     overflow: scroll;
@@ -384,7 +385,7 @@ $inset-transition: inset 110ms motion(standard, productive);
 
 :host(#{$prefix}-tabs[type='contained'])
   .#{$prefix}--tabs-nav-content-container {
-  block-size: $spacing-09;
+  block-size: layout.size('height');
 }
 
 :host(#{$prefix}-tab[type='contained']) {
@@ -392,9 +393,9 @@ $inset-transition: inset 110ms motion(standard, productive);
 
   a.#{$prefix}--tabs__nav-link {
     padding: $spacing-03 $spacing-05;
-    block-size: $spacing-09;
+    block-size: layout.size('height');
     // height - vertical padding
-    line-height: calc(#{$spacing-09} - (#{$spacing-03} * 2));
+    line-height: calc(#{layout.size('height')} - (#{$spacing-03} * 2));
   }
 }
 
@@ -446,7 +447,7 @@ $inset-transition: inset 110ms motion(standard, productive);
     // Draws the border without affecting the inner-content
     box-shadow: inset 0 $spacing-01 0 0 $interactive;
     // height - vertical padding
-    line-height: calc(#{$spacing-09} - (#{$spacing-03} * 2));
+    line-height: calc(#{layout.size('height')} - (#{$spacing-03} * 2));
   }
 
   .#{$prefix}--tabs__nav-link:focus,

--- a/packages/web-components/src/components/tabs/tabs.stories.ts
+++ b/packages/web-components/src/components/tabs/tabs.stories.ts
@@ -54,6 +54,18 @@ const argTypes = {
   },
 };
 
+const containedTabsSizeArgType = {
+  size: {
+    control: { type: 'select' },
+    options: ['sm', 'md', 'lg'],
+    description: 'Specify the size of the contained tabs',
+  },
+};
+
+const containedTabsSizeArgs = {
+  size: 'lg',
+};
+
 const onTabsBeingSelected = action('cds-tabs-beingselected');
 const onTabsSelected = action('cds-tabs-selected');
 const iconStoriesArgs = {
@@ -143,13 +155,16 @@ export const Default = {
 };
 
 export const Contained = {
-  render: () => html`
+  args: containedTabsSizeArgs,
+  argTypes: containedTabsSizeArgType,
+  render: ({ size }) => html`
     <style>
       ${styles}
     </style>
     <cds-tabs
       value="dashboard"
       type="${TABS_TYPE.CONTAINED}"
+      size="${ifDefined(size)}"
       @cds-tabs-beingselected="${onTabsBeingSelected}"
       @cds-tabs-selected="${onTabsSelected}">
       <cds-tab id="tab-dashboard" target="panel-dashboard" value="dashboard">
@@ -227,13 +242,16 @@ export const Contained = {
 };
 
 export const ContainedFullWidth = {
-  render: () => html`
+  args: containedTabsSizeArgs,
+  argTypes: containedTabsSizeArgType,
+  render: ({ size }) => html`
     <style>
       ${styles}
     </style>
     <cds-tabs
       value="tls"
       type="${TABS_TYPE.CONTAINED}"
+      size="${ifDefined(size)}"
       full-width
       @cds-tabs-beingselected="${onTabsBeingSelected}"
       @cds-tabs-selected="${onTabsSelected}">
@@ -345,13 +363,16 @@ export const ContainedFullWidth = {
 };
 
 export const ContainedWithIcons = {
-  render: () => html`
+  args: containedTabsSizeArgs,
+  argTypes: containedTabsSizeArgType,
+  render: ({ size }) => html`
     <style>
       ${styles}
     </style>
     <cds-tabs
       value="dashboard"
       type="${TABS_TYPE.CONTAINED}"
+      size="${ifDefined(size)}"
       @cds-tabs-beingselected="${onTabsBeingSelected}"
       @cds-tabs-selected="${onTabsSelected}">
       <cds-tab id="tab-dashboard" target="panel-dashboard" value="dashboard">
@@ -663,6 +684,7 @@ export const DismissableContained = {
     contained: true,
     dismissable: true,
     selectedIndex: 0,
+    ...containedTabsSizeArgs,
   },
   argTypes: {
     dismissable: {
@@ -674,8 +696,9 @@ export const DismissableContained = {
       description:
         'Specify a selected index for the initially selected content.',
     },
+    ...containedTabsSizeArgType,
   },
-  render: ({ contained, dismissable, selectedIndex }) => {
+  render: ({ contained, dismissable, selectedIndex, size }) => {
     return html`
       <style>
         ${styles}
@@ -683,7 +706,8 @@ export const DismissableContained = {
       <tabs-story-wrapper
         ?dismissable="${dismissable}"
         ?contained="${contained}"
-        selected-index="${selectedIndex}">
+        selected-index="${selectedIndex}"
+        size="${ifDefined(size)}">
       </tabs-story-wrapper>
     `;
   },

--- a/packages/web-components/src/components/tabs/tabs.ts
+++ b/packages/web-components/src/components/tabs/tabs.ts
@@ -572,6 +572,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     super.firstUpdated();
     this._tabInitialLoad();
     this._cleanAndCreateIntersectionObserverContainer({ create: true });
+    this._syncSecondaryLabels();
     this._syncSizeToTabs();
   }
 

--- a/packages/web-components/src/components/tabs/tabs.ts
+++ b/packages/web-components/src/components/tabs/tabs.ts
@@ -18,7 +18,12 @@ import ChevronRight16 from '@carbon/icons/es/chevron--right/16.js';
 import CDSContentSwitcher, {
   NAVIGATION_DIRECTION,
 } from '../content-switcher/content-switcher';
-import { TABS_ICON_SIZE, TABS_KEYBOARD_ACTION, TABS_TYPE } from './defs';
+import {
+  TABS_ICON_SIZE,
+  TABS_KEYBOARD_ACTION,
+  TABS_TYPE,
+  TABS_SIZE,
+} from './defs';
 import CDSTab from './tab';
 import styles from './tabs.scss?lit';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
@@ -28,6 +33,7 @@ export {
   TABS_ICON_SIZE,
   TABS_KEYBOARD_ACTION,
   TABS_TYPE,
+  TABS_SIZE,
 };
 
 /**
@@ -74,6 +80,32 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
    * The width of the overflow scroll buttons.
    */
   private BUTTON_WIDTH = 44;
+
+  /**
+   * Propagates the layout size token to the host and all child tabs.
+   */
+  private _syncSizeToTabs() {
+    if (this.type === TABS_TYPE.CONTAINED) {
+      const size = this.getAttribute('size');
+      if (size) {
+        const value = `var(--${prefix}-layout-size-height-${size})`;
+        this.style.setProperty(`--${prefix}-layout-size-height`, value);
+        this.querySelectorAll(`${prefix}-tab`).forEach((tab) => {
+          (tab as HTMLElement).style.setProperty(
+            `--${prefix}-layout-size-height`,
+            value
+          );
+        });
+      } else {
+        this.style.removeProperty(`--${prefix}-layout-size-height`);
+        this.querySelectorAll(`${prefix}-tab`).forEach((tab) => {
+          (tab as HTMLElement).style.removeProperty(
+            `--${prefix}-layout-size-height`
+          );
+        });
+      }
+    }
+  }
 
   /**
    * Navigates through tabs.
@@ -339,6 +371,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
 
     this._syncSecondaryLabels();
     this._updateTabsState();
+    this._syncSizeToTabs();
   }
 
   protected _selectionDidChange(
@@ -411,6 +444,12 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
    */
   @property({ type: Boolean, reflect: true })
   dismissable;
+
+  /**
+   * Specify the size of contained tabs.
+   */
+  @property({ reflect: true })
+  size?: TABS_SIZE;
 
   /**
    * Specify the icon size used by icon-only tabs.
@@ -513,7 +552,11 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
       this._isScrollable = scrollWidth > clientWidth;
     }
     const { selectorItem } = this.constructor as typeof CDSTabs;
-    if (changedProperties.has('type') || changedProperties.has('iconSize')) {
+    if (
+      changedProperties.has('type') ||
+      changedProperties.has('iconSize') ||
+      changedProperties.has('size')
+    ) {
       this._totalTabs = 0;
       forEach(this.querySelectorAll(selectorItem), (elem) => {
         this._totalTabs++;
@@ -529,12 +572,15 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     super.firstUpdated();
     this._tabInitialLoad();
     this._cleanAndCreateIntersectionObserverContainer({ create: true });
-    this._syncSecondaryLabels();
+    this._syncSizeToTabs();
   }
 
   updated(changedProperties) {
     // Call super to keep selection/value in sync
     super.updated?.(changedProperties);
+    if (changedProperties.has('size') || changedProperties.has('type')) {
+      this._syncSizeToTabs();
+    }
 
     if (changedProperties.has('value')) {
       const tab = this.querySelector(


### PR DESCRIPTION
Closes #21598 

Added sm and md sizes for contained tabs in both react and web components.

### Changelog

**New**

- Added sm and md sizes for contained tabs in both react and web components.

**Changed**

- NA

**Removed**

- NA

#### Testing / Reviewing

Test all contained tabs have a prop size with sm, md and lg options and they should work as per the spec mentioned in the issue in both react and web components

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
