### PR TITLE
feat: added xs sizes for combobox multiselect and dropdown

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1517,6 +1517,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",
@@ -3327,6 +3328,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",
@@ -3371,6 +3373,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",
@@ -4099,6 +4102,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",
@@ -7070,6 +7074,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -47,7 +47,7 @@ export default {
   component: ComboBox,
   argTypes: {
     size: {
-      options: ['sm', 'md', 'lg'],
+      options: ['xs', 'sm', 'md', 'lg'],
       control: { type: 'select' },
     },
     light: {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -334,7 +334,7 @@ export interface ComboBoxProps<ItemType>
   }) => boolean;
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size?: ListBoxSize;
 
@@ -1508,7 +1508,7 @@ ComboBox.propTypes = {
   shouldFilterItem: PropTypes.func,
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size: ListBoxSizePropType,
 

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -145,7 +145,7 @@ const sharedArgTypes = {
     },
   },
   size: {
-    options: ['sm', 'md', 'lg'],
+    options: ['xs', 'sm', 'md', 'lg'],
     control: { type: 'select' },
   },
   type: {

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -205,7 +205,7 @@ export interface DropdownProps<ItemType>
   selectedItem?: ItemType;
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size?: ListBoxSize;
 
@@ -891,7 +891,7 @@ Dropdown.propTypes = {
   ]),
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size: ListBoxSizePropType,
 

--- a/packages/react/src/components/ListBox/ListBox.tsx
+++ b/packages/react/src/components/ListBox/ListBox.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/ListBox/ListBox.tsx
+++ b/packages/react/src/components/ListBox/ListBox.tsx
@@ -74,7 +74,7 @@ export interface ListBoxProps
   light?: boolean;
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size?: ListBoxSize;
 
@@ -129,6 +129,7 @@ const ListBox = forwardRef<HTMLDivElement, ListBoxProps>((props, ref) => {
     ...(containerClassName && { [containerClassName]: true }),
     [`${prefix}--list-box`]: true,
     [`${prefix}--list-box--${size}`]: size,
+    [`${prefix}--layout--size-${size}`]: size,
     [`${prefix}--list-box--inline`]: type === 'inline',
     [`${prefix}--list-box--disabled`]: disabled,
     [`${prefix}--list-box--light`]: light,
@@ -211,7 +212,7 @@ ListBox.propTypes = {
   ),
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size: ListBoxSizePropType,
 

--- a/packages/react/src/components/ListBox/ListBoxPropTypes.ts
+++ b/packages/react/src/components/ListBox/ListBoxPropTypes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/ListBox/ListBoxPropTypes.ts
+++ b/packages/react/src/components/ListBox/ListBoxPropTypes.ts
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 
 const listBoxTypes = ['default', 'inline'] as const;
-const listBoxSizes = ['sm', 'md', 'lg'] as const;
+const listBoxSizes = ['xs', 'sm', 'md', 'lg'] as const;
 
 export type ListBoxType = (typeof listBoxTypes)[number];
 export type ListBoxSize = (typeof listBoxSizes)[number];

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -34,7 +34,7 @@ export default {
   },
   argTypes: {
     size: {
-      options: ['sm', 'md', 'lg'],
+      options: ['xs', 'sm', 'md', 'lg'],
       control: { type: 'select' },
     },
     light: {

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -252,7 +252,7 @@ export interface MultiSelectProps<ItemType>
   selectionFeedback?: 'fixed' | 'top' | 'top-after-reopen';
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size?: ListBoxSize;
 
@@ -1078,7 +1078,7 @@ MultiSelect.propTypes = {
   selectionFeedback: PropTypes.oneOf(['top', 'fixed', 'top-after-reopen']),
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   * Specify the size of the ListBox. Currently supports either `xs`, `sm`, `md` or `lg` as an option.
    */
   size: ListBoxSizePropType,
 

--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -16,6 +16,7 @@
 @use '../../spacing' as *;
 @use '../../motion' as *;
 @use '../../layer' as *;
+@use '../../utilities/layout';
 @use '../../utilities/ai-gradient' as *;
 @use '../../utilities/box-shadow' as *;
 @use '../../utilities/button-reset';
@@ -82,16 +83,17 @@ $list-box-menu-width: convert.to-rem(300px);
 
   .#{$prefix}--list-box {
     @include reset;
+    @include layout.use('size', $default: 'md', $min: 'xs', $max: 'lg');
 
     position: relative;
     border: none;
     background-color: $field;
-    block-size: convert.to-rem(40px);
+    block-size: layout.size('height');
     border-block-end: 1px solid $border-strong;
     color: $text-primary;
     cursor: pointer;
     inline-size: $list-box-width;
-    max-block-size: convert.to-rem(40px);
+    max-block-size: layout.size('height');
     transition: all $duration-fast-01 motion(standard, productive);
 
     &:hover {
@@ -101,16 +103,6 @@ $list-box-menu-width: convert.to-rem(300px);
 
   .#{$prefix}--multi-select.#{$prefix}--multi-select--readonly.#{$prefix}--list-box {
     cursor: default;
-  }
-
-  .#{$prefix}--list-box--lg {
-    block-size: convert.to-rem(48px);
-    max-block-size: convert.to-rem(48px);
-  }
-
-  .#{$prefix}--list-box--sm {
-    block-size: convert.to-rem(32px);
-    max-block-size: convert.to-rem(32px);
   }
 
   .#{$prefix}--list-box--expanded {
@@ -548,20 +540,8 @@ $list-box-menu-width: convert.to-rem(300px);
 
   .#{$prefix}--list-box--expanded .#{$prefix}--list-box__menu {
     display: block;
-    // 40px item height * 5.5 items shown
-    max-block-size: convert.to-rem(220px);
-  }
-
-  .#{$prefix}--list-box--expanded.#{$prefix}--list-box--lg
-    .#{$prefix}--list-box__menu {
-    // 48px item height * 5.5 items shown
-    max-block-size: convert.to-rem(264px);
-  }
-
-  .#{$prefix}--list-box--expanded.#{$prefix}--list-box--sm
-    .#{$prefix}--list-box__menu {
-    // 32px item height * 5.5 items shown
-    max-block-size: convert.to-rem(176px);
+    // item height * 5.5 items shown
+    max-block-size: calc(layout.size('height') * 5.5);
   }
 
   // Descendant of a `list-box__menu` that represents a selection for a control
@@ -569,7 +549,7 @@ $list-box-menu-width: convert.to-rem(300px);
     @include type-style('body-compact-01');
 
     position: relative;
-    block-size: convert.to-rem(40px);
+    block-size: layout.size('height');
     color: $text-secondary;
     cursor: pointer;
     transition: background $duration-fast-01 motion(standard, productive);
@@ -587,14 +567,6 @@ $list-box-menu-width: convert.to-rem(300px);
   // V11: Possibly deprecate
   .#{$prefix}--list-box--light .#{$prefix}--list-box__menu-item:hover {
     background-color: $layer-hover;
-  }
-
-  .#{$prefix}--list-box--sm .#{$prefix}--list-box__menu-item {
-    block-size: convert.to-rem(32px);
-  }
-
-  .#{$prefix}--list-box--lg .#{$prefix}--list-box__menu-item {
-    block-size: convert.to-rem(48px);
   }
 
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__menu-item:hover {
@@ -670,9 +642,9 @@ $list-box-menu-width: convert.to-rem(300px);
 
     display: block;
     overflow: hidden;
-    padding: convert.to-rem(11px) 0;
+    padding: calc((layout.size('height') - 1rem) / 2) 0;
     margin: 0 $spacing-05;
-    block-size: convert.to-rem(40px);
+    block-size: layout.size('height');
     border-block-end: 1px solid transparent;
     border-block-start: 1px solid transparent;
     border-block-start-color: $border-subtle-01;
@@ -690,7 +662,7 @@ $list-box-menu-width: convert.to-rem(300px);
     &:focus {
       @include focus-outline('outline');
 
-      padding: convert.to-rem(11px) convert.to-rem(16px);
+      padding: calc((layout.size('height') - 1rem) / 2) convert.to-rem(16px);
       border-color: transparent;
       margin: 0;
     }
@@ -699,16 +671,6 @@ $list-box-menu-width: convert.to-rem(300px);
       border-color: transparent;
       color: $text-primary;
     }
