### PR TITLE
feat(rating): add rating component feature

### DIFF
--- a/packages/styles/scss/components/_index.scss
+++ b/packages/styles/scss/components/_index.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2025, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -59,6 +59,7 @@
 @use 'popover';
 @use 'progress-bar';
 @use 'progress-indicator';
+@use 'rating';
 @use 'radio-button';
 @use 'search';
 @use 'select';

--- a/packages/styles/scss/components/rating/_index.scss
+++ b/packages/styles/scss/components/rating/_index.scss
@@ -1,0 +1,11 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@forward 'rating';
+@use 'rating';
+
+@include rating.rating;

--- a/packages/styles/scss/components/rating/_rating.scss
+++ b/packages/styles/scss/components/rating/_rating.scss
@@ -1,0 +1,519 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../config' as *;
+@use '../../motion' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type' as *;
+@use '../../utilities/convert';
+@use '../../utilities/high-contrast-mode' as *;
+@use '../../utilities/custom-property';
+
+/// Rating styles
+/// @access public
+/// @group rating
+@mixin rating {
+  // ----------------------------------------
+  // base
+  // ----------------------------------------
+  .#{$prefix}--rating {
+    @include custom-property.declaration(
+      'rating-icon-size',
+      convert.to-rem(24px)
+    );
+
+    @include custom-property.declaration(
+      'rating-nps-size',
+      convert.to-rem(40px)
+    );
+
+    @include custom-property.declaration('rating-gap', $spacing-03);
+
+    //reset fieldset defaults
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0;
+    border: none;
+    margin: 0;
+    gap: $spacing-03;
+  }
+
+  .#{$prefix}--rating__label {
+    @include type-style('label-01');
+
+    color: $text-secondary;
+    cursor: default;
+  }
+
+  // ----------------------------------------
+  // star variant
+  // ----------------------------------------
+  .#{$prefix}--rating__stars {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .#{$prefix}--rating__star-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: $icon-primary;
+    cursor: pointer;
+    transition: color $duration-fast-01 motion(exit, productive);
+
+    svg {
+      fill: currentColor;
+      pointer-events: none;
+      transition: fill $duration-fast-01 motion(exit, productive);
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      border-radius: 2px;
+      outline: 2px solid $focus;
+      outline-offset: 2px;
+    }
+  }
+
+  .#{$prefix}--rating__star-btn--filled {
+    color: $support-warning;
+  }
+
+  // ----------------------------------------
+  // thumb variant
+  // ----------------------------------------
+  .#{$prefix}--rating__thumb {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .#{$prefix}--rating__thumb-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: $icon-secondary;
+    cursor: pointer;
+
+    svg {
+      fill: currentColor;
+      pointer-events: none;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      border-radius: 2px;
+      outline: 2px solid $focus;
+      outline-offset: 2px;
+    }
+  }
+
+  .#{$prefix}--rating__thumb-btn--up {
+    color: $support-success;
+  }
+
+  .#{$prefix}--rating__thumb-btn--down {
+    color: $support-error;
+  }
+
+  // ----------------------------------------
+  // nps variant
+  // ----------------------------------------
+  .#{$prefix}--rating__nps {
+    display: flex;
+  }
+
+  .#{$prefix}--rating__nps-btn {
+    border: 1px solid $border-subtle;
+    border-radius: 50%;
+    background: transparent;
+    cursor: pointer;
+    transition:
+      background $duration-fast-01 motion(exit, productive),
+      transform $duration-fast-01 motion(exit, productive);
+
+    &--hovered {
+      background: $layer-hover;
+      transform: scale(1.05);
+    }
+
+    &--selected {
+      border-color: $interactive;
+      background: $interactive;
+      color: $text-on-color;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
+  .#{$prefix}--rating__nps-wrapper {
+    display: flex;
+    align-items: center;
+    gap: $spacing-03;
+  }
+
+  .#{$prefix}--rating__nps-label {
+    @include type-style('label-01');
+
+    color: $text-secondary;
+    cursor: default;
+    white-space: nowrap;
+  }
+
+  // ----------------------------------------
+  // size modifiers
+  // ----------------------------------------
+
+  .#{$prefix}--rating--sm {
+    @include custom-property.declaration(
+      'rating-icon-size',
+      convert.to-rem(16px)
+    );
+    @include custom-property.declaration('rating-gap', $spacing-02);
+    @include custom-property.declaration(
+      'rating-nps-size',
+      convert.to-rem(32px)
+    );
+  }
+
+  .#{$prefix}--rating--md {
+    @include custom-property.declaration(
+      'rating-icon-size',
+      convert.to-rem(24px)
+    );
+    @include custom-property.declaration('rating-gap', $spacing-03);
+    @include custom-property.declaration(
+      'rating-nps-size',
+      convert.to-rem(40px)
+    );
+  }
+
+  .#{$prefix}--rating--lg {
+    @include custom-property.declaration(
+      'rating-icon-size',
+      convert.to-rem(40px)
+    );
+    @include custom-property.declaration('rating-gap', $spacing-04);
+    @include custom-property.declaration(
+      'rating-nps-size',
+      convert.to-rem(48px)
+    );
+  }
+
+  .#{$prefix}--rating__star-btn svg,
+  .#{$prefix}--rating__thumb-btn svg {
+    block-size: custom-property.get-var('rating-icon-size');
+    inline-size: custom-property.get-var('rating-icon-size');
+  }
+
+  .#{$prefix}--rating__nps-btn {
+    block-size: custom-property.get-var('rating-nps-size');
+    inline-size: custom-property.get-var('rating-nps-size');
+  }
+
+  .#{$prefix}--rating__stars,
+  .#{$prefix}--rating__thumb,
+  .#{$prefix}--rating__nps {
+    gap: custom-property.get-var('rating-gap');
+  }
+  // ----------------------------------------
+  // disabled
+  // ----------------------------------------
+
+  .#{$prefix}--rating--disabled {
+    .#{$prefix}--rating__star-btn,
+    .#{$prefix}--rating__thumb-btn,
+    .#{$prefix}--rating__nps-btn {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    .#{$prefix}--rating__label {
+      color: $text-disabled;
+    }
+  }
+
+  // ----------------------------------------
+  // read-only
+  // ----------------------------------------
+
+  .#{$prefix}--rating--read-only {
+    .#{$prefix}--rating__star-btn,
+    .#{$prefix}--rating__thumb-btn,
+    .#{$prefix}--rating__nps-btn {
+      cursor: default;
+    }
+  }
+
+  // ----------------------------------------
+  // HCM
+  // ----------------------------------------
+
+  .#{$prefix}--rating__star-btn,
+  .#{$prefix}--rating__thumb-btn,
+  .#{$prefix}--rating__nps-btn {
+    @include high-contrast-mode('outline');
+  }
+
+  .#{$prefix}--rating__star-btn:focus,
+  .#{$prefix}--rating__thumb-btn:focus,
+  .#{$prefix}--rating__nps-btn:focus {
+    @include high-contrast-mode('focus');
+  }
+
+  // ----------------------------------------
+  // overflow for animations
+  // ----------------------------------------
+
+  .#{$prefix}--rating__stars,
+  .#{$prefix}--rating__thumb {
+    overflow: visible;
+  }
+
+  .#{$prefix}--rating__star-btn,
+  .#{$prefix}--rating__thumb-btn {
+    position: relative;
+    overflow: visible;
+  }
+
+  // ----------------------------------------
+  // animations
+  // ----------------------------------------
+
+  @keyframes #{$prefix}--rating-pop {
+    0% {
+      transform: scale(1);
+    }
+
+    20% {
+      transform: scale(0);
+    }
+
+    60% {
+      transform: scale(1.5);
+    }
+
+    78% {
+      transform: scale(0.9);
+    }
+
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  @keyframes #{$prefix}--rating-ring {
+    0% {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(0);
+    }
+
+    60% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(1.8);
+    }
+  }
+
+  @keyframes #{$prefix}--rating-particles {
+    0% {
+      box-shadow:
+        0 0 0 $support-success,
+        0 0 0 $support-success,
+        0 0 0 $support-success,
+        0 0 0 $support-success,
+        0 0 0 $support-success,
+        0 0 0 $support-success;
+      opacity: 1;
+    }
+
+    100% {
+      box-shadow:
+        0 convert.to-rem(-22px) 0 $support-success,
+        convert.to-rem(19px) convert.to-rem(-11px) 0 $support-success,
+        convert.to-rem(19px) convert.to-rem(11px) 0 $support-success,
+        0 convert.to-rem(22px) 0 $support-success,
+        convert.to-rem(-19px) convert.to-rem(11px) 0 $support-success,
+        convert.to-rem(-19px) convert.to-rem(-11px) 0 $support-success;
+      opacity: 0;
+    }
+  }
+
+  @keyframes #{$prefix}--rating-particles-down {
+    0% {
+      box-shadow:
+        0 0 0 $support-error,
+        0 0 0 $support-error,
+        0 0 0 $support-error,
+        0 0 0 $support-error,
+        0 0 0 $support-error,
+        0 0 0 $support-error;
+      opacity: 1;
+    }
+
+    100% {
+      box-shadow:
+        0 convert.to-rem(-22px) 0 $support-error,
+        convert.to-rem(19px) convert.to-rem(-11px) 0 $support-error,
+        convert.to-rem(19px) convert.to-rem(11px) 0 $support-error,
+        0 convert.to-rem(22px) 0 $support-error,
+        convert.to-rem(-19px) convert.to-rem(11px) 0 $support-error,
+        convert.to-rem(-19px) convert.to-rem(-11px) 0 $support-error;
+      opacity: 0;
+    }
+  }
+
+  .#{$prefix}--rating__star-btn--animating {
+    svg {
+      animation: #{$prefix}--rating-pop 500ms
+        cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+
+  .#{$prefix}--rating__star-btn--animating-particles {
+    &::before {
+      position: absolute;
+      border: convert.to-rem(4px) solid $support-warning;
+      border-radius: 50%;
+      animation: #{$prefix}--rating-ring 500ms ease-out forwards;
+      block-size: convert.to-rem(32px);
+      content: '';
+      inline-size: convert.to-rem(32px);
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      pointer-events: none;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+
+  .#{$prefix}--rating__thumb-btn--animating {
+    svg {
+      animation: #{$prefix}--rating-pop 500ms
+        cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+
+  .#{$prefix}--rating__thumb-btn--animating-particles {
+    &::before {
+      position: absolute;
+      border: convert.to-rem(4px) solid $support-success;
+      border-radius: 50%;
+      animation: #{$prefix}--rating-ring 500ms ease-out forwards;
+      block-size: 100%;
+      content: '';
+      inline-size: 100%;
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      pointer-events: none;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+
+    &::after {
+      position: absolute;
+      border-radius: 50%;
+      animation: #{$prefix}--rating-particles 500ms ease-out forwards;
+      background: $support-success;
+      block-size: convert.to-rem(4px);
+      content: '';
+      inline-size: convert.to-rem(4px);
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      margin-block-start: convert.to-rem(-2px);
+      margin-inline-start: convert.to-rem(-2px);
+      pointer-events: none;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+
+  .#{$prefix}--rating__thumb-btn--animating-down {
+    svg {
+      animation: #{$prefix}--rating-pop 500ms
+        cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+
+  .#{$prefix}--rating__thumb-btn--animating-down-particles {
+    &::before {
+      position: absolute;
+      border: convert.to-rem(4px) solid $support-error;
+      border-radius: 50%;
+      animation: #{$prefix}--rating-ring 500ms ease-out forwards;
+      block-size: 100%;
+      content: '';
+      inline-size: 100%;
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      pointer-events: none;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+
+    &::after {
+      position: absolute;
+      border-radius: 50%;
+      animation: #{$prefix}--rating-particles-down 500ms ease-out forwards;
+      background: $support-error;
+      block-size: convert.to-rem(4px);
+      content: '';
+      inline-size: convert.to-rem(4px);
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      margin-block-start: convert.to-rem(-2px);
+      margin-inline-start: convert.to-rem(-2px);
+      pointer-events: none;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+  }
+}

--- a/packages/web-components/src/components/rating/__tests__/rating-test.js
+++ b/packages/web-components/src/components/rating/__tests__/rating-test.js
@@ -1,0 +1,616 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon/web-components/es/components/rating/index.js';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+
+describe('cds-rating', () => {
+  it('should render', async () => {
+    const el = await fixture(html`<cds-rating></cds-rating>`);
+
+    expect(el).to.exist;
+  });
+
+  it('should use "Rating" as the default label on the legend when no label-text is provided', async () => {
+    const el = await fixture(html`<cds-rating></cds-rating>`);
+    const legend = el.shadowRoot.querySelector('legend');
+
+    expect(legend.textContent.trim()).to.equal('Rating');
+  });
+
+  it('should set aria-readonly on the fieldset when read-only', async () => {
+    const el = await fixture(html`<cds-rating read-only></cds-rating>`);
+    const fieldset = el.shadowRoot.querySelector('fieldset');
+
+    expect(fieldset).to.have.attribute('aria-readonly', 'true');
+  });
+
+  it('should render a label element when label-text is provided', async () => {
+    const el = await fixture(
+      html`<cds-rating label-text="My rating"></cds-rating>`
+    );
+    const label = el.shadowRoot.querySelector('.cds--rating__label');
+
+    expect(label).to.exist;
+    expect(label.textContent.trim()).to.equal('My rating');
+  });
+
+  describe('star variant', () => {
+    let el;
+
+    beforeEach(async () => {
+      el = await fixture(html`<cds-rating></cds-rating>`);
+    });
+
+    it('should render 5 stars by default', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      expect(stars).to.have.length(5);
+    });
+
+    it('should render the correct number of stars when max is set', async () => {
+      const el = await fixture(html`<cds-rating max="7"></cds-rating>`);
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      expect(stars).to.have.length(7);
+    });
+
+    it('should not change value when disabled', async () => {
+      const el = await fixture(html`<cds-rating disabled></cds-rating>`);
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+    });
+
+    it('should not change value when read-only', async () => {
+      const el = await fixture(html`<cds-rating read-only></cds-rating>`);
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+    });
+
+    it('should update value and set aria-checked on the clicked star', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      expect(el.value).to.equal(3);
+
+      stars.forEach((star, i) => {
+        expect(star).to.have.attribute(
+          'aria-checked',
+          i === 2 ? 'true' : 'false'
+        );
+      });
+    });
+
+    it('should set the filled class on stars up to and including the selected value', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      stars.forEach((star, i) => {
+        if (i <= 2) {
+          expect(star).to.have.class('cds--rating__star-btn--filled');
+        } else {
+          expect(star).not.to.have.class('cds--rating__star-btn--filled');
+        }
+      });
+    });
+
+    it('should not fire cds-rating-changed when disabled', async () => {
+      const el = await fixture(html`<cds-rating disabled></cds-rating>`);
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      const eventPromise = oneEvent(el, 'cds-rating-changed');
+      stars[2].click();
+
+      const result = await Promise.race([
+        eventPromise.then(() => 'event fired'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 100)),
+      ]);
+
+      expect(result).to.equal(
+        'timeout',
+        'cds-rating-changed should not fire when disabled'
+      );
+    });
+
+    it('should not fire cds-rating-changed when read-only', async () => {
+      const el = await fixture(html`<cds-rating read-only></cds-rating>`);
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      const eventPromise = oneEvent(el, 'cds-rating-changed');
+      stars[2].click();
+
+      const result = await Promise.race([
+        eventPromise.then(() => 'event fired'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 100)),
+      ]);
+
+      expect(result).to.equal(
+        'timeout',
+        'cds-rating-changed should not fire when read-only'
+      );
+    });
+
+    it('should fire cds-rating-changed event with the correct value when a star is clicked', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      const listener = oneEvent(el, 'cds-rating-changed');
+      stars[2].click();
+      const event = await listener;
+
+      expect(event).to.exist;
+      expect(event.detail.value).to.equal(3);
+    });
+
+    it('should apply animating class to the clicked star', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      expect(stars[2]).to.have.class('cds--rating__star-btn--animating');
+    });
+
+    it('should remove animating class from star after 600ms', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      await new Promise((resolve) => setTimeout(resolve, 650));
+      await el.updateComplete;
+
+      expect(stars[2]).not.to.have.class('cds--rating__star-btn--animating');
+    });
+
+    it('should apply the correct size class', async () => {
+      for (const size of ['sm', 'md', 'lg']) {
+        const el = await fixture(
+          html`<cds-rating size="${size}"></cds-rating>`
+        );
+        const fieldset = el.shadowRoot.querySelector('fieldset');
+        expect(fieldset).to.have.class(`cds--rating--${size}`);
+      }
+    });
+
+    it('should not apply animating particles class when animated is false', async () => {
+      el.animated = false;
+      await el.updateComplete;
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      expect(stars[2]).not.to.have.class(
+        'cds--rating__star-btn--animating-particles'
+      );
+    });
+
+    it('should apply custom star-label-format to aria-label', async () => {
+      const el = await fixture(
+        html`<cds-rating
+          star-label-format="{value} of {max} stars"></cds-rating>`
+      );
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      expect(stars[0]).to.have.attribute('aria-label', '1 of 5 stars');
+      expect(stars[4]).to.have.attribute('aria-label', '5 of 5 stars');
+    });
+
+    it('should clean up animation timers when disconnected', async () => {
+      const stars = el.shadowRoot.querySelectorAll('.cds--rating__star-btn');
+
+      stars[2].click();
+      await el.updateComplete;
+
+      el.remove();
+
+      await new Promise((resolve) => setTimeout(resolve, 650));
+
+      expect(el._animationTimer).to.be.null;
+    });
+  });
+
+  describe('thumb variant', () => {
+    let el;
+
+    beforeEach(async () => {
+      el = await fixture(html`<cds-rating variant="thumb"></cds-rating>`);
+    });
+
+    it('should render thumbs up and thumbs down buttons', async () => {
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not useful"]'
+      );
+
+      expect(thumbUp).to.exist;
+      expect(thumbDown).to.exist;
+    });
+
+    it('should disable both buttons when disabled', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" disabled></cds-rating>`
+      );
+      const fieldset = el.shadowRoot.querySelector('fieldset');
+
+      expect(fieldset).to.have.attribute('disabled');
+    });
+
+    it('should not change thumb value when read-only', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" read-only></cds-rating>`
+      );
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      thumbUp.click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+    });
+
+    it('should set value=1 and aria-pressed="true" when thumbs up is clicked', async () => {
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      thumbUp.click();
+      await el.updateComplete;
+
+      expect(el.value).to.equal(1);
+      expect(thumbUp).to.have.attribute('aria-pressed', 'true');
+    });
+
+    it('should toggle value to null and aria-pressed="false" when thumbs up is clicked again', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="1"></cds-rating>`
+      );
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      thumbUp.click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+      expect(thumbUp).to.have.attribute('aria-pressed', 'false');
+    });
+
+    it('should set value=0 and aria-pressed="true" when thumbs down is clicked', async () => {
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not useful"]'
+      );
+
+      thumbDown.click();
+      await el.updateComplete;
+
+      expect(el.value).to.equal(0);
+      expect(thumbDown).to.have.attribute('aria-pressed', 'true');
+    });
+
+    it('should toggle value to null when thumbs down is clicked again', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="0"></cds-rating>`
+      );
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not useful"]'
+      );
+
+      thumbDown.click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+      expect(thumbDown).to.have.attribute('aria-pressed', 'false');
+    });
+
+    it('should fire cds-rating-changed event with the correct value when thumbs up is clicked', async () => {
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      const listener = oneEvent(el, 'cds-rating-changed');
+      thumbUp.click();
+      const event = await listener;
+
+      expect(event).to.exist;
+      expect(event.detail.value).to.equal(1);
+    });
+
+    it('should apply animating class to thumbs up when liking', async () => {
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      thumbUp.click();
+      await el.updateComplete;
+
+      expect(thumbUp).to.have.class('cds--rating__thumb-btn--animating');
+    });
+
+    it('should not apply animating class to thumbs up when unliking', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="1"></cds-rating>`
+      );
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      thumbUp.click();
+      await el.updateComplete;
+
+      expect(thumbUp).not.to.have.class('cds--rating__thumb-btn--animating');
+    });
+
+    it('should apply animating class to thumbs down when disliking', async () => {
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not useful"]'
+      );
+
+      thumbDown.click();
+      await el.updateComplete;
+
+      expect(thumbDown).to.have.class('cds--rating__thumb-btn--animating-down');
+    });
+
+    it('should not apply animating class to thumbs down when removing dislike', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="0"></cds-rating>`
+      );
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not useful"]'
+      );
+
+      thumbDown.click();
+      await el.updateComplete;
+
+      expect(thumbDown).not.to.have.class(
+        'cds--rating__thumb-btn--animating-down'
+      );
+    });
+
+    it('should fire cds-rating-changed when thumbs up is toggled off', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="1"></cds-rating>`
+      );
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+
+      const listener = oneEvent(el, 'cds-rating-changed');
+      thumbUp.click();
+      const event = await listener;
+
+      expect(event).to.exist;
+      expect(event.detail.value).to.be.null;
+    });
+
+    it('should fire cds-rating-changed when thumbs down is toggled off', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="0"></cds-rating>`
+      );
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not useful"]'
+      );
+
+      const listener = oneEvent(el, 'cds-rating-changed');
+      thumbDown.click();
+      const event = await listener;
+
+      expect(event).to.exist;
+      expect(event.detail.value).to.be.null;
+    });
+
+    it('should apply custom label-thumbs-up and label-thumbs-down', async () => {
+      const el = await fixture(
+        html`<cds-rating
+          variant="thumb"
+          label-thumbs-up="Helpful"
+          label-thumbs-down="Not helpful"></cds-rating>`
+      );
+
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Helpful"]'
+      );
+      const thumbDown = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Not helpful"]'
+      );
+
+      expect(thumbUp).to.exist;
+      expect(thumbDown).to.exist;
+    });
+
+    it('should switch from thumbs down to thumbs up', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="thumb" value="0"></cds-rating>`
+      );
+
+      const thumbUp = el.shadowRoot.querySelector(
+        '.cds--rating__thumb-btn[aria-label="Useful"]'
+      );
+      thumbUp.click();
+      await el.updateComplete;
+
+      expect(el.value).to.equal(1);
+    });
+  });
+
+  describe('nps variant', () => {
+    let el;
+
+    beforeEach(async () => {
+      el = await fixture(
+        html`<cds-rating variant="nps" max="10"></cds-rating>`
+      );
+    });
+
+    it('should render 11 buttons by default (0 through 10)', async () => {
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      expect(buttons).to.have.length(11);
+    });
+
+    it('should render the correct number of buttons when max is set', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="nps" max="5"></cds-rating>`
+      );
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      expect(buttons).to.have.length(6);
+    });
+
+    it('should render label-min and label-max text', async () => {
+      const labels = el.shadowRoot.querySelectorAll('.cds--rating__nps-label');
+
+      expect(labels[0].textContent.trim()).to.equal('Not likely');
+      expect(labels[1].textContent.trim()).to.equal('Very likely');
+    });
+
+    it('should not change value when disabled', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="nps" max="10" disabled></cds-rating>`
+      );
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      buttons[7].click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+    });
+
+    it('should not change value when read-only', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="nps" max="10" read-only></cds-rating>`
+      );
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      buttons[7].click();
+      await el.updateComplete;
+
+      expect(el.value).to.be.null;
+    });
+
+    it('should update value and set aria-checked on the clicked button', async () => {
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      buttons[7].click();
+      await el.updateComplete;
+
+      expect(el.value).to.equal(7);
+
+      buttons.forEach((btn, i) => {
+        expect(btn).to.have.attribute(
+          'aria-checked',
+          i === 7 ? 'true' : 'false'
+        );
+      });
+    });
+
+    it('should apply selected class to the clicked button', async () => {
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      buttons[7].click();
+      await el.updateComplete;
+
+      buttons.forEach((btn, i) => {
+        if (i === 7) {
+          expect(btn).to.have.class('cds--rating__nps-btn--selected');
+        } else {
+          expect(btn).not.to.have.class('cds--rating__nps-btn--selected');
+        }
+      });
+    });
+
+    it('should disable all buttons when disabled', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="nps" max="10" disabled></cds-rating>`
+      );
+      const fieldset = el.shadowRoot.querySelector('fieldset');
+
+      expect(fieldset).to.have.attribute('disabled');
+    });
+
+    it('should not fire cds-rating-changed when disabled', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="nps" max="10" disabled></cds-rating>`
+      );
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      const eventPromise = oneEvent(el, 'cds-rating-changed');
+      buttons[7].click();
+
+      const result = await Promise.race([
+        eventPromise.then(() => 'event fired'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 100)),
+      ]);
+
+      expect(result).to.equal(
+        'timeout',
+        'cds-rating-changed should not fire when disabled'
+      );
+    });
+
+    it('should not fire cds-rating-changed when read-only', async () => {
+      const el = await fixture(
+        html`<cds-rating variant="nps" max="10" read-only></cds-rating>`
+      );
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      const eventPromise = oneEvent(el, 'cds-rating-changed');
+      buttons[7].click();
+
+      const result = await Promise.race([
+        eventPromise.then(() => 'event fired'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 100)),
+      ]);
+
+      expect(result).to.equal(
+        'timeout',
+        'cds-rating-changed should not fire when read-only'
+      );
+    });
+
+    it('should fire cds-rating-changed with the correct value when a button is clicked', async () => {
+      const buttons = el.shadowRoot.querySelectorAll('.cds--rating__nps-btn');
+
+      const listener = oneEvent(el, 'cds-rating-changed');
+      buttons[7].click();
+      const event = await listener;
+
+      expect(event).to.exist;
+      expect(event.detail.value).to.equal(7);
+    });
+
+    it('should apply custom label-min and label-max', async () => {
+      const el = await fixture(
+        html`<cds-rating
+          variant="nps"
+          max="10"
+          label-min="Terrible"
+          label-max="Excellent"></cds-rating>`
+      );
+      const labels = el.shadowRoot.querySelectorAll('.cds--rating__nps-label');
+
+      expect(labels[0].textContent.trim()).to.equal('Terrible');
+      expect(labels[1].textContent.trim()).to.equal('Excellent');
+    });
+  });
+});

