### PR TITLE
feat: add web components code connect for list

### DIFF
--- a/packages/web-components/code-connect/list/list-item.figma.ts
+++ b/packages/web-components/code-connect/list/list-item.figma.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import figma, { html } from '@figma/code-connect/html';
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=3284-27542&t=Y6lD1uj5Q0yszbgL-4',
+  {
+    props: {
+      children: figma.string('List text'),
+    },
+    example: ({ children }) => html`<cds-list-item>${children}</cds-list-item>`,
+    imports: [
+      "import '@carbon/web-components/es/components/list/list-item.js'",
+    ],
+  }
+);

--- a/packages/web-components/code-connect/list/list.figma.ts
+++ b/packages/web-components/code-connect/list/list.figma.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import figma, { html } from '@figma/code-connect/html';
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=3284-27553&t=Y6lD1uj5Q0yszbgL-4',
+  {
+    variant: { Type: 'Unordered' },
+    props: {
+      children: figma.children(['List item']),
+    },
+    example: ({ children }) =>
+      html`<cds-unordered-list>${children}</cds-unordered-list>`,
+    imports: ["import '@carbon/web-components/es/components/list/index.js'"],
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=3284-27553&t=Y6lD1uj5Q0yszbgL-4',
+  {
+    variant: { Type: 'Ordered' },
+    props: {
+      children: figma.children(['List item']),
+    },
+    example: ({ children }) =>
+      html`<cds-ordered-list>${children}</cds-ordered-list>`,
+    imports: ["import '@carbon/web-components/es/components/list/index.js'"],
+  }
+);


### PR DESCRIPTION
Closes #22378

Adds Figma Code Connect support for the Web Components List component

### Changelog

**New**

- Added Code Connect mappings for Web Components ordered lists, unordered lists, and list items.

**Changed**

- ~None~

**Removed**

- ~None~

#### Testing / Reviewing

Link: https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/-v11--Carbon-Design-System?node-id=3284-27542&m=dev

<img width="930" height="614" alt="image" src="https://github.com/user-attachments/assets/0d929c64-0a4c-4221-b99c-626e3ea7c3eb" />

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