-  }
-
-  .#{$prefix}--list-box--sm .#{$prefix}--list-box__menu-item__option {
-    block-size: convert.to-rem(32px);
-    padding-block: convert.to-rem(7px) convert.to-rem(7px);
-  }
-
-  .#{$prefix}--list-box--lg .#{$prefix}--list-box__menu-item__option {
-    block-size: convert.to-rem(48px);
-    padding-block: convert.to-rem(15px) convert.to-rem(15px);
   }
 
   .#{$prefix}--list-box--disabled
@@ -863,27 +825,7 @@ $list-box-menu-width: convert.to-rem(300px);
 
   // Dropdown top orientation modifiers
   .#{$prefix}--list-box--up .#{$prefix}--list-box__menu {
-    inset-block-end: 2.5rem;
-  }
-
-  .#{$prefix}--list-box--up.#{$prefix}--dropdown--sm
-    .#{$prefix}--list-box__menu,
-  .#{$prefix}--list-box--up.#{$prefix}--list-box--sm
-    .#{$prefix}--list-box__menu,
-  .#{$prefix}--list-box--up
-    .#{$prefix}--list-box--sm
-    .#{$prefix}--list-box__menu {
-    inset-block-end: 2rem;
-  }
-
-  .#{$prefix}--list-box--up.#{$prefix}--dropdown--lg
-    .#{$prefix}--list-box__menu,
-  .#{$prefix}--list-box--up.#{$prefix}--list-box--lg
-    .#{$prefix}--list-box__menu,
-  .#{$prefix}--list-box--up
-    .#{$prefix}--list-box--lg
-    .#{$prefix}--list-box__menu {
-    inset-block-end: 3rem;
+    inset-block-end: layout.size('height');
   }
 
   // Tweaks for descendants

