### PR TITLE
fix(tabs): remove lg line tab size and fix icon story

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -40,6 +40,14 @@ import {
   Icon,
 } from '@carbon/icons-react';
 
+const lineTabsSizeArgType = {
+  size: {
+    control: { type: 'select' },
+    options: ['sm', 'md'],
+    description: 'Specify the size of the tabs',
+  },
+};
+
 const tabsSizeArgType = {
   size: {
     control: { type: 'select' },
@@ -144,7 +152,7 @@ Default.argTypes = {
       type: 'boolean',
     },
   },
-  ...tabsSizeArgType,
+  ...lineTabsSizeArgType,
 };
 
 export const Dismissable = (args) => {
@@ -218,7 +226,7 @@ export const Dismissable = (args) => {
   );
 };
 
-Dismissable.argTypes = tabsSizeArgType;
+Dismissable.argTypes = lineTabsSizeArgType;
 Dismissable.args = lineTabsSizeArgs;
 export const DismissableContained = (args) => {
   const tabs = [
@@ -367,7 +375,7 @@ export const DismissableWithIcons = ({ contained, size }) => {
   );
 };
 
-DismissableWithIcons.argTypes = tabsSizeArgType;
+DismissableWithIcons.argTypes = lineTabsSizeArgType;
 DismissableWithIcons.args = lineTabsSizeArgs;
 
 export const WithIcons = (args) => {
@@ -409,7 +417,7 @@ export const WithIcons = (args) => {
   );
 };
 
-WithIcons.argTypes = tabsSizeArgType;
+WithIcons.argTypes = lineTabsSizeArgType;
 WithIcons.args = lineTabsSizeArgs;
 
 export const Manual = () => {
@@ -513,7 +521,7 @@ export const IconOnly = (args) => {
 };
 
 IconOnly.argTypes = {
-  ...tabsSizeArgType,
+  ...lineTabsSizeArgType,
   badgeIndicator: {
     description: '**Experimental**: Display an empty dot badge on the Tab.',
     control: {

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -439,6 +439,9 @@ export interface TabListProps extends DivAttributes {
 
   /**
    * Specify the size of the tabs.
+   *
+   * Supports `sm` and `md` for line tabs.
+   * Supports `sm`, `md`, and `lg` for contained tabs.
    */
   size?: 'sm' | 'md' | 'lg';
 }
@@ -498,7 +501,10 @@ function TabList({
       [`${prefix}--tabs__icon--default`]: iconSize === 'default',
       [`${prefix}--tabs__icon--lg`]: iconSize === 'lg', // TODO: V12 - Remove this class
       [`${prefix}--layout--size-lg`]: iconSize === 'lg',
-      [`${prefix}--layout--size-${size}`]: size && !hasSecondaryLabelTabs,
+      [`${prefix}--layout--size-${size}`]:
+        size &&
+        !hasSecondaryLabelTabs &&
+        (contained || size === 'sm' || size === 'md'),
       [`${prefix}--tabs--tall`]: hasSecondaryLabelTabs,
       [`${prefix}--tabs--full-width`]: distributeWidth,
       [`${prefix}--tabs--dismissable`]: dismissable,
@@ -866,6 +872,9 @@ TabList.propTypes = {
 
   /**
    * Specify the size of the tabs.
+   *
+   * Supports `sm` and `md` for line tabs.
+   * Supports `sm`, `md`, and `lg` for contained tabs.
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
 };

--- a/packages/react/src/components/Tabs/__tests__/Tabs-test.js
+++ b/packages/react/src/components/Tabs/__tests__/Tabs-test.js
@@ -1023,6 +1023,46 @@ describe('TabList', () => {
     expect(container.firstChild).toHaveClass(`${prefix}--layout--size-sm`);
   });
 
+  it('should not apply large layout size for line tabs', () => {
+    jest.spyOn(hooks, 'useMatchMedia').mockImplementation(() => true);
+    const { container } = render(
+      <Tabs>
+        <TabList aria-label="List of tabs" size="lg">
+          <Tab>Tab Label 1</Tab>
+          <Tab>Tab Label 2</Tab>
+          <Tab>Tab Label 3</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Tab Panel 1</TabPanel>
+          <TabPanel>Tab Panel 2</TabPanel>
+          <TabPanel>Tab Panel 3</TabPanel>
+        </TabPanels>
+      </Tabs>
+    );
+
+    expect(container.firstChild).not.toHaveClass(`${prefix}--layout--size-lg`);
+  });
+
+  it('should apply large layout size for contained tabs', () => {
+    jest.spyOn(hooks, 'useMatchMedia').mockImplementation(() => true);
+    const { container } = render(
+      <Tabs>
+        <TabList aria-label="List of tabs" contained size="lg">
+          <Tab>Tab Label 1</Tab>
+          <Tab>Tab Label 2</Tab>
+          <Tab>Tab Label 3</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Tab Panel 1</TabPanel>
+          <TabPanel>Tab Panel 2</TabPanel>
+          <TabPanel>Tab Panel 3</TabPanel>
+        </TabPanels>
+      </Tabs>
+    );
+
+    expect(container.firstChild).toHaveClass(`${prefix}--layout--size-lg`);
+  });
+
   it('should ignore size class for contained tabs with secondary labels', () => {
     jest.spyOn(hooks, 'useMatchMedia').mockImplementation(() => true);
     const { container } = render(

--- a/packages/web-components/src/components/tabs/stories/tabs-wrapper.ts
+++ b/packages/web-components/src/components/tabs/stories/tabs-wrapper.ts
@@ -110,6 +110,9 @@ export class DismissableTabsWrapper extends LitElement {
 
   render() {
     const { resetTabs } = this;
+    const size =
+      this.size || (this.contained ? TABS_SIZE.LARGE : TABS_SIZE.MEDIUM);
+
     return html`
       <cds-button style="margin-bottom: 3rem" @click="${resetTabs}">
         Reset
@@ -120,7 +123,7 @@ export class DismissableTabsWrapper extends LitElement {
         selected-index="${this.selectedIndex}"
         type="${this.contained ? TABS_TYPE.CONTAINED : TABS_TYPE.REGULAR}"
         ?dismissable="${this.dismissable}"
-        size="${this.size || TABS_SIZE.LARGE}"
+        size="${size}"
         value="all"
         @cds-tab-closed="${this._handleDismissed}"
         @cds-tabs-beingselected="${this._handleBeforeSelected}">

--- a/packages/web-components/src/components/tabs/tabs.scss
+++ b/packages/web-components/src/components/tabs/tabs.scss
@@ -91,7 +91,8 @@ $inset-transition: inset 110ms motion(standard, productive);
   @extend .#{$prefix}--layout--size-md;
 }
 
-:host(#{$prefix}-tabs[size='lg']) {
+:host(#{$prefix}-tabs[type='contained'][size='lg']),
+:host(#{$prefix}-tabs[vertical][size='lg']) {
   @extend .#{$prefix}--layout--size-lg;
 }
 

--- a/packages/web-components/src/components/tabs/tabs.stories.ts
+++ b/packages/web-components/src/components/tabs/tabs.stories.ts
@@ -58,6 +58,14 @@ const argTypes = {
   },
 };
 
+const lineTabsSizeArgType = {
+  size: {
+    control: { type: 'select' },
+    options: ['sm', 'md'],
+    description: 'Specify the size of the tabs',
+  },
+};
+
 const tabsSizeArgType = {
   size: {
     control: { type: 'select' },
@@ -91,7 +99,7 @@ export const Default = {
   args,
   argTypes: {
     ...argTypes,
-    ...tabsSizeArgType,
+    ...lineTabsSizeArgType,
   },
   render: ({ disabled, contained, selectionMode, size }) => {
     const handleBeforeSelected = (event: CustomEvent) => {
@@ -679,7 +687,7 @@ export const Dismissable = {
       description:
         'Specify a selected index for the initially selected content.',
     },
-    ...tabsSizeArgType,
+    ...lineTabsSizeArgType,
   },
   render: ({ dismissable, selectedIndex, size }) => {
     return html`
@@ -744,7 +752,7 @@ export const DismissableWithIcons = {
       description:
         'Specify a selected index for the initially selected content.',
     },
-    ...tabsSizeArgType,
+    ...lineTabsSizeArgType,
   },
   render: ({ dismissable, selectedIndex, size }) => {
     return html`
@@ -847,7 +855,7 @@ export const IconOnly = {
   },
   argTypes: {
     ...iconStoriesArgTypes,
-    ...tabsSizeArgType,
+    ...lineTabsSizeArgType,
   },
   render: ({ badgeIndicator, size }) => html`
     <style>
@@ -1199,7 +1207,7 @@ export const Vertical = {
 
 export const WithIcons = {
   args: lineTabsSizeArgs,
-  argTypes: tabsSizeArgType,
+  argTypes: lineTabsSizeArgType,
   render: ({ size }) => {
     return html`
       <style>
@@ -1208,8 +1216,7 @@ export const WithIcons = {
       <cds-tabs
         selection-mode="manual"
         value="icon-tab-1"
-        size="${ifDefined(size)}"
-        icon-size="${TABS_ICON_SIZE.DEFAULT}">
+        size="${ifDefined(size)}">
         <cds-tab id="icon-tab-1" target="icon-panel-1" value="icon-tab-1">
           Dashboard ${iconLoader(Dashboard16)}
         </cds-tab>

--- a/packages/web-components/src/components/tabs/tabs.ts
+++ b/packages/web-components/src/components/tabs/tabs.ts
@@ -485,7 +485,8 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
   /**
    * Specify the size of the tabs.
    *
-   * Supports `sm`, `md`, and `lg` for all tabs.
+   * Supports `sm` and `md` for line tabs.
+   * Supports `sm`, `md`, and `lg` for contained tabs.
    * Supports `xl` only when `vertical` is set; otherwise `xl` falls back to `lg`.
    */
   @property({ reflect: true })


### PR DESCRIPTION
Closes N/A
Follow-up to #22340.

This PR was opened separately to keep the scope focused on Alina’s latest feedback in [#22340](https://github.com/carbon-design-system/carbon/pull/22340#issuecomment-4719656903): the `lg` size is no longer needed for Line Tabs and should be removed across all Line Tabs variants.

The goal is to remove `lg` only from Line Tabs while preserving the existing behavior for contained tabs and vertical tabs.

### Changelog

**New**

- ~None.~

**Changed**

- Updated React and Web Components Line Tabs stories to keep only `sm` and `md` size options.

**Removed**

- Removed `icon-size` from the Web Components `With icons` story so label + icon tabs use the standard line-tab overflow behavior.
- Removed `lg` as a selectable Storybook size option for Line Tabs.

#### Testing / Reviewing

Test the line tabs stories in React and Web Components and confirm the size control works for sm, md, and lg.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)