### PR TITLE
standalone typeahead feature without adding it to the component, but as a parent

### DIFF
--- a/packages/react/src/components/Search/TypeAhead.stories.js
+++ b/packages/react/src/components/Search/TypeAhead.stories.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright IBM Corp. 2016, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { TypeAhead } from '.';
+import Search from '.';
+
+export default {
+  title: 'Components/Search/TypeAhead',
+  component: TypeAhead,
+  args: {
+    size: 'md',
+    suggestions: [
+      'How to check your emails before noon',
+      'How to water your plants properly',
+      'How to find and try a new coffee shop nearby',
+      'How to finish reading a book you started',
+      'How to schedule a meeting with the design team',
+      'How to update your resume with recent projects',
+      'How to take a refreshing short walk',
+      'How to organize your workspace for productivity',
+      'How to plan meals for the upcoming week',
+      'How to back up important files to the cloud',
+
+      'How to start a morning routine that works',
+      'How to stay focused while working from home',
+      'How to prepare for a job interview',
+      'How to improve your time management skills',
+      'How to clean and declutter your room',
+      'How to create a weekly workout plan',
+      'How to cook a healthy dinner quickly',
+      'How to save money every month',
+      'How to learn a new skill online',
+      'How to build better daily habits',
+
+      'What to do when you feel unproductive',
+      'What to pack for a weekend trip',
+      'What to include in a professional resume',
+      'What to eat for a balanced breakfast',
+      'What to ask during a team meeting',
+      'What to do before going to sleep',
+      'What to prioritize in your daily schedule',
+      'What to keep in your work backpack',
+      'What to review before submitting a project',
+      'What to do during a study break',
+    ],
+  },
+  argTypes: {
+    size: {
+      options: ['xs', 'sm', 'md', 'lg'],
+      control: {
+        type: 'select',
+      },
+    },
+  },
+};
+
+export const Default = (args) => {
+  const [value, setValue] = useState('');
+
+  return (
+    <div style={{ width: '400px' }}>
+      <TypeAhead
+        value={value}
+        suggestions={args.suggestions}
+        size={args.size}
+        onSelect={(suggestion) => {
+          setValue(suggestion);
+        }}>
+        <Search
+          id="search-default-1"
+          size={args.size}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </TypeAhead>
+    </div>
+  );
+};

