### PR TITLE
fix(overflow-menu): add $background-active color on focus state

### DIFF
--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -46,6 +46,7 @@
 
     &:focus {
       @include focus-outline('outline');
+      background-color: $background-active;
     }
 
     &:hover {


### PR DESCRIPTION
## 🎯 Fix for carbon-design-system/carbon#22293

**Title:** `[Bug]: \`cds-overflow-menu\` icon button focus state is missing \$background-active colour token`

### Problem
When focused, the overflow menu icon button in `@carbon/web-components` does not show the `$background-active` color. The React version correctly shows a background color on focus.

### Solution
Added `background-color: $background-active;` to the `&:focus` state in `packages/styles/scss/components/overflow-menu/_overflow-menu.scss`.

This matches the React component behavior where focusing the overflow menu button applies the active background color.

### Testing
1. Go to https://web-components.carbondesignsystem.com/?path=/story/components-overflow-menu--default
2. Focus the overflow menu icon button (Tab into it)
3. Verify the ghost icon button now has the required background colour
4. Compare with React version: https://react.carbondesignsystem.com/?path=/story/components-overflowmenu--default

Fixes #22293
