### PR TITLE
test: migrate AILabel tests to TypeScript

### DIFF
--- a/packages/react/src/components/AILabel/__tests__/AILabel-test.tsx
+++ b/packages/react/src/components/AILabel/__tests__/AILabel-test.tsx
@@ -1,15 +1,17 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import React from 'react';
-import { AILabel, AILabelContent, AILabelActions } from '../';
-import { Button } from '../../Button';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { AILabel, AILabelActions, AILabelContent } from '../';
+import { Button } from '../../Button';
 
 const prefix = 'cds';
 
@@ -18,7 +20,7 @@ describe('AILabel', () => {
     it('should spread extra props onto the popover element', () => {
       const { container } = render(<AILabel data-testid="test" />);
 
-      expect(container.firstChild.firstChild).toHaveAttribute(
+      expect(container.firstChild?.firstChild).toHaveAttribute(
         'data-testid',
         'test'
       );
@@ -97,7 +99,7 @@ describe('AILabel', () => {
       const { container } = render(<AILabel revertActive />);
 
       expect(container.firstChild).toHaveClass(`${prefix}--ai-label--revert`);
-      expect(container.firstChild.firstChild).toHaveClass(
+      expect(container.firstChild?.firstChild).toHaveClass(
         `${prefix}--icon-tooltip`
       );
     });
@@ -157,6 +159,7 @@ describe('AILabelActions', () => {
 
     expect(screen.getByText('View details')).toBeInTheDocument();
   });
+
   describe('Labels and kind prop', () => {
     it('should use empty label for inline kind', () => {
       render(<AILabel kind="inline" aiText="AI" textLabel="Text goes here" />);


### PR DESCRIPTION
No issue.

Migrated `AILabel` tests to TypeScript.

### Changelog

**Changed**

- Migrated `AILabel` tests to TypeScript.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/AILabel/__tests__/AILabel-test.tsx
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