--- a/packages/web-components/src/components/rating/defs.ts
+++ b/packages/web-components/src/components/rating/defs.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Rating variant.
+ */
+export enum RATING_VARIANT {
+  /**
+   * Star rating
+   */
+  STAR = 'star',
+  /**
+   * Thumbs up/down
+   */
+  THUMB = 'thumb',
+  /**
+   * Net Promoter Score
+   */
+  NPS = 'nps',
+}
+
+/**
+ * Rating size.
+ */
+export enum RATING_SIZE {
+  /**
+   * Small size
+   */
+  SMALL = 'sm',
+  /**
+   * Medium size (default)
+   */
+  MEDIUM = 'md',
+  /**
+   * Large size
+   */
+  LARGE = 'lg',
+}

--- a/packages/web-components/src/components/rating/index.ts
+++ b/packages/web-components/src/components/rating/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './rating';

--- a/packages/web-components/src/components/rating/rating.mdx
+++ b/packages/web-components/src/components/rating/rating.mdx
@@ -1,0 +1,64 @@
+import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
+import { cdnJs } from '../../globals/internal/storybook-cdn';
+import * as RatingStories from './rating.stories';
+
+<Meta of={RatingStories} />
+
+# Rating
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/web-components/src/components/rating)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Star Rating](#star-rating)
+- [Thumb Rating](#thumb-rating)
+- [NPS Rating](#nps-rating)
+- [Component API](#component-api)
+- [CDN](#cdn)
+- [Feedback](#feedback)
+
+## Overview
+
+The `cds-rating` component allows users to provide feedback by selecting a
+rating. It is commonly used in forms, product reviews, and customer satisfaction
+surveys.
+
+The component supports three variants controlled by the `variant` attribute:
+`star`, `thumb` and `nps`.
+
+## Star Rating
+
+The `star` variant renders a 1-to-N star selector. The number of stars is
+configurable via the `max` attribute (default: 5). Stars are filled up to the
+current `value`.
+
+<Canvas of={RatingStories.Default} />
+
+## Thumb Rating
+
+The `thumb` variant renders a binary thumbs up / thumbs down selector, useful
+for simple useful / not-useful feedback patterns.
+
+<Canvas of={RatingStories.Thumb} />
+
+## NPS Rating
+
+The `nps` variant renders a 0-to-10 Net Promoter Score scale, a standard
+enterprise metric used to measure customer loyalty and satisfaction.
+
+<Canvas of={RatingStories.Nps} />
+
+## Component API
+
+## `cds-rating`
+
+<ArgTypes of="cds-rating" />
+
+<Markdown>{`${cdnJs({ components: ['rating'] })}`}</Markdown>
+
+## Feedback
+
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/web-components/src/components/rating/rating.mdx).

--- a/packages/web-components/src/components/rating/rating.scss
+++ b/packages/web-components/src/components/rating/rating.scss
@@ -1,0 +1,24 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+$css--plex: true !default;
+
+@use '@carbon/styles/scss/components/rating/index' as *;
+@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/theme' as *;
+
+:host(#{$prefix}-rating) {
+  outline: none;
+}
+
+:host(#{$prefix}-rating[disabled]) {
+  @extend .#{$prefix}--rating--disabled !optional;
+}
+
+:host(#{$prefix}-rating[read-only]) {
+  @extend .#{$prefix}--rating--read-only !optional;
+}

--- a/packages/web-components/src/components/rating/rating.stories.ts
+++ b/packages/web-components/src/components/rating/rating.stories.ts
@@ -1,0 +1,219 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit';
+import { RATING_VARIANT, RATING_SIZE } from './rating';
+import './index';
+
+const sizes = {
+  [`Small size (${RATING_SIZE.SMALL})`]: RATING_SIZE.SMALL,
+  [`Medium size (default)`]: RATING_SIZE.MEDIUM,
+  [`Large size (${RATING_SIZE.LARGE})`]: RATING_SIZE.LARGE,
+};
+
+const defaultArgs = {
+  animated: true,
+  disabled: false,
+  label: 'Label',
+  max: 5,
+  readOnly: false,
+  size: RATING_SIZE.MEDIUM,
+};
+
+const defaultThumbArgs = {
+  animated: true,
+  disabled: false,
+  label: 'Label',
+  labelThumbsDown: 'Thumbs Down',
+  labelThumbsUp: 'Thumbs Up',
+  readOnly: false,
+  size: RATING_SIZE.MEDIUM,
+};
+
+const defaultNpsArgs = {
+  disabled: false,
+  label: 'Label',
+  labelMin: 'Not likely',
+  labelMax: 'Very likely',
+  max: 10,
+  readOnly: false,
+  size: RATING_SIZE.MEDIUM,
+};
+
+const argTypes = {
+  animated: {
+    control: 'boolean',
+    description: 'Whether to show animations on interaction (animated)',
+  },
+  disabled: {
+    control: 'boolean',
+    description: 'Whether the rating is disabled (disabled)',
+  },
+  label: {
+    control: 'text',
+    description: 'Specify the text for the rating label (label)',
+  },
+  labelMax: {
+    control: 'text',
+    description: 'The best rating (labelMax)',
+  },
+  labelMin: {
+    control: 'text',
+    description: 'The worst rating (labelMin)',
+  },
+  labelThumbsDown: {
+    control: 'text',
+    description:
+      'Provide the accessible label for the thumbs down button. Only read by screen readers, not visible in the UI',
+  },
+  labelThumbsUp: {
+    control: 'text',
+    description:
+      'Provide the accessible label for the thumbs up button. Only read by screen readers, not visible in the UI',
+  },
+  max: {
+    control: 'number',
+    description: 'The maximum rating value (max)',
+  },
+  readOnly: {
+    control: 'boolean',
+    description: 'Whether the rating is read-only (read-only)',
+  },
+  size: {
+    control: 'radio',
+    description: 'The size of the rating component (size)',
+    options: sizes,
+  },
+};
+
+export const Default = {
+  args: { ...defaultArgs, variant: RATING_VARIANT.STAR },
+  argTypes: {
+    ...argTypes,
+    variant: {
+      table: { readonly: true },
+    },
+  },
+  parameters: {
+    controls: {
+      include: [
+        'animated',
+        'disabled',
+        'label',
+        'max',
+        'readOnly',
+        'size',
+        'variant',
+      ],
+    },
+  },
+  render: ({ animated, disabled, label, max, readOnly, size }) => html`
+    <cds-rating
+      ?animated="${animated}"
+      ?disabled="${disabled}"
+      label-text="${label}"
+      max="${max}"
+      ?read-only="${readOnly}"
+      size="${size}"
+      variant="${RATING_VARIANT.STAR}">
+    </cds-rating>
+  `,
+};
+
+export const Thumb = {
+  args: { ...defaultThumbArgs, variant: RATING_VARIANT.THUMB },
+  argTypes: {
+    ...argTypes,
+    variant: {
+      table: { readonly: true },
+    },
+  },
+  parameters: {
+    controls: {
+      include: [
+        'animated',
+        'disabled',
+        'label',
+        'labelThumbsDown',
+        'labelThumbsUp',
+        'readOnly',
+        'size',
+        'variant',
+      ],
+    },
+  },
+  render: ({
+    animated,
+    disabled,
+    label,
+    labelThumbsDown,
+    labelThumbsUp,
+    readOnly,
+    size,
+  }) => html`
+    <cds-rating
+      ?animated="${animated}"
+      ?disabled="${disabled}"
+      label-text="${label}"
+      label-thumbs-down="${labelThumbsDown}"
+      label-thumbs-up="${labelThumbsUp}"
+      ?read-only="${readOnly}"
+      size="${size}"
+      variant="${RATING_VARIANT.THUMB}">
+    </cds-rating>
+  `,
+};
+
+export const Nps = {
+  args: { ...defaultNpsArgs, variant: RATING_VARIANT.NPS },
+  argTypes: {
+    ...argTypes,
+    variant: {
+      table: { readonly: true },
+    },
+  },
+  parameters: {
+    controls: {
+      include: [
+        'disabled',
+        'label',
+        'max',
+        'labelMax',
+        'labelMin',
+        'readOnly',
+        'size',
+        'variant',
+      ],
+    },
+  },
+  render: ({
+    disabled,
+    label,
+    max,
+    labelMax,
+    labelMin,
+    readOnly,
+    size,
+  }) => html`
+    <cds-rating
+      ?disabled="${disabled}"
+      label-text="${label}"
+      max="${max}"
+      label-max="${labelMax}"
+      label-min="${labelMin}"
+      ?read-only="${readOnly}"
+      size="${size}"
+      variant="${RATING_VARIANT.NPS}">
+    </cds-rating>
+  `,
+};
+
+const meta = {
+  title: 'Components/Rating',
+};
+
+export default meta;

--- a/packages/web-components/src/components/rating/rating.ts
+++ b/packages/web-components/src/components/rating/rating.ts
@@ -1,0 +1,425 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { LitElement, html } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { prefix } from '../../globals/settings';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
+import { RATING_VARIANT, RATING_SIZE } from './defs';
+import { iconLoader } from '../../globals/internal/icon-loader';
+import styles from './rating.scss?lit';
+import ThumbsUp16 from '@carbon/icons/es/thumbs-up/16.js';
+import ThumbsDown16 from '@carbon/icons/es/thumbs-down/16.js';
+import ThumbsUpFilled16 from '@carbon/icons/es/thumbs-up--filled/16.js';
+import ThumbsDownFilled16 from '@carbon/icons/es/thumbs-down--filled/16.js';
+import Star16 from '@carbon/icons/es/star/16.js';
+import StarFilled16 from '@carbon/icons/es/star--filled/16.js';
+
+export { RATING_VARIANT, RATING_SIZE };
+
+/**
+ * Rating component.
+ *
+ * @element cds-rating
+ * @fires cds-rating-changed - The custom event fired after the rating value changes.
+ * @slot label-text - The label text.
+ */
+@customElement(`${prefix}-rating`)
+class CDSRating extends LitElement {
+  /**
+   * Whether to show animations on interaction.
+   */
+  @property({ type: Boolean, attribute: 'animated', reflect: true })
+  animated = true;
+
+  /**
+   * The aria-label for the rating group when no label-text is provided.
+   */
+  @property({ attribute: 'aria-label' })
+  ariaLabel = 'Rating';
+
+  /**
+   * Whether the rating is disabled.
+   */
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  /**
+   * Label for the highest value (right side of the NPS scale).
+   */
+  @property({ attribute: 'label-max' })
+  labelMax = 'Very likely';
+
+  /**
+   * Label for the lowest value (left side of the NPS scale).
+   */
+  @property({ attribute: 'label-min' })
+  labelMin = 'Not likely';
+
+  /**
+   * The label text for accessibility.
+   */
+  @property({ attribute: 'label-text' })
+  labelText = '';
+
+  /**
+   * The label for the thumb down button.
+   */
+  @property({ attribute: 'label-thumbs-down' })
+  labelThumbsDown = 'Not useful';
+
+  /**
+   * The label for the thumb up button.
+   */
+  @property({ attribute: 'label-thumbs-up' })
+  labelThumbsUp = 'Useful';
+
+  /**
+   * The maximum rating value (used by star variant).
+   */
+  @property({ type: Number })
+  max = 5;
+
+  /**
+   * Whether the rating is read-only.
+   */
+  @property({ reflect: true, attribute: 'read-only', type: Boolean })
+  readOnly = false;
+
+  /**
+   * The size of the rating component.
+   */
+  @property({ reflect: true })
+  size = RATING_SIZE.MEDIUM;
+
+  /**
+   * The aria-label format for each star button.
+   * Use {value} and {max} as placeholders.
+   */
+  @property({ attribute: 'star-label-format', reflect: true })
+  starLabelFormat = '{value} out of {max}';
+
+  /**
+   * The current rating value.
+   */
+  @property({ type: Number, reflect: true })
+  value: number | null = null;
+
+  /**
+   * The rating variant.
+   */
+  @property({ reflect: true })
+  variant = RATING_VARIANT.STAR;
+
+  /**
+   * Internal animation state for the currently animating star.
+   */
+  @state()
+  private _animatingStarValue: number | null = null;
+
+  /**
+   * Internal animation state for the thumb down button.
+   */
+  @state()
+  private _animatingThumbDown = false;
+
+  /**
+   * Internal animation state for the thumb up button.
+   */
+  @state()
+  private _animatingThumbUp = false;
+
+  /**
+   * Internal hover state for thumb variant preview.
+   */
+  @state()
+  private _hoverThumb: 'up' | 'down' | null = null;
+
+  /**
+   * Internal hover state for star variant preview.
+   */
+  @state()
+  private _hoverValue: number | null = null;
+
+  /**
+   * Timer for star and thumb up animations.
+   */
+  private _animationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Timer for thumb down animations.
+   */
+  private _thumbDownAnimTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Cleans up animation timers when the component is disconnected.
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._animationTimer) {
+      clearTimeout(this._animationTimer);
+      this._animationTimer = null;
+    }
+    if (this._thumbDownAnimTimer) {
+      clearTimeout(this._thumbDownAnimTimer);
+      this._thumbDownAnimTimer = null;
+    }
+  }
+
+  /**
+   * Handles value change and dispatches the change event.
+   */
+  private _handleChange(newValue: number | null) {
+    if (this.disabled || this.readOnly) return;
+    this.value = newValue;
+    const { eventChange } = this.constructor as typeof CDSRating;
+    this.dispatchEvent(
+      new CustomEvent(eventChange, {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value },
+      })
+    );
+  }
+
+  /**
+   * Handles star button click and triggers pop animation.
+   */
+  private _handleStarClick(starValue: number) {
+    if (this.disabled || this.readOnly) return;
+    this._handleChange(starValue);
+    if (this._animationTimer) clearTimeout(this._animationTimer);
+    this._animatingStarValue = starValue;
+    this._animationTimer = setTimeout(() => {
+      this._animatingStarValue = null;
+      this._animationTimer = null;
+    }, 600);
+  }
+
+  /**
+   * Handles thumb up button click and triggers animation.
+   */
+  private _handleThumbUpClick = () => {
+    if (this.disabled || this.readOnly) return;
+    const isLiking = this.value !== 1;
+    this._handleChange(isLiking ? 1 : null);
+    if (!isLiking) return;
+    if (this._animationTimer) clearTimeout(this._animationTimer);
+    this._animatingThumbUp = true;
+    this._animationTimer = setTimeout(() => {
+      this._animatingThumbUp = false;
+      this._animationTimer = null;
+    }, 600);
+  };
+
+  /**
+   * Handles thumb down button click and triggers animation.
+   */
+  private _handleThumbDownClick = () => {
+    if (this.disabled || this.readOnly) return;
+    const isDisliking = this.value !== 0;
+    this._handleChange(isDisliking ? 0 : null);
+    if (!isDisliking) return;
+    if (this._thumbDownAnimTimer) clearTimeout(this._thumbDownAnimTimer);
+    this._animatingThumbDown = true;
+    this._thumbDownAnimTimer = setTimeout(() => {
+      this._animatingThumbDown = false;
+      this._thumbDownAnimTimer = null;
+    }, 600);
+  };
+
+  render() {
+    const {
+      animated,
+      ariaLabel,
+      disabled,
+      labelMax,
+      labelMin,
+      labelText,
+      labelThumbsDown,
+      labelThumbsUp,
+      max,
+      readOnly,
+      size,
+      starLabelFormat,
+      value,
+      variant,
+    } = this;
+
+    const classes = classMap({
+      [`${prefix}--rating`]: true,
+      [`${prefix}--rating--${size}`]: !!size,
+    });
+
+    if (variant === RATING_VARIANT.THUMB) {
+      const thumbUpClasses = classMap({
+        [`${prefix}--rating__thumb-btn`]: true,
+        [`${prefix}--rating__thumb-btn--up`]:
+          value === 1 || this._hoverThumb === 'up',
+        [`${prefix}--rating__thumb-btn--animating`]: this._animatingThumbUp,
+        [`${prefix}--rating__thumb-btn--animating-particles`]:
+          this._animatingThumbUp && animated,
+      });
+      const thumbDownClasses = classMap({
+        [`${prefix}--rating__thumb-btn`]: true,
+        [`${prefix}--rating__thumb-btn--down`]:
+          value === 0 || this._hoverThumb === 'down',
+        [`${prefix}--rating__thumb-btn--animating-down`]:
+          this._animatingThumbDown,
+        [`${prefix}--rating__thumb-btn--animating-down-particles`]:
+          this._animatingThumbDown && animated,
+      });
+      return html`
+        <fieldset
+          class=${classes}
+          ?disabled=${disabled}
+          aria-readonly=${readOnly}>
+          <legend class="${prefix}--rating__label">
+            <slot name="label-text">${labelText || ariaLabel}</slot>
+          </legend>
+          <div class="${prefix}--rating__thumb">
+            <button
+              class=${thumbUpClasses}
+              aria-pressed=${value === 1}
+              aria-label=${labelThumbsUp}
+              @click=${this._handleThumbUpClick}
+              @mouseenter=${() => {
+                if (!readOnly && !disabled) this._hoverThumb = 'up';
+              }}
+              @mouseleave=${() => {
+                this._hoverThumb = null;
+              }}>
+              ${value === 1
+                ? iconLoader(ThumbsUpFilled16)
+                : iconLoader(ThumbsUp16)}
+            </button>
+            <button
+              class=${thumbDownClasses}
+              aria-pressed=${value === 0}
+              aria-label=${labelThumbsDown}
+              @click=${this._handleThumbDownClick}
+              @mouseenter=${() => {
+                if (!readOnly && !disabled) this._hoverThumb = 'down';
+              }}
+              @mouseleave=${() => {
+                this._hoverThumb = null;
+              }}>
+              ${value === 0
+                ? iconLoader(ThumbsDownFilled16)
+                : iconLoader(ThumbsDown16)}
+            </button>
+          </div>
+        </fieldset>
+      `;
+    }
+    if (variant === RATING_VARIANT.STAR) {
+      const activeValue = this._hoverValue ?? value ?? 0;
+      return html`
+        <fieldset
+          class=${classes}
+          ?disabled=${disabled}
+          aria-readonly=${readOnly}>
+          <legend class="${prefix}--rating__label">
+            <slot name="label-text">${labelText || ariaLabel}</slot>
+          </legend>
+          <div
+            class="${prefix}--rating__stars"
+            @mouseleave=${() => {
+              this._hoverValue = null;
+            }}>
+            ${Array.from({ length: max }, (_, i) => {
+              const starValue = i + 1;
+              const isFilled = starValue <= activeValue;
+              const starClasses = classMap({
+                [`${prefix}--rating__star-btn`]: true,
+                [`${prefix}--rating__star-btn--filled`]: isFilled,
+                [`${prefix}--rating__star-btn--animating`]:
+                  starValue === this._animatingStarValue,
+                [`${prefix}--rating__star-btn--animating-particles`]:
+                  starValue === this._animatingStarValue && animated,
+              });
+              return html`
+                <button
+                  class=${starClasses}
+                  role="radio"
+                  aria-checked=${value === starValue}
+                  aria-label=${starLabelFormat
+                    .replace('{value}', String(starValue))
+                    .replace('{max}', String(max))}
+                  @click=${() => this._handleStarClick(starValue)}
+                  @mouseenter=${() => {
+                    if (!readOnly && !disabled) this._hoverValue = starValue;
+                  }}>
+                  ${isFilled ? iconLoader(StarFilled16) : iconLoader(Star16)}
+                </button>
+              `;
+            })}
+          </div>
+        </fieldset>
+      `;
+    }
+    if (variant === RATING_VARIANT.NPS) {
+      return html`
+        <fieldset
+          class=${classes}
+          ?disabled=${disabled}
+          aria-readonly=${readOnly}>
+          <legend class="${prefix}--rating__label">
+            <slot name="label-text">${labelText || ariaLabel}</slot>
+          </legend>
+          <div class="${prefix}--rating__nps-wrapper">
+            <span class="${prefix}--rating__nps-label">${labelMin}</span>
+            <div
+              class="${prefix}--rating__nps"
+              @mouseleave=${() => {
+                this._hoverValue = null;
+              }}>
+              ${Array.from({ length: max + 1 }, (_, i) => {
+                const isSelected = value === i;
+                const isHovered = this._hoverValue === i;
+                return html`
+                  <button
+                    class=${classMap({
+                      [`${prefix}--rating__nps-btn`]: true,
+                      [`${prefix}--rating__nps-btn--selected`]: isSelected,
+                      [`${prefix}--rating__nps-btn--hovered`]:
+                        isHovered && !isSelected,
+                    })}
+                    role="radio"
+                    aria-checked=${isSelected}
+                    aria-label=${`${i} out of ${max}`}
+                    @click=${() => this._handleChange(i)}
+                    @mouseenter=${() => {
+                      if (!readOnly && !disabled) {
+                        this._hoverValue = i;
+                      }
+                    }}>
+                    ${i}
+                  </button>
+                `;
+              })}
+            </div>
+            <span class="${prefix}--rating__nps-label">${labelMax}</span>
+          </div>
+        </fieldset>
+      `;
+    }
+    return html``;
+  }
+
+  /**
+   * The name of the custom event fired after the rating value changes.
+   */
+  static get eventChange() {
+    return `${prefix}-rating-changed`;
+  }
+
+  static styles = styles;
+}
+
+export default CDSRating;


### PR DESCRIPTION
Closes carbon-design-system/carbon-labs#1285 

This feature consists of implementing a new cds-rating web component in @carbon/web-components. The implementation includes:

- Three rating variants: star (1 to N stars), thumb (thumbs up/down binary selection) and nps (Net Promoter Score 0-N scale).

- Accessibility using `fieldset` and `legend` following the cds-radio-button-group pattern.

- Animations with prefers-reduced-motion support across all variants. Animations are optional and can be disabled via the animated attribute.

- Size modifiers (small, medium and large) using CSS custom properties.

- Storybook stories, MDX documentation and unit tests.

### Changelog

**New**

- Added cds-rating web component with three variants:
    - Star (1-N), 
    - Thumbs Up / Thumbs Down, 
    - NPS (0-N).
- Added accessibility support.
- Added optional animations with `prefers-reduced-motion` support.
- Added size variants (`sm`, `md`, `lg`) using CSS custom properties.
- Added Storybook stories and MDX documentation.
- Added unit tests covering component behavior and interactions.


#### Testing / Reviewing

- Verify that all rating component tests pass.
- Check Storybook examples for all rating variants.
- Verify that `fieldset` and `legend` semantics correctly group the rating options and provide the right name for the control. Confirm that screen readers, such as NVDA screen reader (used to test this part of the feature), announce the rating group and its options as expected for all rating types.
- Verify that animations can be enabled and disabled using the `animated` attribute.
- Verify that animations are automatically reduced or disabled when the user has `prefers-reduced-motion` enabled.
- Verify that size variants (`sm`, `md`, `lg`) render correctly in all rating types.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
