### PR TITLE
fix(styles): align support/status token usage and document rules

### DIFF
--- a/docs/decisions/0007-validation-and-status-color-tokens.md
+++ b/docs/decisions/0007-validation-and-status-color-tokens.md
@@ -1,0 +1,44 @@
+# Validation and status color tokens
+
+## Status
+
+Accepted
+
+## Context
+
+Core theme tokens include `$support-*`, `$interactive`, and component-level
+`$status-*` tokens. Form fields, list boxes, and notifications were reviewed for
+consistent use when showing error, warning, and success feedback.
+
+`$status-*` tokens exist for preview status indicator components (Icon Indicator,
+Shape Indicator). `$support-*` tokens are theme-level semantic colors for
+validation and alerts. `$interactive` and `$icon-interactive` express focus and
+action affordances, not validation meaning.
+
+## Decision
+
+Use each token family only for its intended role.
+
+| Token family | Use for | Do not use for |
+| --- | --- | --- |
+| `$support-error`, `$support-warning`, `$support-success`, `$support-info` (and inverse variants) | Invalid and warning icons, borders, and text inside inputs, list boxes, checkboxes, notifications, progress feedback | Generic icons, loading spinners, or primary UI chrome |
+| `$status-*` | Icon Indicator and Shape Indicator only | Icons inside other components |
+| `$interactive`, `$border-interactive` | Progress, loading, sliders, selected tree nodes, default progress bar fill | Validation icons or semantic success/error coloring |
+| `$icon-interactive` | Interactive icon affordances (for example, file upload complete) | Validation states |
+
+Nested validation icons in components use `$support-error` and `$support-warning`
+with the existing warning icon inner-path treatment. List box invalid icons are
+the canonical pattern for dropdown, combo box, and multi-select.
+
+`$support-*` tokens remain theme-level. `$status-*` tokens remain
+component-level and are registered through `icon-indicator` component tokens.
+
+## Consequences
+
+New form or feedback UI should use `$support-*` for semantic states. New status
+visualizations outside status indicator components should not introduce `$status-*`
+into shared input styles. Replacing `$interactive` with `$icon-interactive` for
+icon fills avoids conflating validation color with interactive affordance color.
+
+Deprecating `$support-*` in favor of `$status-*` is out of scope; both families
+serve different layers of the token system.

--- a/packages/styles/scss/components/dropdown/_dropdown.scss
+++ b/packages/styles/scss/components/dropdown/_dropdown.scss
@@ -119,14 +119,6 @@
     }
   }
 
-  .#{$prefix}--dropdown__invalid-icon {
-    position: absolute;
-    fill: $support-error;
-    inset-block-start: 50%;
-    inset-inline-end: $spacing-08;
-    transform: translateY(-50%);
-  }
-
   .#{$prefix}--dropdown--open:hover {
     background-color: $field;
   }
@@ -420,11 +412,6 @@
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled:focus
     .#{$prefix}--dropdown-text {
     outline: 0;
-  }
-
-  .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--invalid
-    .#{$prefix}--dropdown__invalid-icon {
-    inset-inline-end: convert.to-rem(32px);
   }
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--invalid

--- a/packages/styles/scss/components/file-uploader/_file-uploader.scss
+++ b/packages/styles/scss/components/file-uploader/_file-uploader.scss
@@ -352,8 +352,7 @@
   }
 
   .#{$prefix}--file__state-container .#{$prefix}--file-complete {
-    // TODO: Should this be $icon-interactive instead?
-    fill: $interactive;
+    fill: $icon-interactive;
     inline-size: $spacing-06;
 
     &:focus {


### PR DESCRIPTION
Closes #22321

- Align $support, $status, and $interactive color token usage in styles.

#### Changelog
New

- ADR 0007-validation-and-status-color-tokens.md
Changed

- File uploader complete icon: $icon-interactive
Removed

Unused dropdown__invalid-icon styles

#### Testing / Reviewing

File uploader complete state icon color
Dropdown/ComboBox invalid and warning icons unchanged
Review ADR

#### PR Checklist
As the author of this PR, before marking ready for review, confirm you:

 Reviewed every line of the diff
 Updated documentation and storybook examples
 Wrote passing tests that cover this change
 Addressed any impact on accessibility (a11y)
 Tested for cross-browser consistency