### PR TITLE
chore: update promote workflows for release

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./actions/promote
         with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,6 @@ jobs:
         run:
           yarn lerna publish from-package --dist-tag next --no-verify-access
           --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Release
         id: create_release
@@ -97,7 +95,7 @@ jobs:
       - name: Promote packages
         uses: ./actions/promote
         with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
           DRY_RUN: false
 
       # run deploy-packages workflow


### PR DESCRIPTION
Update our release workflow - promote portion - with the org Carbon NPM Token. The promote workflow needs the NPM token to perform the `npm dist-tag add` command.

Removed the NPM Token set for the publish step as that is now taken care of by OIDC. Seen [here](https://github.com/carbon-design-system/carbon/actions/runs/26185450509/job/77043330437) where the publish step passes and the promote step fails once the `NPM_TOKEN` expired.

We technically don't need the separate `promote.yml` workflow anymore? But maybe we want to keep it around so we can manually trigger the promote step separately when needed?

### Changelog

**Changed**

- swap outdated `NPM_TOKEN` with org `CARBON_BOT_NPM_TOKEN`

**Removed**

- NPM_TOKEN from the publish step - no longer necessary with OIDC set up

#### Testing / Reviewing

Should pass ci-checks, will have to test in the next release

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