--- a/packages/react/src/components/Search/TypeAhead.tsx
+++ b/packages/react/src/components/Search/TypeAhead.tsx
@@ -1,0 +1,268 @@
+import React, {
+  forwardRef,
+  ReactNode,
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import cx from 'classnames';
+import { usePrefix } from '../../internal/usePrefix';
+
+interface TypeAheadProps {
+  children?: ReactNode;
+  className?: string;
+  suggestions?: string[];
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  value?: string;
+  onSelect?: (suggestion: string) => void;
+}
+
+const TypeAhead = forwardRef<HTMLDivElement, TypeAheadProps>(
+  (
+    {
+      className,
+      children,
+      suggestions = [],
+      size = 'md',
+      value = '',
+      onSelect,
+    },
+    ref
+  ) => {
+    const prefix = usePrefix();
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listboxRef = useRef<HTMLUListElement>(null);
+    const [activeIndex, setActiveIndex] = useState<number>(-1);
+    const [isOpen, setIsOpen] = useState<boolean>(true);
+
+    const typeaheadClasses = cx(`${prefix}--typeahead`, className);
+    const listClasses = cx(`${prefix}--typeahead__list`, {
+      [`${prefix}--typeahead__list--${size}`]: size,
+    });
+
+    // Filter suggestions - match all keywords
+    const filteredSuggestions = useMemo(() => {
+      if (!value || value.trim() === '') {
+        return [];
+      }
+      const keywords = value
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((keyword) => keyword.length > 0);
+
+      return suggestions.filter((suggestion) => {
+        const lowerSuggestion = suggestion.toLowerCase();
+        if (lowerSuggestion === value.toLowerCase()) {
+          return false;
+        }
+        return keywords.every((keyword) => lowerSuggestion.includes(keyword));
+      });
+    }, [suggestions, value]);
+
+    // Reset active index and open state when suggestions change
+    useEffect(() => {
+      setActiveIndex(-1);
+      setIsOpen(true);
+    }, [filteredSuggestions]);
+
+    // Highlight matching keywords
+    const highlightMatch = (text: string, query: string) => {
+      if (!query || !query.trim()) return text;
+
+      const keywords = query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((keyword) => keyword.length > 0);
+
+      if (keywords.length === 0) return text;
+
+      const pattern = keywords
+        .map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('|');
+      const regex = new RegExp(`(${pattern})`, 'gi');
+      const parts = text.split(regex);
+
+      return (
+        <span>
+          {parts.map((part, index) => {
+            const isMatch = keywords.some(
+              (keyword) => part.toLowerCase() === keyword
+            );
+            return isMatch ? (
+              <strong
+                key={index}
+                className={`${prefix}--typeahead__item-highlight`}>
+                {part}
+              </strong>
+            ) : (
+              <span key={index}>{part}</span>
+            );
+          })}
+        </span>
+      );
+    };
+
+    const handleSelect = (suggestion: string) => {
+      onSelect?.(suggestion);
+      setActiveIndex(-1);
+      setIsOpen(false);
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    };
+
+    const handleBlur = (e: React.FocusEvent) => {
+      // Check if focus is moving outside the typeahead component
+      const currentTarget = e.currentTarget;
+      setTimeout(() => {
+        if (!currentTarget.contains(document.activeElement)) {
+          setIsOpen(false);
+        }
+      }, 0);
+    };
+
+    const handleFocus = () => {
+      if (filteredSuggestions.length > 0) {
+        setIsOpen(true);
+      }
+    };
+
+    const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (filteredSuggestions.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          if (activeIndex < filteredSuggestions.length - 1) {
+            const newIndex = activeIndex + 1;
+            setActiveIndex(newIndex);
+            const items = listboxRef.current?.querySelectorAll('button');
+            items?.[newIndex]?.focus();
+          }
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          if (activeIndex > 0) {
+            const newIndex = activeIndex - 1;
+            setActiveIndex(newIndex);
+            const items = listboxRef.current?.querySelectorAll('button');
+            items?.[newIndex]?.focus();
+          } else if (activeIndex === 0) {
+            setActiveIndex(-1);
+            inputRef.current?.focus();
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setActiveIndex(-1);
+          setIsOpen(false);
+          break;
+      }
+    };
+
+    const handleButtonKeyDown = (
+      e: React.KeyboardEvent<HTMLButtonElement>,
+      index: number
+    ) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          if (index < filteredSuggestions.length - 1) {
+            const newIndex = index + 1;
+            setActiveIndex(newIndex);
+            const items = listboxRef.current?.querySelectorAll('button');
+            items?.[newIndex]?.focus();
+          }
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          if (index > 0) {
+            const newIndex = index - 1;
+            setActiveIndex(newIndex);
+            const items = listboxRef.current?.querySelectorAll('button');
+            items?.[newIndex]?.focus();
+          } else {
+            setActiveIndex(-1);
+            inputRef.current?.focus();
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setActiveIndex(-1);
+          setIsOpen(false);
+          inputRef.current?.focus();
+          break;
+      }
+    };
+
+    // Clone children to add keyboard handler and ref
+    const enhancedChildren = isValidElement(children)
+      ? cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+          onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+            handleInputKeyDown(e);
+            const childElement = children as React.ReactElement<{
+              onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+            }>;
+            const originalOnKeyDown = childElement.props?.onKeyDown;
+            if (originalOnKeyDown) {
+              originalOnKeyDown(e);
+            }
+          },
+          ref: (node: HTMLInputElement) => {
+            inputRef.current = node;
+          },
+          onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+            handleFocus();
+            const childElement = children as React.ReactElement<{
+              onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
+            }>;
+            const originalOnFocus = childElement.props?.onFocus;
+            if (originalOnFocus) {
+              originalOnFocus(e);
+            }
+          },
+        })
+      : children;
+
+    return (
+      <div ref={ref} className={typeaheadClasses} onBlur={handleBlur}>
+        {enhancedChildren}
+        {filteredSuggestions.length > 0 && isOpen && (
+          <div className={`${prefix}--typeahead__menu`}>
+            <ul ref={listboxRef} className={listClasses}>
+              {filteredSuggestions.map((suggestion, index) => {
+                const itemClasses = cx(`${prefix}--typeahead__item`, {
+                  [`${prefix}--typeahead__item--${size}`]: size,
+                  [`${prefix}--typeahead__item--active`]: index === activeIndex,
+                });
+
+                return (
+                  <li key={index}>
+                    <button
+                      type="button"
+                      className={itemClasses}
+                      tabIndex={-1}
+                      onClick={() => handleSelect(suggestion)}
+                      onKeyDown={(e) =>
+                        handleButtonKeyDown(e, index, suggestion)
+                      }>
+                      {highlightMatch(suggestion, value)}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+TypeAhead.displayName = 'TypeAhead';
+
+export { TypeAhead };
+export default TypeAhead;

--- a/packages/react/src/components/Search/index.tsx
+++ b/packages/react/src/components/Search/index.tsx
@@ -12,3 +12,5 @@ export default Search;
 export { Search };
 
 export { default as SearchSkeleton } from './Search.Skeleton';
+export { default as TypeAhead } from './TypeAhead';
+export * from './TypeAhead';

--- a/packages/styles/scss/components/search/_index.scss
+++ b/packages/styles/scss/components/search/_index.scss
@@ -6,6 +6,9 @@
 //
 
 @forward 'search';
+@forward 'typeahead';
 @use 'search';
+@use 'typeahead';
 
 @include search.search;
+@include typeahead.typeahead;

--- a/packages/styles/scss/components/search/_typeahead.scss
+++ b/packages/styles/scss/components/search/_typeahead.scss
@@ -1,0 +1,113 @@
+//
+// Copyright IBM Corp. 2016, 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+//-----------------------------
+// TypeAhead
+//-----------------------------
+
+@use '../../theme' as *;
+@use '../../config' as *;
+@use '../../type';
+@use '../../motion' as *;
+@use '../../spacing' as *;
+@use '../../utilities/focus-outline' as *;
+@use '../../utilities/convert';
+@use '../../utilities/z-index' as *;
+
+/// TypeAhead styles
+/// @access public
+/// @group typeahead
+@mixin typeahead {
+  .#{$prefix}--typeahead {
+    position: relative;
+    inline-size: 100%;
+  }
+
+  .#{$prefix}--typeahead__menu {
+    position: absolute;
+    z-index: z('dropdown');
+    background-color: $layer;
+    inline-size: 100%;
+    inset-block-start: 100%;
+    inset-inline: 0;
+    max-block-size: convert.to-rem(220px);
+    overflow-y: auto;
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+  }
+
+  .#{$prefix}--typeahead__list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .#{$prefix}--typeahead__item {
+    @include type.type-style('body-compact-01');
+
+    display: flex;
+    align-items: center;
+    border: 0;
+    background: transparent;
+    block-size: convert.to-rem(40px);
+    color: $text-secondary;
+    cursor: pointer;
+    inline-size: 100%;
+    padding-block: 0;
+    padding-inline: $spacing-05;
+    text-align: start;
+    transition: background $duration-fast-01 motion(standard, productive);
+
+    &:hover {
+      background-color: $layer-hover;
+    }
+
+    &:active {
+      background-color: $layer-selected;
+    }
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+  }
+
+  .#{$prefix}--typeahead__item--active {
+    background-color: $layer-hover;
+  }
+
+  .#{$prefix}--typeahead__item-highlight {
+    color: $text-primary;
+    font-weight: 600;
+  }
+
+  // Size variants
+  .#{$prefix}--typeahead__list--xs .#{$prefix}--typeahead__item,
+  .#{$prefix}--typeahead__item--xs {
+    block-size: convert.to-rem(24px);
+    padding-inline-start: convert.to-rem(24px);
+  }
+
+  .#{$prefix}--typeahead__list--sm .#{$prefix}--typeahead__item,
+  .#{$prefix}--typeahead__item--sm {
+    block-size: convert.to-rem(32px);
+    padding-inline-start: convert.to-rem(32px);
+  }
+
+  .#{$prefix}--typeahead__list--md .#{$prefix}--typeahead__item,
+  .#{$prefix}--typeahead__item--md {
+    block-size: convert.to-rem(40px);
+    padding-inline-start: convert.to-rem(40px);
+  }
+
+  .#{$prefix}--typeahead__list--lg .#{$prefix}--typeahead__item,
+  .#{$prefix}--typeahead__item--lg {
+    block-size: convert.to-rem(48px);
+    padding-inline-start: convert.to-rem(48px);
+  }
+}


### PR DESCRIPTION
Closes #

https://deploy-preview-22302--v11-carbon-react.netlify.app/?path=/story/components-search-typeahead--default

a poc to test typeahead cleanly by introducing a parent wrapper sharing value. and a suggestions array that could be populated from an api response.

this is a reference point to build typeahead wrapper without any reliance from our library except building blocks. and as a pure pattern

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
