### PR TITLE
refactor(pagination): simplify selector usage in CDSPagination component

### DIFF
--- a/packages/web-components/src/components/pagination/pagination.ts
+++ b/packages/web-components/src/components/pagination/pagination.ts
@@ -22,6 +22,11 @@ import { iconLoader } from '../../globals/internal/icon-loader';
 import { prefix } from '../../globals/settings';
 import styles from './pagination.scss?lit';
 
+const selectorPagesSelect = `${prefix}-select#pages-select`;
+const selectorPageSizesSelect = `${prefix}-select`;
+const selectorPreviousButton = `${prefix}--pagination__button--backward`;
+const selectorForwardButton = `${prefix}--pagination__button--forward`;
+
 /**
  * Pagination UI.
  *
@@ -32,8 +37,17 @@ import styles from './pagination.scss?lit';
  */
 @customElement(`${prefix}-pagination`)
 class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
-  @query(`${prefix}-select`)
-  private _pageSizeSelect!: HTMLElement;
+  @query(selectorPageSizesSelect)
+  private _pageSizeSelect!: CDSSelect;
+
+  @query(selectorPagesSelect)
+  private _pagesSelect!: CDSSelect | null;
+
+  @query(`[button-class-name*=${selectorPreviousButton}]`)
+  private _previousButton!: HTMLElement;
+
+  @query(`[button-class-name*=${selectorForwardButton}]`)
+  private _forwardButton!: HTMLElement;
 
   private _handleSlotChange({ target }: Event) {
     const content = (target as HTMLSlotElement).assignedNodes().filter(
@@ -163,13 +177,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
     }
     // reset focus to forward button if it reaches the beginning
     if (this.page === 1) {
-      const { selectorForwardButton } = this
-        .constructor as typeof CDSPagination;
-      (
-        this.shadowRoot?.querySelector(
-          `[button-class-name*=${selectorForwardButton}]`
-        ) as HTMLElement
-      ).focus();
+      this._forwardButton.focus();
     }
   }
 
@@ -189,13 +197,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
     }
     // reset focus to previous button if it reaches the end and `pagesUnknown` is not true
     if (!pagesUnknown && this.page === this.totalPages) {
-      const { selectorPreviousButton } = this
-        .constructor as typeof CDSPagination;
-      (
-        this.shadowRoot?.querySelector(
-          `[button-class-name*=${selectorPreviousButton}]`
-        ) as HTMLElement
-      ).focus();
+      this._previousButton.focus();
     }
   }
 
@@ -375,17 +377,9 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
 
   updated(changedProperties) {
     const { pageSize, totalItems } = this;
-    const { selectorPageSizesSelect, selectorPagesSelect } = this
-      .constructor as typeof CDSPagination;
 
     if (changedProperties.has('pageSize')) {
-      const pageSizeSelect = this.shadowRoot?.querySelector(
-        selectorPageSizesSelect
-      ) as CDSSelect | null;
-
-      if (pageSizeSelect) {
-        pageSizeSelect.value = String(pageSize ?? '');
-      }
+      this._pageSizeSelect.value = String(pageSize ?? '');
     }
 
     // Recompute total pages and clamp the visible page whenever any relevant input changes
@@ -411,12 +405,8 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
       const requestedPage = Math.max(1, Math.floor(this.page || 1));
       const displayPage = Math.min(requestedPage, totalPagesSafe);
 
-      const pagesSelect = this.shadowRoot?.querySelector(
-        selectorPagesSelect
-      ) as CDSSelect | null;
-
-      if (pagesSelect) {
-        pagesSelect.value = displayPage.toString();
+      if (this._pagesSelect) {
+        this._pagesSelect.value = displayPage.toString();
       }
     }
 
@@ -427,11 +417,8 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
         this.totalItems,
         this.pagesUnknown
       );
-      const pagesSelect = this.shadowRoot?.querySelector(
-        (this.constructor as typeof CDSPagination).selectorPagesSelect
-      ) as CDSSelect | null;
-      if (pagesSelect) {
-        pagesSelect.value = String(this.page);
+      if (this._pagesSelect) {
+        this._pagesSelect.value = String(this.page);
       }
     }
   }
