### PR TITLE
fix: move to a single theme selector

### DIFF
--- a/packages/react/.storybook/modes.js
+++ b/packages/react/.storybook/modes.js
@@ -1,12 +1,14 @@
+import { g10, g90, g100 } from '@carbon/themes';
+
 export const allModes = {
   g10: {
-    theme: 'g10',
+    backgrounds: { value: g10.background },
   },
   g90: {
-    theme: 'g90',
+    backgrounds: { value: g90.background },
   },
   g100: {
-    theme: 'g100',
+    backgrounds: { value: g100.background },
   },
   'breakpoint-sm': {
     viewport: 'Small',

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -21,6 +21,7 @@
     flex-direction: column;
     align-items: center;
     padding: 42px;
+    transition: initial;
   }
 
   body #storybook-root {

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -18,7 +18,7 @@ import './styles.scss';
 import '../src/feature-flags';
 
 import { white, g10, g90, g100 } from '@carbon/themes';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useIsomorphicEffect from '../src/internal/useIsomorphicEffect';
 import { breakpoints } from '@carbon/layout';
 import { GlobalTheme } from '../src/components/Theme';

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -350,11 +350,7 @@ const decorators = [
     const backgroundValue = context.globals.backgrounds?.value;
     const [randomKey, setRandomKey] = useState(1);
 
-    // Memoize theme calculation to avoid redundant calls
-    const theme = useMemo(
-      () => getThemeFromBackground(backgroundValue),
-      [backgroundValue]
-    );
+    const theme = getThemeFromBackground(backgroundValue);
 
     useEffect(() => {
       document.documentElement.setAttribute('data-carbon-theme', theme);

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -18,7 +18,7 @@ import './styles.scss';
 import '../src/feature-flags';
 
 import { white, g10, g90, g100 } from '@carbon/themes';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import useIsomorphicEffect from '../src/internal/useIsomorphicEffect';
 import { breakpoints } from '@carbon/layout';
 import { GlobalTheme } from '../src/components/Theme';
@@ -121,16 +121,6 @@ const globalTypes = {
           value: 'rtl',
         },
       ],
-    },
-  },
-  theme: {
-    name: 'Theme',
-    description: 'Set the global theme for displaying components',
-    defaultValue: 'white',
-    toolbar: {
-      icon: 'paintbrush',
-      title: 'Theme',
-      items: ['white', 'g10', 'g90', 'g100'],
     },
   },
   ...(process.env.NODE_ENV === 'development' ? devTools : {}),
@@ -339,10 +329,35 @@ const parameters = {
   },
 };
 
+// Helper function to map background values to theme names
+function getThemeFromBackground(backgroundValue) {
+  // Handle both hex values and named values
+  if (backgroundValue === white.background || backgroundValue === 'white') {
+    return 'white';
+  } else if (backgroundValue === g10.background || backgroundValue === 'g10') {
+    return 'g10';
+  } else if (backgroundValue === g90.background || backgroundValue === 'g90') {
+    return 'g90';
+  } else if (
+    backgroundValue === g100.background ||
+    backgroundValue === 'g100'
+  ) {
+    return 'g100';
+  }
+  return 'white'; // default theme
+}
+
 const decorators = [
   (Story, context) => {
-    const { layoutDensity, layoutSize, locale, dir, theme } = context.globals;
+    const { layoutDensity, layoutSize, locale, dir } = context.globals;
+    const backgroundValue = context.globals.backgrounds?.value;
     const [randomKey, setRandomKey] = useState(1);
+
+    // Memoize theme calculation to avoid redundant calls
+    const theme = useMemo(
+      () => getThemeFromBackground(backgroundValue),
+      [backgroundValue]
+    );
 
     useEffect(() => {
       document.documentElement.setAttribute('data-carbon-theme', theme);

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -331,20 +331,17 @@ const parameters = {
 
 // Helper function to map background values to theme names
 function getThemeFromBackground(backgroundValue) {
-  // Handle both hex values and named values
-  if (backgroundValue === white.background || backgroundValue === 'white') {
-    return 'white';
-  } else if (backgroundValue === g10.background || backgroundValue === 'g10') {
-    return 'g10';
-  } else if (backgroundValue === g90.background || backgroundValue === 'g90') {
-    return 'g90';
-  } else if (
-    backgroundValue === g100.background ||
-    backgroundValue === 'g100'
-  ) {
-    return 'g100';
-  }
-  return 'white'; // default theme
+  const backgroundThemeMap = {
+    [white.background]: 'white',
+    white: 'white',
+    [g10.background]: 'g10',
+    g10: 'g10',
+    [g90.background]: 'g90',
+    g90: 'g90',
+    [g100.background]: 'g100',
+    g100: 'g100',
+  };
+  return backgroundThemeMap[backgroundValue] ?? 'white';
 }
 
 const decorators = [

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -349,7 +349,6 @@ const decorators = [
     const { layoutDensity, layoutSize, locale, dir } = context.globals;
     const backgroundValue = context.globals.backgrounds?.value;
     const [randomKey, setRandomKey] = useState(1);
-
     const theme = getThemeFromBackground(backgroundValue);
 
     useEffect(() => {


### PR DESCRIPTION
Closes #

Storybook feels broken when changing Carbon theme it is necessary to change two settings, the background value and a theme value. The only impact is the change to the URL

Selecting g100

<img width="960" height="305" alt="image" src="https://github.com/user-attachments/assets/47e2d827-fb53-44b4-b412-ab0e4301c2d1" />

Results in
<img width="960" height="326" alt="image" src="https://github.com/user-attachments/assets/bc758fcf-4878-4fd9-91a9-d77884c81237" />

This second value needs changing
<img width="962" height="309" alt="image" src="https://github.com/user-attachments/assets/303e6ae7-4557-46f4-9672-5f6388713269" />

to give
<img width="962" height="298" alt="image" src="https://github.com/user-attachments/assets/ffe0d956-4b15-42ba-a4d1-edcb92f00e7a" />

This PR removes the second step option in favour of reacting to the background change.

### Changelog

**Changed**

- packages/react/.storybook/preview.js
- packages/react/.storybook/preview-head.html

#### Testing / Reviewing

Ran tests and storybook locally

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
