### PR TITLE
chore: update issue template fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -108,10 +108,12 @@ body:
         - 'Severity 4 = Unrelated to a user task, has a workaround or does not
           need a workaround.'
   - type: input
-    id: application
+    id: project
     attributes:
-      label: Application/PAL
-      description: 'What application and/or PAL do you work on?'
+      label: Project name
+      description: 'What project, team, or product do you work on?'
+    validations:
+      required: true
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
@@ -102,10 +102,12 @@ body:
     validations:
       required: true
   - type: input
-    id: application
+    id: project
     attributes:
-      label: Application/PAL
-      description: 'What application and/or PAL do you work on?'
+      label: Project name
+      description: 'What project, team, or product do you work on?'
+    validations:
+      required: true
   - type: dropdown
     id: priority
     attributes:

--- a/docs/decisions/0003-use-preview-moniker.md
+++ b/docs/decisions/0003-use-preview-moniker.md
@@ -48,7 +48,7 @@ stability.
 - This change could cause confusion as `preview` is inherently a bit more "open
   to interpretation". We'll need to ground this with new/updated docs, increased
   communications surrounding the `preview` meaning, and discussions during
-  community events (office hours, DSAG, etc.).
+  community events (office hours, Carbon Collective, etc.).
 - Our exports and feature flags and such will bloat a bit. `unstable__Component`
   will need to stick around for backwards compatibility of the new
   `preview__Component`, for instance.

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -321,7 +321,7 @@ https://carbondesignsystem.com/all-about-carbon/what-is-carbon/#our-guiding-prin
 Carbon Collective - Formerly the Design System Adoption Guild (DSAG) is an
 expansive group of designers and developers all aligned on the mission of
 delivering amazing experiences in the IBM Products organization. You can learn