--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -642,7 +642,7 @@ $list-box-menu-width: convert.to-rem(300px);
 
     display: block;
     overflow: hidden;
-    padding: calc((layout.size('height') - 1rem) / 2) 0;
+    padding: calc((layout.size('height') - 1rem) / 2 - 1px) 0;
     margin: 0 $spacing-05;
     block-size: layout.size('height');
     border-block-end: 1px solid transparent;

--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/styles/scss/components/multiselect/_multiselect.scss
+++ b/packages/styles/scss/components/multiselect/_multiselect.scss
@@ -29,6 +29,10 @@
     inline-size: 100%;
   }
 
+  .#{$prefix}--multi-select .#{$prefix}--list-box__field {
+    block-size: 100%;
+  }
+
   .#{$prefix}--multi-select .#{$prefix}--list-box__field:focus {
     @include focus-outline('reset');
   }

--- a/packages/web-components/src/components/combo-box/combo-box.scss
+++ b/packages/web-components/src/components/combo-box/combo-box.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/combo-box/combo-box.scss
+++ b/packages/web-components/src/components/combo-box/combo-box.scss
@@ -319,3 +319,5 @@ $css--plex: true !default;
     inset-inline-end: to-rem(116px) !important;
   }
 }
+
+@include emit-layout-tokens-to-shadow-host('#{$prefix}-combo-box');

