### PR TITLE
fix(MultiSelect): resolve focus issue

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2180,6 +2180,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "saiteja-nizam",
+      "name": "Saiteja Nizam",
+      "avatar_url": "https://avatars.githubusercontent.com/u/88249670?v=4",
+      "profile": "https://github.com/saiteja-nizam",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/baadhira"><img src="https://avatars.githubusercontent.com/u/69342013?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Badira P P</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=baadhira" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/harishjanardhanan"><img src="https://avatars.githubusercontent.com/u/32760275?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Harish</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=harishjanardhanan" title="Documentation">📖</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=harishjanardhanan" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/fucadzi"><img src="https://avatars.githubusercontent.com/u/8070263?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Natalija Fucadzi</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=fucadzi" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/saiteja-nizam"><img src="https://avatars.githubusercontent.com/u/88249670?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Saiteja Nizam</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=saiteja-nizam" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -429,8 +429,6 @@ export const MultiSelect = React.forwardRef(
       locale,
     };
 
-    const toggleButtonRef = useRef<HTMLButtonElement>(null);
-
     const selectProps: UseSelectProps<ItemType> = {
       stateReducer,
       isOpen,
@@ -510,6 +508,7 @@ export const MultiSelect = React.forwardRef(
       },
     });
 
+    const toggleButtonRef = useRef<HTMLButtonElement>(null);
     const mergedRef = mergeRefs<HTMLButtonElement>(
       toggleButtonProps.ref,
       ref,

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -501,6 +501,11 @@ export const MultiSelect = React.forwardRef(
           if (match(e, keys.Enter) && isOpen) {
             setInputFocused(true);
           }
+          // Handle Tab key to close menu and allow natural tab order
+          if (match(e, keys.Tab) && isOpen) {
+            setIsOpenWrapper(false);
+            // Don't prevent default - let Tab move focus naturally
+          }
         }
       },
     });
@@ -712,7 +717,6 @@ export const MultiSelect = React.forwardRef(
         getMenuProps({
           ref: enableFloatingStyles ? refs.setFloating : null,
           hidden: !isOpen,
-          tabIndex: -1, // Prevent menu from being in tab order
         }),
       [enableFloatingStyles, getMenuProps, isOpen, refs.setFloating]
     );

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -501,13 +501,6 @@ export const MultiSelect = React.forwardRef(
           if (match(e, keys.Enter) && isOpen) {
             setInputFocused(true);
           }
-          if (match(e, keys.Tab) && isOpen) {
-            setInputFocused(true);
-            // Refocus the toggle button after dropdown closes on Tab
-            setTimeout(() => {
-              toggleButtonRef.current?.focus();
-            }, 0);
-          }
         }
       },
     });

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -499,6 +499,13 @@ export const MultiSelect = React.forwardRef(
           if (match(e, keys.Enter) && isOpen) {
             setInputFocused(true);
           }
+          if (match(e, keys.Tab) && isOpen) {
+            setInputFocused(true);
+            // Refocus the toggle button after dropdown closes on Tab
+            setTimeout(() => {
+              toggleButtonRef.current?.focus();
+            }, 0);
+          }
         }
       },
     });

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -429,6 +429,8 @@ export const MultiSelect = React.forwardRef(
       locale,
     };
 
+    const toggleButtonRef = useRef<HTMLButtonElement>(null);
+
     const selectProps: UseSelectProps<ItemType> = {
       stateReducer,
       isOpen,
@@ -510,7 +512,6 @@ export const MultiSelect = React.forwardRef(
       },
     });
 
-    const toggleButtonRef = useRef<HTMLButtonElement>(null);
     const mergedRef = mergeRefs<HTMLButtonElement>(
       toggleButtonProps.ref,
       ref,

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -499,10 +499,8 @@ export const MultiSelect = React.forwardRef(
           if (match(e, keys.Enter) && isOpen) {
             setInputFocused(true);
           }
-          // Handle Tab key to close menu and allow natural tab order
           if (match(e, keys.Tab) && isOpen) {
             setIsOpenWrapper(false);
-            // Don't prevent default - let Tab move focus naturally
           }
         }
       },

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -712,6 +712,7 @@ export const MultiSelect = React.forwardRef(
         getMenuProps({
           ref: enableFloatingStyles ? refs.setFloating : null,
           hidden: !isOpen,
+          tabIndex: -1, // Prevent menu from being in tab order
         }),
       [enableFloatingStyles, getMenuProps, isOpen, refs.setFloating]
     );

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -217,6 +217,54 @@ describe('MultiSelect', () => {
       container.querySelector('[aria-expanded="true"][aria-haspopup="listbox"]')
     ).toBeNull();
   });
+  
+  it('should move focus to the next control when the user tabs away with the menu open', async () => {
+    jest.useFakeTimers();
+
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
+    try {
+      const items = generateItems(4, generateGenericItem);
+      render(
+        <>
+          <MultiSelect id="test" label="test-label" items={items} />
+          <input data-testid="next-input" type="text" />
+        </>
+      );
+
+      const combobox = screen.getByRole('combobox');
+      const nextInput = screen.getByTestId('next-input');
+
+      // Tab to focus the combobox
+      await user.tab();
+      expect(combobox).toHaveFocus();
+
+      // Open the menu with Space
+      await user.keyboard('[Space]');
+      expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+      // Verify focus is still on combobox before tabbing
+      expect(combobox).toHaveFocus();
+
+      // Tab away from the combobox
+      await user.tab();
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+
+      // Verify focus moved to the next interactive element
+      expect(nextInput).toHaveFocus();
+      expect(document.activeElement).toBe(nextInput);
+      
+      // Verify menu is closed after tabbing away
+      expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
 
   it('close menu with click outside of field', async () => {
     const items = generateItems(4, generateGenericItem);

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -217,7 +217,7 @@ describe('MultiSelect', () => {
       container.querySelector('[aria-expanded="true"][aria-haspopup="listbox"]')
     ).toBeNull();
   });
-  
+
   it('should move focus to the next control when the user tabs away with the menu open', async () => {
     jest.useFakeTimers();
 
@@ -257,14 +257,13 @@ describe('MultiSelect', () => {
       // Verify focus moved to the next interactive element
       expect(nextInput).toHaveFocus();
       expect(document.activeElement).toBe(nextInput);
-      
+
       // Verify menu is closed after tabbing away
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
     } finally {
       jest.useRealTimers();
     }
   });
-
 
   it('close menu with click outside of field', async () => {
     const items = generateItems(4, generateGenericItem);


### PR DESCRIPTION
Closes #22320 

Focus moves in natural tab order when we hit the tab when dropdown was open.

### Changelog

**New**

Focus moves in natural tab order when we hit the tab when dropdown was open.

**Changed**

handled tab navigation

#### Testing / Reviewing

Go to MultiSelect component and expand dropdown menu. now press tab key, options will be collapsed and focus returned to the next interactive element.

before fix:

https://github.com/user-attachments/assets/64906f75-b343-4cc9-8fc0-3581bc29a95c


after fix:


https://github.com/user-attachments/assets/46d3961c-b85b-4999-9e04-fea0a8fff320





## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
