### PR TITLE
feat(react): warn on React 16 and 17 support

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,6 +9,7 @@
 'use client'
 
 import './feature-flags';
+import './internal/warnAboutDeprecatedReactVersion';
 
 export * from './components/Accordion';
 export * from './components/AccordionItem';

--- a/packages/react/src/internal/__tests__/warnAboutDeprecatedReactVersion-test.js
+++ b/packages/react/src/internal/__tests__/warnAboutDeprecatedReactVersion-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2026
+ * Copyright IBM Corp. 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/internal/__tests__/warnAboutDeprecatedReactVersion-test.js
+++ b/packages/react/src/internal/__tests__/warnAboutDeprecatedReactVersion-test.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright IBM Corp. 2016, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('warnAboutDeprecatedReactVersion', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let spy;
+
+  function loadWithReactVersion(version) {
+    jest.doMock('react', () => ({
+      __esModule: true,
+      default: {
+        version,
+      },
+      version,
+    }));
+
+    return require('../warnAboutDeprecatedReactVersion');
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    jest.dontMock('react');
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it.each(['16.14.0', '17.0.2'])(
+    'warns when React %s is detected',
+    (version) => {
+      loadWithReactVersion(version);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(`Detected React ${version}.`)
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('https://carbondesignsystem.com/deprecations')
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Carbon v11 (@carbon/react v1.x) and will be removed in Carbon v12 (@carbon/react v2.x)'
+        )
+      );
+    }
+  );
+
+  it.each(['18.2.0', '19.2.3'])(
+    'does not warn when React %s is detected',
+    (version) => {
+      loadWithReactVersion(version);
+
+      expect(spy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('only warns once', () => {
+    const { warnAboutDeprecatedReactVersion } = loadWithReactVersion('17.0.2');
+
+    warnAboutDeprecatedReactVersion('17.0.2');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn in production', () => {
+    process.env.NODE_ENV = 'production';
+    jest.resetModules();
+
+    loadWithReactVersion('17.0.2');
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when React does not provide a version', () => {
+    loadWithReactVersion(undefined);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/internal/warnAboutDeprecatedReactVersion.ts
+++ b/packages/react/src/internal/warnAboutDeprecatedReactVersion.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2026
+ * Copyright IBM Corp. 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/internal/warnAboutDeprecatedReactVersion.ts
+++ b/packages/react/src/internal/warnAboutDeprecatedReactVersion.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright IBM Corp. 2016, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { warning } from './warning';
+
+let didWarnAboutDeprecatedReactVersion = false;
+
+function getReactMajorVersion(version: string | undefined) {
+  if (typeof version !== 'string') {
+    return null;
+  }
+
+  const match = version.match(/^(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+export function warnAboutDeprecatedReactVersion(version?: string) {
+  if (
+    process.env.NODE_ENV === 'production' ||
+    didWarnAboutDeprecatedReactVersion
+  ) {
+    return;
+  }
+
+  const reactVersion =
+    version ?? (React as { version?: string } | undefined)?.version;
+  const major = getReactMajorVersion(reactVersion);
+
+  if (major === 16 || major === 17) {
+    didWarnAboutDeprecatedReactVersion = true;
+
+    warning(
+      false,
+      `Detected React ${reactVersion}. Support for React 16 and React 17 ` +
+        'is deprecated in Carbon v11 (@carbon/react v1.x) and will be ' +
+        'removed in Carbon v12 (@carbon/react v2.x). Please upgrade your ' +
+        'project to React 18 or later. For more information, visit ' +
+        'https://carbondesignsystem.com/deprecations.'
+    );
+  }
+}
+
+warnAboutDeprecatedReactVersion();


### PR DESCRIPTION
> [!IMPORTANT]
> For questions or feedback relating to this deprecation, please post in the GitHub discussion: 
> - https://github.com/carbon-design-system/carbon/discussions/22396

Closes #22397
Related to https://github.com/carbon-design-system/carbon-website/pull/4923

This adds a dev-only deprecation warning for using React v16 or v17 with `@carbon/react`. 

### Changelog

**New**

- add react version deprecation functions

#### Testing / Reviewing

- I added some tests that should pass
- If you want to try it end-to-end you can pull down locally, spin up the `vite` example and see no warning, then downgrade the react version in that template and restart the server - the warning should pop.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
