### PR TITLE
feat: add web components code connect for breadcrumb

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -80,7 +80,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@carbon/test-utils": "^10.41.0",
     "@carbon/themes": "^11.75.0",
-    "@figma/code-connect": "^1.4.5",
+    "@figma/code-connect": "^1.4.7",
     "@stackblitz/sdk": "^1.11.0",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",

--- a/packages/web-components/code-connect/breadcrumb/breadcrumb-item.figma.ts
+++ b/packages/web-components/code-connect/breadcrumb/breadcrumb-item.figma.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import figma, { html } from '@figma/code-connect/html';
+
+const imports = [
+  "import '@carbon/web-components/es/components/breadcrumb/index.js'",
+  "import '@carbon/web-components/es/components/overflow-menu/index.js'",
+];
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=3136-29234&t=U57NnoohldL54XAl-4',
+  {
+    variant: { Type: 'Link' },
+    props: {
+      children: figma.string('Text'),
+    },
+    example: ({ children }) =>
+      html`<cds-breadcrumb-item>
+        <cds-breadcrumb-link href="#">${children}</cds-breadcrumb-link>
+      </cds-breadcrumb-item>`,
+    imports,
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=3136-29234&t=U57NnoohldL54XAl-4',
+  {
+    variant: { State: 'Current' },
+    props: {
+      children: figma.string('Text'),
+      isCurrentPage: figma.boolean('Current'),
+    },
+    example: ({ children, isCurrentPage }) =>
+      html`<cds-breadcrumb-item>
+        <cds-breadcrumb-link is-currentpage=${isCurrentPage}>
+          ${children}
+        </cds-breadcrumb-link>
+      </cds-breadcrumb-item>`,
+    imports,
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=3136-29234&t=U57NnoohldL54XAl-4',
+  {
+    variant: { Type: 'Overflow' },
+    example: () =>
+      html`<cds-breadcrumb-item>
+        <cds-overflow-menu breadcrumb align="bottom">
+          <svg
+            slot="icon"
+            class="cds--overflow-menu__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 32 32"
+            fill="currentColor"
+            width="16"
+            height="16">
+            <circle cx="8" cy="16" r="2"></circle>
+            <circle cx="16" cy="16" r="2"></circle>
+            <circle cx="24" cy="16" r="2"></circle>
+          </svg>
+          <span slot="tooltip-content">Options</span>
+          <cds-overflow-menu-body>
+            <cds-overflow-menu-item>Breadcrumb 3</cds-overflow-menu-item>
+            <cds-overflow-menu-item>Breadcrumb 4</cds-overflow-menu-item>
+          </cds-overflow-menu-body>
+        </cds-overflow-menu>
+      </cds-breadcrumb-item>`,
+    imports,
+  }
+);

--- a/packages/web-components/code-connect/breadcrumb/breadcrumb.figma.ts
+++ b/packages/web-components/code-connect/breadcrumb/breadcrumb.figma.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import figma, { html } from '@figma/code-connect/html';
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/-v11--Carbon-Design-System?node-id=104376-11673&m=dev',
+  {
+    props: {
+      children: figma.children(['_Breadcrumb item']),
+      size: figma.enum('Size', {
+        Medium: 'md',
+        Small: 'sm',
+      }),
+    },
+    example: ({ children, size }) =>
+      html`<cds-breadcrumb size=${size}>${children}</cds-breadcrumb>`,
+    imports: [
+      "import '@carbon/web-components/es/components/breadcrumb/index.js'",
+    ],
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1961,7 +1961,7 @@ __metadata:
     "@carbon/test-utils": "npm:^10.41.0"
     "@carbon/themes": "npm:^11.75.0"
     "@carbon/utilities": "npm:^0.20.0"
-    "@figma/code-connect": "npm:^1.4.5"
+    "@figma/code-connect": "npm:^1.4.7"
     "@floating-ui/react": "npm:^0.27.4"
     "@ibm/telemetry-js": "npm:^1.5.0"
     "@stackblitz/sdk": "npm:^1.11.0"
@@ -3134,9 +3134,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@figma/code-connect@npm:^1.4.5":
-  version: 1.4.5
-  resolution: "@figma/code-connect@npm:1.4.5"
+"@figma/code-connect@npm:^1.4.7":
+  version: 1.4.7
+  resolution: "@figma/code-connect@npm:1.4.7"
   dependencies:
     boxen: "npm:5.1.1"
     chalk: "npm:^4.1.2"
@@ -3162,7 +3162,7 @@ __metadata:
     zod-validation-error: "npm:^3.2.0"
   bin:
     figma: bin/figma
-  checksum: 10/a7e17f35b817f2ff156258b4b5b48c05bdcf14fd48a61fadace09f438c3f8c45d24b948c5aef338a37e87a691e0b0f6a258a7330dd02fa985fbd62b897d1750b
+  checksum: 10/978936eacd15205f8017f400b2bcab34616952a91d4642a585f21a4748c409d5ccdcc015e734e8934d488d7859f76b0c5d4ffe09068d6c3a820720b0ccb1dbd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #22377 

Adds Figma Code Connect support for the Web Components Breadcrumb.

Updates `@figma/code-connect` to the latest version `1.4.7`

### Changelog

**New**

- Added Code Connect files for `cds-breadcrumb` and breadcrumb items.

**Changed**

- Updated `@figma/code-connect` to `1.4.7`.

**Removed**

- ~None~

#### Testing / Reviewing

Link: https://www.figma.com/design/NwXsMCCoMg1po4KK2oUK3o/Code-connect-demo---Carbon-Design-System?node-id=870-34987&m=dev

<img width="936" height="630" alt="image" src="https://github.com/user-attachments/assets/b7074709-61a5-4e0f-8ae2-3077b091b4b5" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