--- a/packages/web-components/src/components/combo-box/combo-box.stories.ts
+++ b/packages/web-components/src/components/combo-box/combo-box.stories.ts
@@ -51,6 +51,8 @@ const directionOptions = {
 };
 
 const sizes = {
+  [`Extra small size (${DROPDOWN_SIZE.EXTRA_SMALL})`]:
+    DROPDOWN_SIZE.EXTRA_SMALL,
   [`Small size (${DROPDOWN_SIZE.SMALL})`]: DROPDOWN_SIZE.SMALL,
   'Regular size': null,
   [`Large size (${DROPDOWN_SIZE.LARGE})`]: DROPDOWN_SIZE.LARGE,

--- a/packages/web-components/src/components/dropdown/defs.ts
+++ b/packages/web-components/src/components/dropdown/defs.ts
@@ -47,6 +47,11 @@ export enum DROPDOWN_KEYBOARD_ACTION {
  */
 export enum DROPDOWN_SIZE {
   /**
+   * Extra small size.
+   */
+  EXTRA_SMALL = 'xs',
+
+  /**
    * Small size.
    */
   SMALL = 'sm',

--- a/packages/web-components/src/components/dropdown/defs.ts
+++ b/packages/web-components/src/components/dropdown/defs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2022, 2023
+ * Copyright IBM Corp. 2020, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/dropdown/dropdown.scss
+++ b/packages/web-components/src/components/dropdown/dropdown.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/dropdown/dropdown.scss
+++ b/packages/web-components/src/components/dropdown/dropdown.scss
@@ -18,11 +18,14 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/components/tag';
 @use '@carbon/styles/scss/utilities/ai-gradient' as *;
 @use '@carbon/styles/scss/utilities/convert' as convert;
+@use '@carbon/styles/scss/layout' as *;
 
 // https://github.com/carbon-design-system/carbon/issues/11408
 @include list-box;
 
 :host(#{$prefix}-dropdown) {
+  @include emit-layout-tokens();
+
   outline: none;
 
   .#{$prefix}--list-box {
@@ -362,3 +365,5 @@ $divider-width: 1px;
     inset-inline-end: $spacing-08;
   }
 }
+
+@include emit-layout-tokens-to-shadow-host('#{$prefix}-dropdown');

--- a/packages/web-components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.stories.ts
@@ -27,6 +27,8 @@ const directionOptions = {
 };
 
 const sizes = {
+  [`Extra small size (${DROPDOWN_SIZE.EXTRA_SMALL})`]:
+    DROPDOWN_SIZE.EXTRA_SMALL,
   [`Small size (${DROPDOWN_SIZE.SMALL})`]: DROPDOWN_SIZE.SMALL,
   [`Medium size (${DROPDOWN_SIZE.MEDIUM})`]: DROPDOWN_SIZE.MEDIUM,
   [`Large size (${DROPDOWN_SIZE.LARGE})`]: DROPDOWN_SIZE.LARGE,

--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -1260,6 +1260,7 @@ class CDSDropdown extends ValidityMixin(
       [`${prefix}--list-box--inline`]: inline,
       [`${prefix}--list-box--expanded`]: open,
       [`${prefix}--list-box--${size}`]: size,
+      [`${prefix}--layout--size-${size}`]: size,
       [`${prefix}--dropdown--invalid`]: normalizedProps.invalid,
       [`${prefix}--dropdown--warn`]: normalizedProps.warn,
       [`${prefix}--dropdown--inline`]: inline,

--- a/packages/web-components/src/components/multi-select/multi-select.scss
+++ b/packages/web-components/src/components/multi-select/multi-select.scss
@@ -17,8 +17,11 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/components/checkbox';
 @use '@carbon/styles/scss/components/tag';
 @use '@carbon/styles/scss/utilities/convert';
+@use '@carbon/styles/scss/layout' as *;
 
 :host(#{$prefix}-multi-select) {
+  @include emit-layout-tokens();
+
   box-sizing: border-box;
   outline: none;
 
@@ -515,3 +518,5 @@ $css--plex: true !default;
     outline: none !important;
   }
 }
+
+@include emit-layout-tokens-to-shadow-host('#{$prefix}-multi-select');

--- a/packages/web-components/src/components/multi-select/multi-select.stories.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.stories.ts
@@ -58,6 +58,8 @@ const actions = html`
 `;
 
 const sizes = {
+  [`Extra small size (${DROPDOWN_SIZE.EXTRA_SMALL})`]:
+    DROPDOWN_SIZE.EXTRA_SMALL,
   [`Small size (${DROPDOWN_SIZE.SMALL})`]: DROPDOWN_SIZE.SMALL,
   [`Medium size (${DROPDOWN_SIZE.MEDIUM})`]: DROPDOWN_SIZE.MEDIUM,
   [`Large size (${DROPDOWN_SIZE.LARGE})`]: DROPDOWN_SIZE.LARGE,


### PR DESCRIPTION
Closes #21764
Closes #21769 
Closes #21777 

Added xs sizes for combobox , multiselect and dropdown and used layout systemfor the same

### Changelog

**New**

- XS size prop

**Changed**

- N/A

**Removed**

- Hradcoded styles instead used layout system

#### Testing / Reviewing

Visit combobox, multiselect and dropdown and check different sizes, It should work as per design spec mentioned in issues.
Check for both react and web-components.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
