### PR TITLE
fix: comboBox input field now clears when value is cleared externally

### DIFF
--- a/packages/web-components/src/components/combo-box/__tests__/combo-box-test.js
+++ b/packages/web-components/src/components/combo-box/__tests__/combo-box-test.js
@@ -720,4 +720,41 @@ describe('cds-combo-box', function () {
       expect(el.shadowRoot.textContent).to.contain('Warning text');
     });
   });
+
+  describe('external value clearing', () => {
+    it('should clear input field when value is cleared externally', async () => {
+      const el = await fixture(comboBox({ value: 'option-2' }));
+
+      expect(el.value).to.equal('option-2');
+      expect(getInput(el).value).to.equal('Option 2');
+
+      // Clear value externally (simulating JavaScript manipulation)
+      el.value = '';
+      await waitForUpdates(el);
+
+      expect(el.value).to.equal('');
+      expect(getInput(el).value).to.equal('');
+    });
+
+    it('should clear input field when value is set to empty string externally with allow-custom-value', async () => {
+      const el = await fixture(html`
+        <cds-combo-box
+          title-text="Combo box Label"
+          allow-custom-value
+          value="custom-value">
+          <cds-combo-box-item value="option-1">Option 1</cds-combo-box-item>
+        </cds-combo-box>
+      `);
+
+      expect(el.value).to.equal('custom-value');
+      expect(getInput(el).value).to.equal('custom-value');
+
+      // Clear value externally
+      el.value = '';
+      await waitForUpdates(el);
+
+      expect(el.value).to.equal('');
+      expect(getInput(el).value).to.equal('');
+    });
+  });
 });

--- a/packages/web-components/src/components/combo-box/combo-box.ts
+++ b/packages/web-components/src/components/combo-box/combo-box.ts
@@ -590,6 +590,18 @@ class CDSComboBox extends CDSDropdown {
     if (!changedProperties.has('value')) {
       return true;
     }
+
+    // Handle when value is cleared externally (empty string, null, or undefined)
+    // Check this BEFORE _selectedItemContent to ensure clearing works
+    if (!this.value) {
+      this._filterInputValue = '';
+      // Directly clear the input if it exists
+      if (this._filterInputNode) {
+        this._filterInputNode.value = '';
+      }
+      return true;
+    }
+
     if (this._selectedItemContent) {
       this._filterInputValue = this._selectedItemContent.textContent || '';
       return true;
@@ -597,9 +609,6 @@ class CDSComboBox extends CDSDropdown {
     if (this.allowCustomValue && this.value) {
       this._filterInputValue = String(this.value);
       return true;
-    }
-    if (this.value === '') {
-      this._filterInputValue = '';
     }
     return true;
   }
@@ -626,6 +635,14 @@ class CDSComboBox extends CDSDropdown {
 
   updated(changedProperties) {
     super.updated(changedProperties);
+
+    // Handle external value changes to ensure input field syncs
+    if (changedProperties.has('value') && this._filterInputNode) {
+      // Always sync the input field with _filterInputValue when value changes
+      // This ensures the input clears when value is set to empty/null externally
+      this._filterInputNode.value = this._filterInputValue;
+    }
+
     if (changedProperties.has('open')) {
       if (this.open && this._filterInputNode) {
         this._handleInput(changedProperties);


### PR DESCRIPTION
Closes #20319

### Changelog
Fix ComboBox input field not clearing when value is cleared externally via JavaScript

**Changed**

- Fixed ComboBox input field to properly clear when the `value` attribute is set to empty string, null, or undefined externally
- Reordered logic in `shouldUpdate()` method to check for empty value before checking `_selectedItemContent`
- Added direct DOM synchronization in `updated()` lifecycle method to ensure input field stays in sync with value changes
- Enhanced Controlled story in Storybook with better documentation and demonstration of external value clearing

#### Testing / Reviewing

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
