### PR TITLE
fix(web-components): use esbuild for cssMinify

### DIFF
--- a/packages/web-components/.storybook/main.ts
+++ b/packages/web-components/.storybook/main.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -57,6 +57,13 @@ const config: StorybookConfig = {
       optimizeDeps: {
         include: ['@storybook/web-components-vite'],
         exclude: ['lit', 'lit-html'],
+      },
+      build: {
+        /**
+         * Use esbuild for CSS minification because Lightning CSS (Vite 8.0 default) can fail on some
+         * web component selectors, such as ::slotted() and ::part().
+         */
+        cssMinify: 'esbuild',
       },
       define: {
         'process.env.NODE_ENV': JSON.stringify(

--- a/packages/web-components/.storybook/main.ts
+++ b/packages/web-components/.storybook/main.ts
@@ -60,8 +60,8 @@ const config: StorybookConfig = {
       },
       build: {
         /**
-         * Use esbuild for CSS minification because Lightning CSS (Vite 8.0 default) can fail on some
-         * web component selectors, such as ::slotted() and ::part().
+         * Use esbuild for CSS minification because Lightning CSS (Vite 8.0 default)
+         * fails when additional selectors are appended after ::slotted(), ::part(), etc..
          */
         cssMinify: 'esbuild',
       },

--- a/packages/web-components/.storybook/main.ts
+++ b/packages/web-components/.storybook/main.ts
@@ -61,7 +61,7 @@ const config: StorybookConfig = {
       build: {
         /**
          * Use esbuild for CSS minification because Lightning CSS (Vite 8.0 default)
-         * fails when additional selectors are appended after ::slotted(), ::part(), etc..
+         * fails when additional selectors are appended after ::slotted(), ::part(), etc.
          */
         cssMinify: 'esbuild',
       },


### PR DESCRIPTION
No issue

Netlify deploy preview for Web Components are [failing](https://app.netlify.com/projects/v11-carbon-web-components/deploys). Most likely due to the migration to[ Vite 8.0](https://github.com/carbon-design-system/carbon/pull/22080) which [uses Lightning CSS as the default CSS minifier](https://vite.dev/guide/migration#:~:text=your%20JavaScript%20apps.-,CSS%20Minification%20by%20Lightning%20CSS,better%20syntax%20lowering%20and%20your%20CSS%20bundle%20size%20might%20increase%20slightly.,-Consistent%20CommonJS%20Interop) instead of esbuild like the previous versions.

This PR changes the minifier to esbuild.

### Changelog

**New**

- Set CSS Minifier as esbuild in main.ts


#### Testing / Reviewing

- Web Components deploy preview should build successfully

## PR Checklist
As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~~[ ] Updated documentation and storybook examples~~
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- ~~[ ] Tested for cross-browser consistency~~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
