### PR TITLE
feat(codemod): codemod for composable IBM Products PageHeader

### DIFF
--- a/packages/upgrade/src/upgrades.js
+++ b/packages/upgrade/src/upgrades.js
@@ -673,6 +673,38 @@ export const upgrades = [
         },
       },
       {
+        name: 'ibm-products-update-page-header-composable',
+        description:
+          'Migrates stable PageHeader to composable PageHeader architecture',
+        migrate: async (options) => {
+          const transform = path.join(
+            TRANSFORM_DIR,
+            'ibm-products-update-page-header-composable.js'
+          );
+          const paths =
+            Array.isArray(options.paths) && options.paths.length > 0
+              ? options.paths
+              : await glob(['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'], {
+                  cwd: options.workspaceDir,
+                  ignore: [
+                    '**/es/**',
+                    '**/lib/**',
+                    '**/umd/**',
+                    '**/node_modules/**',
+                    '**/storybook-static/**',
+                  ],
+                });
+
+          await runCodemod(options, {
+            dry: !options.write,
+            transform,
+            paths,
+            verbose: options.verbose,
+            parser: 'tsx',
+          });
+        },
+      },
+      {
         name: 'ibm-products-update-userprofileimage',
         description: 'Rewrites UserProfileImage to UserAvatar',
         migrate: async (options) => {

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable-aliased.input.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable-aliased.input.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { preview__PageHeader as ProductsPageHeader } from '@carbon/ibm-products';
+
+// Test: PageHeader with aliased import
+export const AliasedPageHeader = () => (
+  <ProductsPageHeader>
+    <ProductsPageHeader.Content title="Page title">
+      <ProductsPageHeader.ContentText subtitle="Optional subtitle" />
+      <p>Content</p>
+    </ProductsPageHeader.Content>
+  </ProductsPageHeader>
+);

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable-aliased.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable-aliased.output.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { preview__PageHeader as ProductsPageHeader } from '@carbon/ibm-products';
+
+// Test: PageHeader with aliased import
+export const AliasedPageHeader = () => (
+  <ProductsPageHeader><ProductsPageHeader.Content title="Page title"><ProductsPageHeader.ContentText subtitle="Optional subtitle" />
+    <p>Content</p>
+  </ProductsPageHeader.Content></ProductsPageHeader>
+);

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.input.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.input.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { PageHeader } from '@carbon/ibm-products';
+import { Button, Tabs, Tab, TabList, TabPanels, TabPanel } from '@carbon/react';
+import { Lightning, Settings } from '@carbon/react/icons';
+
+// Test 1: Basic PageHeader with title only
+export const BasicPageHeader = () => <PageHeader title="Page title" />;
+
+// Test 2: PageHeader with title and subtitle
+export const PageHeaderWithSubtitle = () => (
+  <PageHeader title="Page title" subtitle="Optional subtitle" />
+);
+
+// Test 3: PageHeader with title, subtitle, and children
+export const PageHeaderWithChildren = () => (
+  <PageHeader title="Page title" subtitle="Optional subtitle">
+    <p>Additional content in the page header</p>
+  </PageHeader>
+);
+
+// Test 4: PageHeader with breadcrumbs
+export const PageHeaderWithBreadcrumbs = () => (
+  <PageHeader
+    title="Page title"
+    breadcrumbs={[
+      { href: '#', key: 'breadcrumb-1', label: 'Home' },
+      { href: '#', key: 'breadcrumb-2', label: 'Level 2' },
+    ]}
+    breadcrumbOverflowAriaLabel="Open breadcrumb menu"
+  />
+);
+
+// Test 5: PageHeader with pageActions
+export const PageHeaderWithPageActions = () => (
+  <PageHeader
+    title="Page title"
+    pageActions={[
+      {
+        key: 'action-1',
+        label: 'Primary action',
+        kind: 'primary',
+        onClick: () => console.log('Primary action'),
+      },
+      {
+        key: 'action-2',
+        label: 'Secondary action',
+        kind: 'secondary',
+        onClick: () => console.log('Secondary action'),
+      },
+    ]}
+    pageActionsOverflowLabel="More actions"
+  />
+);
+
+// Test 6: PageHeader with actionBarItems
+export const PageHeaderWithActionBar = () => (
+  <PageHeader
+    title="Page title"
+    actionBarItems={[
+      {
+        key: 'action-1',
+        renderIcon: Lightning,
+        iconDescription: 'Lightning',
+        onClick: () => console.log('Lightning'),
+      },
+      {
+        key: 'action-2',
+        renderIcon: Settings,
+        iconDescription: 'Settings',
+        onClick: () => console.log('Settings'),
+      },
+    ]}
+    actionBarOverflowAriaLabel="Action bar overflow"
+  />
+);
+
+// Test 7: PageHeader with navigation (Tabs)
+export const PageHeaderWithNavigation = () => (
+  <PageHeader
+    title="Page title"
+    navigation={
+      <Tabs>
+        <TabList aria-label="Tab navigation">
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+          <Tab>Tab 3</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Content 1</TabPanel>
+          <TabPanel>Content 2</TabPanel>
+          <TabPanel>Content 3</TabPanel>
+        </TabPanels>
+      </Tabs>
+    }
+  />
+);
+
+// Test 8: PageHeader with tags
+export const PageHeaderWithTags = () => (
+  <PageHeader
+    title="Page title"
+    tags={[
+      { label: 'Tag 1', key: 'tag-1' },
+      { label: 'Tag 2', key: 'tag-2' },
+      { label: 'Tag 3', key: 'tag-3' },
+    ]}
+  />
+);
+
+// Test 9: Complete PageHeader with all features
+export const CompletePageHeader = () => (
+  <PageHeader
+    title="Complete page title"
+    subtitle="With all the features"
+    breadcrumbs={[
+      { href: '#', key: 'breadcrumb-1', label: 'Home' },
+      { href: '#', key: 'breadcrumb-2', label: 'Level 2' },
+    ]}
+    breadcrumbOverflowAriaLabel="Open breadcrumb menu"
+    actionBarItems={[
+      {
+        key: 'action-1',
+        renderIcon: Lightning,
+        iconDescription: 'Lightning',
+        onClick: () => console.log('Lightning'),
+      },
+    ]}
+    actionBarOverflowAriaLabel="Action bar overflow"
+    pageActions={[
+      {
+        key: 'action-1',
+        label: 'Primary action',
+        kind: 'primary',
+        onClick: () => console.log('Primary action'),
+      },
+    ]}
+    pageActionsOverflowLabel="More actions"
+    navigation={
+      <Tabs>
+        <TabList aria-label="Tab navigation">
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+      </Tabs>
+    }
+    tags={[
+      { label: 'Tag 1', key: 'tag-1' },
+      { label: 'Tag 2', key: 'tag-2' },
+    ]}>
+    <p>Page content goes here</p>
+  </PageHeader>
+);
+
+// Test 10: PageHeader with title as object
+export const PageHeaderWithTitleObject = () => (
+  <PageHeader
+    title={{
+      text: 'Page title',
+      icon: Lightning,
+    }}
+  />
+);
+
+// Test 11: PageHeader with deprecated props (should be ignored)
+export const PageHeaderWithDeprecatedProps = () => (
+  <PageHeader
+    title="Page title"
+    collapseHeader={false}
+    hasCollapseHeaderToggle={true}
+    collapseHeaderIconDescription="Collapse"
+    expandHeaderIconDescription="Expand"
+    enableBreadcrumbScroll={true}
+    withoutBackground={false}
+  />
+);

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.output.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { preview__PageHeader as PageHeader } from '@carbon/ibm-products';
+import { Button, Tabs, Tab, TabList, TabPanels, TabPanel } from '@carbon/react';
+import { Lightning, Settings } from '@carbon/react/icons';
+
+// Test 1: Basic PageHeader with title only
+export const BasicPageHeader = () => (
+  <PageHeader><PageHeader.Content title="Page title" /></PageHeader>
+);
+
+// Test 2: PageHeader with title and subtitle
+export const PageHeaderWithSubtitle = () => (
+  <PageHeader><PageHeader.Content title="Page title"><PageHeader.ContentText subtitle="Optional subtitle" /></PageHeader.Content></PageHeader>
+);
+
+// Test 3: PageHeader with title, subtitle, and children
+export const PageHeaderWithChildren = () => (
+  <PageHeader><PageHeader.Content title="Page title"><PageHeader.ContentText subtitle="Optional subtitle" />
+      <p>Additional content in the page header</p>
+    </PageHeader.Content></PageHeader>
+);
+
+// Test 4: PageHeader with breadcrumbs
+export const PageHeaderWithBreadcrumbs = () => (
+  <PageHeader><PageHeader.BreadcrumbBar
+      breadcrumbs={[
+        { href: '#', key: 'breadcrumb-1', label: 'Home' },
+        { href: '#', key: 'breadcrumb-2', label: 'Level 2' },
+      ]}
+      breadcrumbOverflowAriaLabel="Open breadcrumb menu" /><PageHeader.Content title="Page title" /></PageHeader>
+);
+
+// Test 5: PageHeader with pageActions
+export const PageHeaderWithPageActions = () => (
+  <PageHeader pageActionsOverflowLabel="More actions"><PageHeader.Content
+      title="Page title"
+      pageActions={[
+        {
+          key: 'action-1',
+          label: 'Primary action',
+          kind: 'primary',
+          onClick: () => console.log('Primary action'),
+        },
+        {
+          key: 'action-2',
+          label: 'Secondary action',
+          kind: 'secondary',
+          onClick: () => console.log('Secondary action'),
+        },
+      ]} /></PageHeader>
+);
+
+// Test 6: PageHeader with actionBarItems
+export const PageHeaderWithActionBar = () => (
+  <PageHeader actionBarOverflowAriaLabel="Action bar overflow"><PageHeader.Content
+      title="Page title"
+      contextualActions={[
+        {
+          key: 'action-1',
+          renderIcon: Lightning,
+          iconDescription: 'Lightning',
+          onClick: () => console.log('Lightning'),
+        },
+        {
+          key: 'action-2',
+          renderIcon: Settings,
+          iconDescription: 'Settings',
+          onClick: () => console.log('Settings'),
+        },
+      ]} /></PageHeader>
+);
+
+// Test 7: PageHeader with navigation (Tabs)
+export const PageHeaderWithNavigation = () => (
+  <PageHeader><PageHeader.Content title="Page title" /><PageHeader.TabBar><Tabs>
+        <TabList aria-label="Tab navigation">
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+          <Tab>Tab 3</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Content 1</TabPanel>
+          <TabPanel>Content 2</TabPanel>
+          <TabPanel>Content 3</TabPanel>
+        </TabPanels>
+      </Tabs></PageHeader.TabBar></PageHeader>
+);
+
+// Test 8: PageHeader with tags
+export const PageHeaderWithTags = () => (
+  <PageHeader><PageHeader.Content title="Page title" /><PageHeader.TagOverflow
+      tags={[
+        { label: 'Tag 1', key: 'tag-1' },
+        { label: 'Tag 2', key: 'tag-2' },
+        { label: 'Tag 3', key: 'tag-3' },
+      ]} /></PageHeader>
+);
+
+// Test 9: Complete PageHeader with all features
+export const CompletePageHeader = () => (
+  <PageHeader
+    actionBarOverflowAriaLabel="Action bar overflow"
+    pageActionsOverflowLabel="More actions"><PageHeader.BreadcrumbBar
+      breadcrumbs={[
+        { href: '#', key: 'breadcrumb-1', label: 'Home' },
+        { href: '#', key: 'breadcrumb-2', label: 'Level 2' },
+      ]}
+      breadcrumbOverflowAriaLabel="Open breadcrumb menu" /><PageHeader.Content
+      title="Complete page title"
+      pageActions={[
+        {
+          key: 'action-1',
+          label: 'Primary action',
+          kind: 'primary',
+          onClick: () => console.log('Primary action'),
+        },
+      ]}
+      contextualActions={[
+        {
+          key: 'action-1',
+          renderIcon: Lightning,
+          iconDescription: 'Lightning',
+          onClick: () => console.log('Lightning'),
+        },
+      ]}><PageHeader.ContentText subtitle="With all the features" />
+      <p>Page content goes here</p>
+    </PageHeader.Content><PageHeader.TabBar><Tabs>
+        <TabList aria-label="Tab navigation">
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+      </Tabs></PageHeader.TabBar><PageHeader.TagOverflow
+      tags={[
+        { label: 'Tag 1', key: 'tag-1' },
+        { label: 'Tag 2', key: 'tag-2' },
+      ]} /></PageHeader>
+);
+
+// Test 10: PageHeader with title as object
+export const PageHeaderWithTitleObject = () => (
+  <PageHeader><PageHeader.Content title={'Page title'} renderIcon={Lightning} /></PageHeader>
+);
+
+// Test 11: PageHeader with deprecated props (should be ignored)
+export const PageHeaderWithDeprecatedProps = () => (
+  <PageHeader><PageHeader.Content title="Page title" /></PageHeader>
+);

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.output.js
@@ -11,9 +11,7 @@ import { Button, Tabs, Tab, TabList, TabPanels, TabPanel } from '@carbon/react';
 import { Lightning, Settings } from '@carbon/react/icons';
 
 // Test 1: Basic PageHeader with title only
-export const BasicPageHeader = () => (
-  <PageHeader><PageHeader.Content title="Page title" /></PageHeader>
-);
+export const BasicPageHeader = () => <PageHeader><PageHeader.Content title="Page title" /></PageHeader>;
 
 // Test 2: PageHeader with title and subtitle
 export const PageHeaderWithSubtitle = () => (

--- a/packages/upgrade/transforms/__tests__/ibm-products-update-page-header-composable-test.js
+++ b/packages/upgrade/transforms/__tests__/ibm-products-update-page-header-composable-test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { defineTest } = require('jscodeshift/dist/testUtils');
+
+defineTest(__dirname, 'ibm-products-update-page-header-composable');

--- a/packages/upgrade/transforms/ibm-products-update-page-header-composable.js
+++ b/packages/upgrade/transforms/ibm-products-update-page-header-composable.js
@@ -1,0 +1,356 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Rewrites stable PageHeader to composable PageHeader
+ *
+ * Transforms:
+ *
+ * <PageHeader
+ *   title="Page title"
+ *   subtitle="Optional subtitle"
+ *   breadcrumbs={[...]}
+ *   pageActions={[...]}
+ *   actionBarItems={[...]}
+ *   navigation={<Tabs>...</Tabs>}
+ *   tags={[...]}
+ * >
+ *   <p>Content</p>
+ * </PageHeader>
+ *
+ * Into:
+ *
+ * <PageHeader>
+ *   <PageHeader.BreadcrumbBar breadcrumbs={[...]} />
+ *   <PageHeader.Content title="Page title" pageActions={[...]} contextualActions={[...]}>
+ *     <PageHeader.ContentText subtitle="Optional subtitle" />
+ *     <p>Content</p>
+ *   </PageHeader.Content>
+ *   <PageHeader.TabBar>{<Tabs>...</Tabs>}</PageHeader.TabBar>
+ *   <PageHeader.TagOverflow tags={[...]} />
+ * </PageHeader>
+ */
+
+'use strict';
+
+const transform = (fileInfo, api) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let dirtyFlag = false;
+
+  // Helper to create JSX member expression (e.g., PageHeader.Content)
+  const createMemberExpression = (object, property) => {
+    return j.jsxMemberExpression(
+      j.jsxIdentifier(object),
+      j.jsxIdentifier(property)
+    );
+  };
+
+  // Helper to create JSX element with member expression
+  const createMemberJSXElement = (object, property, attributes, children) => {
+    const memberExpression = createMemberExpression(object, property);
+    const openingElement = j.jsxOpeningElement(
+      memberExpression,
+      attributes,
+      children.length === 0
+    );
+    return children.length === 0
+      ? j.jsxElement(openingElement, null, [])
+      : j.jsxElement(
+          openingElement,
+          j.jsxClosingElement(memberExpression),
+          children
+        );
+  };
+
+  // Transform PageHeader components
+  root
+    .find(j.JSXElement, { openingElement: { name: { name: 'PageHeader' } } })
+    .forEach((path) => {
+      const attributes = path.node.openingElement.attributes;
+      const originalChildren = path.node.children || [];
+
+      // Props to extract
+      let titleProp = null;
+      let subtitleProp = null;
+      let breadcrumbsProp = null;
+      let breadcrumbOverflowAriaLabelProp = null;
+      let pageActionsProp = null;
+      let actionBarItemsProp = null;
+      let navigationProp = null;
+      let tagsProp = null;
+      let showAllTagsLabelProp = null;
+      let allTagsModalTitleProp = null;
+      let allTagsModalSearchLabelProp = null;
+      let allTagsModalSearchPlaceholderTextProp = null;
+
+      // Props to keep on root PageHeader
+      const rootAttributes = [];
+
+      // Deprecated props to ignore
+      const deprecatedProps = [
+        'collapseHeader',
+        'collapseHeaderIconDescription',
+        'expandHeaderIconDescription',
+        'hasCollapseHeaderToggle',
+        'enableBreadcrumbScroll',
+        'withoutBackground',
+      ];
+
+      // Process attributes
+      attributes.forEach((attr) => {
+        if (attr.type !== 'JSXAttribute') {
+          rootAttributes.push(attr);
+          return;
+        }
+
+        const attrName = attr.name.name;
+
+        // Extract props for transformation
+        if (attrName === 'title') {
+          titleProp = attr;
+        } else if (attrName === 'subtitle') {
+          subtitleProp = attr;
+        } else if (attrName === 'breadcrumbs') {
+          breadcrumbsProp = attr;
+        } else if (attrName === 'breadcrumbOverflowAriaLabel') {
+          breadcrumbOverflowAriaLabelProp = attr;
+        } else if (attrName === 'pageActions') {
+          pageActionsProp = attr;
+        } else if (attrName === 'actionBarItems') {
+          actionBarItemsProp = attr;
+        } else if (attrName === 'navigation') {
+          navigationProp = attr;
+        } else if (attrName === 'tags') {
+          tagsProp = attr;
+        } else if (attrName === 'showAllTagsLabel') {
+          showAllTagsLabelProp = attr;
+        } else if (attrName === 'allTagsModalTitle') {
+          allTagsModalTitleProp = attr;
+        } else if (attrName === 'allTagsModalSearchLabel') {
+          allTagsModalSearchLabelProp = attr;
+        } else if (attrName === 'allTagsModalSearchPlaceholderText') {
+          allTagsModalSearchPlaceholderTextProp = attr;
+        } else if (deprecatedProps.includes(attrName)) {
+          // Ignore deprecated props
+        } else {
+          // Keep other props on root
+          rootAttributes.push(attr);
+        }
+      });
+
+      // Only transform if we have any props that need migration
+      const needsTransformation =
+        titleProp ||
+        subtitleProp ||
+        breadcrumbsProp ||
+        pageActionsProp ||
+        actionBarItemsProp ||
+        navigationProp ||
+        tagsProp;
+
+      if (!needsTransformation) {
+        return; // Skip this PageHeader, no transformation needed
+      }
+
+      dirtyFlag = true;
+
+      const newChildren = [];
+
+      // 1. Add BreadcrumbBar if breadcrumbs exist
+      if (breadcrumbsProp) {
+        const breadcrumbBarAttrs = [breadcrumbsProp];
+        if (breadcrumbOverflowAriaLabelProp) {
+          breadcrumbBarAttrs.push(breadcrumbOverflowAriaLabelProp);
+        }
+        newChildren.push(
+          createMemberJSXElement(
+            'PageHeader',
+            'BreadcrumbBar',
+            breadcrumbBarAttrs,
+            []
+          )
+        );
+      }
+
+      // 2. Add Content if title exists
+      if (titleProp) {
+        const contentAttrs = [titleProp];
+
+        // Handle title as object with icon
+        if (
+          titleProp.value &&
+          titleProp.value.type === 'JSXExpressionContainer'
+        ) {
+          const titleExpr = titleProp.value.expression;
+          if (titleExpr.type === 'ObjectExpression') {
+            // Extract text and icon from title object
+            const textProp = titleExpr.properties.find(
+              (p) => p.key && p.key.name === 'text'
+            );
+            const iconProp = titleExpr.properties.find(
+              (p) => p.key && p.key.name === 'icon'
+            );
+
+            if (textProp) {
+              // Replace title with just the text value
+              contentAttrs[0] = j.jsxAttribute(
+                j.jsxIdentifier('title'),
+                j.jsxExpressionContainer(textProp.value)
+              );
+            }
+
+            if (iconProp) {
+              // Add renderIcon prop
+              contentAttrs.push(
+                j.jsxAttribute(
+                  j.jsxIdentifier('renderIcon'),
+                  j.jsxExpressionContainer(iconProp.value)
+                )
+              );
+            }
+          }
+        }
+
+        // Add pageActions if exists
+        if (pageActionsProp) {
+          contentAttrs.push(pageActionsProp);
+        }
+
+        // Add contextualActions (from actionBarItems) if exists
+        if (actionBarItemsProp) {
+          const contextualActionsAttr = j.jsxAttribute(
+            j.jsxIdentifier('contextualActions'),
+            actionBarItemsProp.value
+          );
+          contentAttrs.push(contextualActionsAttr);
+        }
+
+        const contentChildren = [];
+
+        // Add ContentText if subtitle exists
+        if (subtitleProp) {
+          contentChildren.push(
+            createMemberJSXElement(
+              'PageHeader',
+              'ContentText',
+              [subtitleProp],
+              []
+            )
+          );
+        }
+
+        // Add original children to Content
+        contentChildren.push(...originalChildren);
+
+        newChildren.push(
+          createMemberJSXElement(
+            'PageHeader',
+            'Content',
+            contentAttrs,
+            contentChildren
+          )
+        );
+      }
+
+      // 3. Add TabBar if navigation exists
+      if (navigationProp) {
+        const tabBarChildren = [];
+        if (navigationProp.value.type === 'JSXExpressionContainer') {
+          tabBarChildren.push(navigationProp.value.expression);
+        }
+        newChildren.push(
+          createMemberJSXElement('PageHeader', 'TabBar', [], tabBarChildren)
+        );
+      }
+
+      // 4. Add TagOverflow if tags exist
+      if (tagsProp) {
+        const tagOverflowAttrs = [tagsProp];
+        if (showAllTagsLabelProp) {
+          tagOverflowAttrs.push(showAllTagsLabelProp);
+        }
+        if (allTagsModalTitleProp) {
+          tagOverflowAttrs.push(allTagsModalTitleProp);
+        }
+        if (allTagsModalSearchLabelProp) {
+          tagOverflowAttrs.push(allTagsModalSearchLabelProp);
+        }
+        if (allTagsModalSearchPlaceholderTextProp) {
+          tagOverflowAttrs.push(allTagsModalSearchPlaceholderTextProp);
+        }
+        newChildren.push(
+          createMemberJSXElement(
+            'PageHeader',
+            'TagOverflow',
+            tagOverflowAttrs,
+            []
+          )
+        );
+      }
+
+      // Update the PageHeader element
+      path.node.openingElement.attributes = rootAttributes;
+      path.node.children = newChildren;
+
+      // If PageHeader was self-closing, convert it to have opening/closing tags
+      if (path.node.openingElement.selfClosing) {
+        path.node.openingElement.selfClosing = false;
+      }
+      if (!path.node.closingElement) {
+        path.node.closingElement = j.jsxClosingElement(
+          j.jsxIdentifier('PageHeader')
+        );
+      }
+    });
+
+  // Update imports if transformation occurred
+  if (dirtyFlag) {
+    root
+      .find(j.ImportDeclaration)
+      .filter((path) => path.node.source.value === '@carbon/ibm-products')
+      .forEach((path) => {
+        const specifiers = path.node.specifiers;
+        let hasPageHeader = false;
+
+        // Check if PageHeader is imported
+        specifiers.forEach((specifier) => {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported &&
+            specifier.imported.name === 'PageHeader'
+          ) {
+            hasPageHeader = true;
+          }
+        });
+
+        // If PageHeader is imported, update to preview version
+        if (hasPageHeader) {
+          const newSpecifiers = specifiers.map((specifier) => {
+            if (
+              specifier.type === 'ImportSpecifier' &&
+              specifier.imported &&
+              specifier.imported.name === 'PageHeader'
+            ) {
+              // Change to preview__PageHeader
+              return j.importSpecifier(
+                j.identifier('preview__PageHeader'),
+                j.identifier('PageHeader')
+              );
+            }
+            return specifier;
+          });
+
+          path.node.specifiers = newSpecifiers;
+        }
+      });
+  }
+
+  return root.toSource();
+};
+
+module.exports = transform;

--- a/packages/upgrade/transforms/ibm-products-update-page-header-composable.js
+++ b/packages/upgrade/transforms/ibm-products-update-page-header-composable.js
@@ -42,6 +42,30 @@ const transform = (fileInfo, api) => {
   const root = j(fileInfo.source);
   let dirtyFlag = false;
 
+  // Find the local name used for PageHeader import (could be aliased)
+  let pageHeaderLocalName = null;
+  root
+    .find(j.ImportDeclaration)
+    .filter((path) => path.node.source.value === '@carbon/ibm-products')
+    .forEach((path) => {
+      path.node.specifiers.forEach((specifier) => {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported &&
+          specifier.imported.name === 'PageHeader'
+        ) {
+          pageHeaderLocalName = specifier.local
+            ? specifier.local.name
+            : 'PageHeader';
+        }
+      });
+    });
+
+  // If PageHeader is not imported, nothing to transform
+  if (!pageHeaderLocalName) {
+    return root.toSource();
+  }
+
   // Helper to create JSX member expression (e.g., PageHeader.Content)
   const createMemberExpression = (object, property) => {
     return j.jsxMemberExpression(
@@ -67,9 +91,11 @@ const transform = (fileInfo, api) => {
         );
   };
 
-  // Transform PageHeader components
+  // Transform PageHeader components (using the local name which could be an alias)
   root
-    .find(j.JSXElement, { openingElement: { name: { name: 'PageHeader' } } })
+    .find(j.JSXElement, {
+      openingElement: { name: { name: pageHeaderLocalName } },
+    })
     .forEach((path) => {
       const attributes = path.node.openingElement.attributes;
       const originalChildren = path.node.children || [];
@@ -169,7 +195,7 @@ const transform = (fileInfo, api) => {
         }
         newChildren.push(
           createMemberJSXElement(
-            'PageHeader',
+            pageHeaderLocalName,
             'BreadcrumbBar',
             breadcrumbBarAttrs,
             []
@@ -236,7 +262,7 @@ const transform = (fileInfo, api) => {
         if (subtitleProp) {
           contentChildren.push(
             createMemberJSXElement(
-              'PageHeader',
+              pageHeaderLocalName,
               'ContentText',
               [subtitleProp],
               []
@@ -249,7 +275,7 @@ const transform = (fileInfo, api) => {
 
         newChildren.push(
           createMemberJSXElement(
-            'PageHeader',
+            pageHeaderLocalName,
             'Content',
             contentAttrs,
             contentChildren
@@ -264,7 +290,12 @@ const transform = (fileInfo, api) => {
           tabBarChildren.push(navigationProp.value.expression);
         }
         newChildren.push(
-          createMemberJSXElement('PageHeader', 'TabBar', [], tabBarChildren)
+          createMemberJSXElement(
+            pageHeaderLocalName,
+            'TabBar',
+            [],
+            tabBarChildren
+          )
         );
       }
 
@@ -285,7 +316,7 @@ const transform = (fileInfo, api) => {
         }
         newChildren.push(
           createMemberJSXElement(
-            'PageHeader',
+            pageHeaderLocalName,
             'TagOverflow',
             tagOverflowAttrs,
             []
@@ -303,7 +334,7 @@ const transform = (fileInfo, api) => {
       }
       if (!path.node.closingElement) {
         path.node.closingElement = j.jsxClosingElement(
-          j.jsxIdentifier('PageHeader')
+          j.jsxIdentifier(pageHeaderLocalName)
         );
       }
     });
@@ -336,10 +367,14 @@ const transform = (fileInfo, api) => {
               specifier.imported &&
               specifier.imported.name === 'PageHeader'
             ) {
-              // Change to preview__PageHeader
+              // Change to preview__PageHeader, preserving the local name (alias)
+              // If there's a local name (alias), preserve it; otherwise use 'PageHeader'
+              const localName = specifier.local
+                ? specifier.local.name
+                : 'PageHeader';
               return j.importSpecifier(
                 j.identifier('preview__PageHeader'),
-                j.identifier('PageHeader')
+                j.identifier(localName)
               );
             }
             return specifier;


### PR DESCRIPTION
Closes [#9494](https://github.com/carbon-design-system/ibm-products/issues/9494)

### Changelog

**New**

- Transform: `packages/upgrade/transforms/ibm-products-update-page-header-composable.js`

Transforms PageHeader → composable architecture
Updates imports to preview__PageHeader

- Test: `packages/upgrade/transforms/__tests__/ibm-products-update-page-header-composable-test.js`

- Test Fixtures:

Input: `packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.input.js`
Output: `packages/upgrade/transforms/__testfixtures__/ibm-products-update-page-header-composable.output.js`

**Changed**

- Configuration: `packages/upgrade/src/upgrades.js` (lines 675-706)

#### Testing / Reviewing

```bash
cd packages/upgrade
npx jscodeshift -t transforms/ibm-products-update-page-header-composable.js /path/to/your/files/**/*.{js,jsx,ts,tsx}

```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
