### PR TITLE
fix(search): update search landmark labeling to use `aria-labelledby`

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -537,7 +537,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
         class="cds--toolbar-content"
       >
         <div
-          aria-label="Filter table"
+          aria-labelledby="custom-id-search"
           class="cds--search cds--toolbar-search-container-persistent"
           role="search"
         >
@@ -987,7 +987,7 @@ exports[`DataTable renders as expected - Component API should render and match s
         class="cds--toolbar-content"
       >
         <div
-          aria-label="Filter table"
+          aria-labelledby="custom-id-search"
           class="cds--search cds--toolbar-search-container-persistent"
           role="search"
         >

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -3,7 +3,7 @@
 exports[`TableToolbarSearch renders as expected - Component API should render 1`] = `
 <div>
   <div
-    aria-label="Filter table"
+    aria-labelledby="custom-id-search"
     class="cds--search custom-class cds--toolbar-search-container-expandable"
     role="search"
   >

--- a/packages/react/src/components/Search/Search-test.js
+++ b/packages/react/src/components/Search/Search-test.js
@@ -21,6 +21,30 @@ const contentScenarios = [
 
 describe('Search', () => {
   describe('renders as expected - Component API', () => {
+    it('should label the search landmark using labelText via aria-labelledby', () => {
+      render(<Search labelText="Search A" />);
+
+      expect(
+        screen.getByRole('search', { name: 'Search A' })
+      ).toBeInTheDocument();
+    });
+
+    it('should give each search landmark a unique accessible name when labelText differs', () => {
+      render(
+        <>
+          <Search labelText="Search A" />
+          <Search labelText="Search B" />
+        </>
+      );
+
+      expect(
+        screen.getByRole('search', { name: 'Search A' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('search', { name: 'Search B' })
+      ).toBeInTheDocument();
+    });
+
     it('should spread extra props onto the input element', () => {
       render(<Search labelText="test-search" data-testid="test-id" />);
 

--- a/packages/react/src/components/Search/Search.stories.js
+++ b/packages/react/src/components/Search/Search.stories.js
@@ -21,7 +21,7 @@ export default {
     closeButtonLabelText: 'Clear search input',
     disabled: false,
     defaultWidth: 800,
-    labelText: 'Search',
+    labelText: 'Site search',
     placeholder: 'Placeholder text',
     size: 'md',
     type: 'search',

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -282,7 +282,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       );
 
     return (
-      <div role="search" aria-label={placeholder} className={searchClasses}>
+      <div role="search" aria-labelledby={searchId} className={searchClasses}>
         {magnifierWithTooltip}
         {/* the magnifier is used in ExpandableSearch as a click target to expand,
       however, it does not need a keyboard event bc the input element gets focus on keyboard nav and expands that way*/}


### PR DESCRIPTION
Closes #12360 

This changes the search landmark to use `aria-labelledby` instead of `aria-label`. The new reference points to the existing `label` element that contains the required `labelText` prop. This approach enforces unique labels and `labelText` values for each search component used on the page.

### Changelog

**New**

- add test to verify that search component landmarks are unique

**Changed**

- search component landmarks now use `aria-labelledby` rather than `aria-label`

#### Testing / Reviewing

- view the default `Search` story
- inspect the component and verify `<div role="search">` has `aria-labelledby` pointing to the label's ID
- the label's ID should match the `aria-labelledby` value
- Search tests should pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