-more about the guild
+more about the Carbon Collective
 [here](https://pages.github.ibm.com/cdai-design/pal/contributing/contribution-framework/intent).
 
 PAL - Pattern & Asset Library. These are the local systems around IBM that

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -318,9 +318,10 @@ flowchart TD
 Guiding principles -
 https://carbondesignsystem.com/all-about-carbon/what-is-carbon/#our-guiding-principles
 
-Carbon Collective - Formerly the Design System Adoption Guild (DSAG) is an expansive group of designers and
-developers all aligned on the mission of delivering amazing experiences in the
-IBM Products organization. You can learn more about the guild
+Carbon Collective - Formerly the Design System Adoption Guild (DSAG) is an
+expansive group of designers and developers all aligned on the mission of
+delivering amazing experiences in the IBM Products organization. You can learn
+more about the guild
 [here](https://pages.github.ibm.com/cdai-design/pal/contributing/contribution-framework/intent).
 
 PAL - Pattern & Asset Library. These are the local systems around IBM that

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -279,8 +279,8 @@ the ask. Checkout the flow chart to see the path a given feature might take.
 flowchart TD
     A[Received] --> B[Does it align with the maintainer team's <br />guiding principles for building a design system at IBM?]
     B -->|No| C[Closed]
-    B -->|Yes| D[Is it supporting a PAL in the DSAG?]
-    D -->|No| E[Is it suporting a PAL not in the DSAG?]
+    B -->|Yes| D[Is it supporting a PAL part of the Carbon Collective?]
+    D -->|No| E[Is it suporting a PAL not part of Carbon Collective?]
     E -->|No| F[Is it supporting an IBM product without a PAL?]
     F -->|No| G[Is it supporting a non-IBM offering that uses Carbon?]
     G -->|No| C[Closed]
@@ -294,7 +294,7 @@ flowchart TD
     J & K & L -->|Yes| M([Your request has been labeled as an `accepted` <br />proposal and has been added to our Icebox and is <br />being prioritized against competing workstreams])
     M --> N([Labeled with `Community Contribution` <br /> on GH. Looking for contributions])
     M --> O([Added to maintainer team's roadmap <br /> and backlog for refinement])
-    N & O --> storm((Design Crits, Code Reviews,<br /> CAG, DSAG meetings, <br /> Office hours when needed))
+    N & O --> storm((Design Crits, Code Reviews,<br /> CAG, Carbon Collective meetings, <br /> Office hours when needed))
     storm --> ide1
     subgraph ide1 [Evaluate against a definition of done]
     P[Storybook]
@@ -318,7 +318,7 @@ flowchart TD
 Guiding principles -
 https://carbondesignsystem.com/all-about-carbon/what-is-carbon/#our-guiding-principles
 
-DSAG - The Design System Adoption Guild is an expansive group of designers and
+Carbon Collective - Formerly the Design System Adoption Guild (DSAG) is an expansive group of designers and
 developers all aligned on the mission of delivering amazing experiences in the
 IBM Products organization. You can learn more about the guild
 [here](https://pages.github.ibm.com/cdai-design/pal/contributing/contribution-framework/intent).

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -8,14 +8,16 @@
 - [Overview](#overview)
   - [What does "ongoing support" mean regarding GitHub?](#what-does-ongoing-support-mean-regarding-github)
   - [What does "ongoing support" mean regarding Slack?](#what-does-ongoing-support-mean-regarding-slack)
+  - [Configuring the GitHub Slack integration](#configuring-the-github-slack-integration)
   - [What repositories do we support?](#what-repositories-do-we-support)
 - [Issues](#issues)
   - [Types of issues](#types-of-issues)
   - [Triaging a new issue](#triaging-a-new-issue)
   - [Triage Process](#triage-process)
-    - [type: bug 🐛 & type: a11y ♿](#type-bug---type-a11y-)
+    - [type: bug 🐛](#type-bug-)
     - [type: question ❓](#type-question-)
     - [type: enhancement 💡](#type-enhancement-)
+  - [Definitions](#definitions)
   - [Severity](#severity)
   - [Project](#project)
   - [Other labels](#other-labels)
@@ -38,8 +40,8 @@ our support channels, here are some responses that can help get the conversation
 started in case you get stuck.
 
 - “Could you share more about what you’ve already tried?”
-- “Can you share more about your usecase?”
-- “Can you add a repro (reproduction) using Stackblitz?”
+- “Can you share more about your use case?”
+- “Can you add a repro (reproduction) using StackBlitz?”
 - “After searching through [FILL IN RESOURCE HERE], I was able to find this and thought
   it might be helpful... Let me know if that works.”
 
@@ -65,11 +67,11 @@ started in case you get stuck.
   reiterating the answer and acknowledging the community member.
 - Use discretion to respond to applicable threads. Lean on the maintainer team's
   private #carbon-support channel to look for subject matter experts when a
-  question goes beyond your skillset. When you ask in this channel, take a leap
+  question goes beyond your skill set. When you ask in this channel, take a leap
   of faith in your skills and propose a response, such as, "This is how I want
   to respond ... YOUR REPLY HERE". Follow the question by practicing humility,
   "How far off am I"? "What am I missing"? Remember, you're acting as an
-  advocate for the person who originally asked the question. Respresent their
+  advocate for the person who originally asked the question. Represent their
   needs to the best of your ability.
 - If a question is Carbon-related, but not necessarily related to the core
   components, route the person to the correct Slack channel where they might
@@ -208,7 +210,7 @@ If they are, remove the question label, label as a `type: enhancement 💡` or
 <details>
 <summary>Is there a duplicate question?</summary>
 
-We tend to recieve more questions through Slack than through GitHub so with any
+We tend to receive more questions through Slack than through GitHub so with any
 incoming question issues, search in both places to see if it has already been
 answered. If you can find an answer, point the author to where they can find it
 and close the issue.
@@ -328,7 +330,7 @@ PAL - Pattern & Asset Library. These are the local systems around IBM that
 extend our core components to fit their desired business need.
 
 CAG - Carbon Accessibility Guild. A once a sprint meeting where the Carbon team
-gets together with the Accessiblity team. Our components and patterns are
+gets together with the Accessibility team. Our components and patterns are
 reviewed and made more accessible.
 
 Design crit - A once a sprint meeting led by Carbon designers to review patterns

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -280,7 +280,7 @@ flowchart TD
     A[Received] --> B[Does it align with the maintainer team's <br />guiding principles for building a design system at IBM?]
     B -->|No| C[Closed]
     B -->|Yes| D[Is it supporting a PAL part of the Carbon Collective?]
-    D -->|No| E[Is it suporting a PAL not part of Carbon Collective?]
+    D -->|No| E[Is it supporting a PAL not part of Carbon Collective?]
     E -->|No| F[Is it supporting an IBM product without a PAL?]
     F -->|No| G[Is it supporting a non-IBM offering that uses Carbon?]
     G -->|No| C[Closed]


### PR DESCRIPTION
This makes it so that when someone opens an issue, they'll be required to put an answer in for `What project, team, or product do you work on?`

I also updated references of DSAG -> Carbon Collective.

Thanks @anishapatroibm for this idea!

### Changelog

**Changed**

- update issue templates to require product field
- update DSAG references to Carbon Collective

#### Testing / Reviewing

- n/a, check my spelling

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