@@ -587,28 +574,28 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
    * A selector that will return the select box for the current page.
    */
   static get selectorPagesSelect() {
-    return `${prefix}-select#pages-select`;
+    return selectorPagesSelect;
   }
 
   /**
    * A selector that will return the select box for page sizes.
    */
   static get selectorPageSizesSelect() {
-    return `${prefix}-select`;
+    return selectorPageSizesSelect;
   }
 
   /**
    * A selector that will return the previous button.
    */
   static get selectorPreviousButton() {
-    return `${prefix}--pagination__button--backward`;
+    return selectorPreviousButton;
   }
 
   /**
    * A selector that will return the forward button.
    */
   static get selectorForwardButton() {
-    return `${prefix}--pagination__button--forward`;
+    return selectorForwardButton;
   }
 
   /**


### PR DESCRIPTION
Closes #22476 

Replaces direct ```shadowRoot.querySelector()``` calls in the web components pagination component with Lit’s ```@query``` decorator.

The affected elements use selectors that are fixed when the component is defined:
- The page-size select
- The current-page select
- The previous-page button
- The next-page button
Because these selectors do not depend on runtime values such as a changing ID, they are suitable for ```@query```. Each element is now represented by a private property, allowing handlers to access ```this._pagesSelect```, ```this._previousButton```, and similar properties instead of repeatedly querying the shadow DOM.

This change is useful because it:
- Follows Lit’s recommended pattern for accessing known elements in a component’s render root.
- Keeps selector definitions in one place.
- Removes repeated selector strings, type assertions, and temporary variables.
- Makes update and event-handler logic easier to read.
- Provides reusable element properties if other methods need the same elements later.
- Reduces the risk of different methods accidentally using inconsistent selectors.

The current-page select requires additional care because it is conditionally rendered. It is absent when pagination has an unknown or empty total. Therefore, ```_pagesSelect``` remains typed as nullable and is checked before use:

```
if (this._pagesSelect) {
  this._pagesSelect.value = String(this.page);
}
```

The decorator deliberately does not enable Lit’s optional caching flag. With the default behavior, the decorated getter queries the current render root whenever it is accessed. This allows ```_pagesSelect``` to reflect whether the conditionally rendered element currently exists.

This change does not replace genuinely dynamic queries. A selector constructed from runtime state, such as ```#page-${this.page}```, would still need an explicit query because the selector itself changes.

### Changelog

**New**

- Added private ```@query``` properties for the page-size select, current-page select, previous button, and forward button.
- Added shared constants for the static selector values.

**Changed**

- Updated page-size synchronization to write through ```_pageSizeSelect```.
- Updated current-page synchronization to write through ```_pagesSelect```.
- Updated focus management to use ```_previousButton``` and ```_forwardButton```.
- Updated existing static selector getters to return the shared selector constants, preserving their existing API and values.

**Removed**

- Removed repeated ```shadowRoot.querySelector()``` calls from the pagination component.
- Removed temporary element variables and associated type assertions from update handlers.

#### Testing / Reviewing

1. Run the pagination tests:
```
yarn workspace @carbon/web-components exec web-test-runner src/components/pagination/__tests__/pagination-test.js --node-resolve --concurrency=1
```
2. Verify changing the page size updates the page-size select and recalculates the total number of pages.
3. Verify changing the current page updates the pages select.
4. Verify pagination still works when the pages select is conditionally absent, including unknown-page and zero-item states.
5. Verify reaching the first or last page correctly moves focus to the enabled navigation button.
6. Confirm ```pagination.ts``` contains no direct ```querySelector``` or ```querySelectorAll``` calls.
7. Run the static checks:
```
yarn eslint packages/web-components/src/components/pagination/pagination.ts
yarn prettier --check packages/web-components/src/components/pagination/pagination.ts
```
Test Screenshot
<img width="721" height="144" alt="coverage-test" src="https://github.com/user-attachments/assets/f053eaa2-24b3-4fe2-a59b-431f8d11fb99" />

## PR Checklist
As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
