### PR TITLE
fix(web-components): allow textarea to fill flex height

### DIFF
--- a/packages/web-components/src/components/textarea/__tests__/textarea-test.js
+++ b/packages/web-components/src/components/textarea/__tests__/textarea-test.js
@@ -99,6 +99,23 @@ describe('cds-textarea', () => {
     expect(textarea.getAttribute('rows')).to.equal('10');
   });
 
+  it('should stretch the inner textarea when the host grows in a flex column layout', async () => {
+    const container = await fixture(html`
+      <div style="display: flex; flex-direction: column; height: 240px;">
+        <div style="flex: 0 0 20px;"></div>
+        <cds-textarea hide-label style="flex: 1 1 auto;"></cds-textarea>
+        <div style="flex: 0 0 20px;"></div>
+      </div>
+    `);
+
+    const el = container.querySelector('cds-textarea');
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const textarea = el.shadowRoot.querySelector('textarea');
+    expect(textarea.getBoundingClientRect().height).to.be.greaterThan(150);
+  });
+
   it('should accept pattern and required attributes', async () => {
     const el = await fixture(html`
       <cds-textarea pattern="[A-Za-z]+" required></cds-textarea>

--- a/packages/web-components/src/components/textarea/textarea.scss
+++ b/packages/web-components/src/components/textarea/textarea.scss
@@ -15,6 +15,8 @@ $css--plex: true !default;
 :host(#{$prefix}-textarea) {
   @include emit-layout-tokens();
 
+  display: flex;
+  flex-direction: column;
   outline: none;
   ::slotted(#{$prefix}-ai-label),
   ::slotted(#{$prefix}-slug) {
@@ -59,6 +61,10 @@ $css--plex: true !default;
 :host(#{$prefix}-textarea[ai-label])
   .#{$prefix}--text-area__wrapper--decorator {
   @include ai-gradient;
+}
+
+.#{$prefix}--text-area__wrapper {
+  flex: 1 1 auto;
 }
 
 .#{$prefix}--text-area__wrapper--cols {


### PR DESCRIPTION
Closes #22446

Updates `cds-textarea` so the shadow DOM layout can consume the height assigned to the host when it is used as a growing flex item. The host now lays out its shadow contents as a column and lets the textarea wrapper flex, allowing the native `<textarea>` to fill the available vertical space.

### Changelog

**Changed**

- Allow the inner native textarea in `cds-textarea` to stretch when the custom element grows in a flex column layout.

#### Testing / Reviewing

- `yarn workspace @carbon/web-components build`
- `CI=1 yarn web-test-runner "src/components/textarea/__tests__/textarea-test.js" --node-resolve --concurrency=1 --coverage=false` (22 passed, 0 failed)
- `yarn prettier --check packages/web-components/src/components/textarea/textarea.scss packages/web-components/src/components/textarea/__tests__/textarea-test.js`
- `yarn stylelint packages/web-components/src/components/textarea/textarea.scss --allow-empty-input`
- `yarn eslint packages/web-components/src/components/textarea/__tests__/textarea-test.js --no-warn-ignored`
- `git diff --check`

Note: `yarn workspace @carbon/web-components typecheck` was attempted and currently fails on existing `tests/spec/*.ts` files that are outside this change, with missing Jasmine globals/story exports such as `describe`, `it`, `expect`, and `Playground`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
