### PR TITLE
fix: add MenuContext action types

### DIFF
--- a/packages/react/src/components/Menu/Menu-test.js
+++ b/packages/react/src/components/Menu/Menu-test.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { useState } from 'react';
+import { Checkmark } from '@carbon/icons-react';
 import { Menu, MenuItem, MenuItemSelectable, MenuItemRadioGroup } from './';
 import {
   act,
@@ -324,6 +325,40 @@ describe('MenuItem', () => {
       );
 
       expect(screen.getByText('item')).toBeInTheDocument();
+    });
+
+    it('should mark the menu as having icons when a menu item renders an icon', () => {
+      render(
+        <Menu open>
+          <MenuItem label="item" renderIcon={Checkmark} />
+        </Menu>
+      );
+
+      expect(screen.getByRole('menu')).toHaveClass(
+        'cds--menu',
+        'cds--menu--sm',
+        'cds--menu--open',
+        'cds--menu--shown',
+        'cds--menu--with-icons',
+        { exact: true }
+      );
+    });
+
+    it('should mark the menu as having selectable items when a selectable item is rendered', () => {
+      render(
+        <Menu open>
+          <MenuItemSelectable label="item" />
+        </Menu>
+      );
+
+      expect(screen.getByRole('menu')).toHaveClass(
+        'cds--menu',
+        'cds--menu--sm',
+        'cds--menu--open',
+        'cds--menu--shown',
+        'cds--menu--with-selectable-items',
+        { exact: true }
+      );
     });
   });
 

--- a/packages/react/src/components/Menu/MenuContext.ts
+++ b/packages/react/src/components/Menu/MenuContext.ts
@@ -7,19 +7,26 @@
 
 import { createContext, KeyboardEvent, RefObject } from 'react';
 
-type ActionType = {
-  type: 'enableIcons' | 'enableSelectableItems' | 'registerItem';
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  payload: any;
+type RegisterItemPayload = {
+  ref: RefObject<HTMLLIElement | null>;
+  disabled: boolean;
 };
+
+type ActionType =
+  | {
+      type: 'enableIcons' | 'enableSelectableItems';
+    }
+  | {
+      type: 'registerItem';
+      payload: RegisterItemPayload;
+    };
 
 type StateType = {
   isRoot: boolean;
   hasIcons: boolean;
   hasSelectableItems: boolean;
   size: 'xs' | 'sm' | 'md' | 'lg' | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  items: any[];
+  items: RegisterItemPayload[];
   requestCloseRoot: (e: Pick<KeyboardEvent<HTMLUListElement>, 'type'>) => void;
 };
 
@@ -55,17 +62,9 @@ function menuReducer(state: StateType, action: ActionType) {
   }
 }
 
-type DispatchFuncProps = {
-  type: ActionType['type'];
-  payload: {
-    ref: RefObject<HTMLLIElement | null>;
-    disabled: boolean;
-  };
-};
-
 type MenuContextProps = {
   state: StateType;
-  dispatch: (props: DispatchFuncProps) => void;
+  dispatch: (props: ActionType) => void;
 };
 
 const MenuContext = createContext<MenuContextProps>({

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -282,7 +282,6 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
 
     useEffect(() => {
       if (IconElement && !context.state.hasIcons) {
-        // @ts-expect-error - TODO: Should we be passing payload?
         context.dispatch({ type: 'enableIcons' });
       }
     }, [IconElement, context.state.hasIcons, context]);
@@ -445,7 +444,6 @@ export const MenuItemSelectable = forwardRef<
 
   useEffect(() => {
     if (!context.state.hasSelectableItems) {
-      // @ts-expect-error - TODO: Should we be passing payload?
       context.dispatch({ type: 'enableSelectableItems' });
     }
   }, [context.state.hasSelectableItems, context]);
@@ -608,7 +606,6 @@ export const MenuItemRadioGroup = forwardRef(function MenuItemRadioGroup<Item>(
 
   useEffect(() => {
     if (!context.state.hasSelectableItems) {
-      // @ts-expect-error - TODO: Should we be passing payload?
       context.dispatch({ type: 'enableSelectableItems' });
     }
   }, [context.state.hasSelectableItems, context]);


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/20452

Added `MenuContext` action types.

### Changelog

**New**

- Added `MenuContext` action types.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/Menu/Menu-test.js
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
