### PR TITLE
fix: multiselect select all alignment issue for sm and lg sizes

### DIFF
--- a/packages/styles/scss/components/multiselect/_multiselect.scss
+++ b/packages/styles/scss/components/multiselect/_multiselect.scss
@@ -13,6 +13,7 @@
 @use '../../theme' as *;
 @use '../../utilities/convert';
 @use '../../utilities/focus-outline' as *;
+@use '../../utilities/layout';
 
 /// Multi select styles
 /// @access public
@@ -56,7 +57,7 @@
   .#{$prefix}--multi-select.#{$prefix}--multi-select--selectall
     .#{$prefix}--list-box__menu-item:first-child
     .#{$prefix}--list-box__menu-item__option {
-    padding: 0.6875rem $spacing-05;
+    padding: calc((layout.size('height') - 1rem) / 2 - 1px) $spacing-05;
     margin: 0;
     border-block-end: 1px solid $border-subtle-01;
   }

--- a/packages/styles/scss/components/multiselect/_multiselect.scss
+++ b/packages/styles/scss/components/multiselect/_multiselect.scss
@@ -57,7 +57,7 @@
   .#{$prefix}--multi-select.#{$prefix}--multi-select--selectall
     .#{$prefix}--list-box__menu-item:first-child
     .#{$prefix}--list-box__menu-item__option {
-    padding: calc((layout.size('height') - 1rem) / 2 - 1px) $spacing-05;
+    padding: calc((layout.size('height') - 1lh) / 2 - 1px) $spacing-05;
     margin: 0;
     border-block-end: 1px solid $border-subtle-01;
   }


### PR DESCRIPTION
Closes #21556

Fix MultiSelect "Select all" vertical alignment for sm and lg sizes

### Changelog

**Changed**

- Updated MultiSelect "Select all" option padding to use dynamic sizing calculation instead of fixed value, ensuring proper vertical centering across all component sizes (sm, md, lg)

#### Testing / Reviewing

To verify this fix works correctly:

1. **Open Storybook** and navigate to Components > MultiSelect
2. **Test Small Size:**
   - Set `size="sm"` and enable `selectAll`
   - Open the dropdown
   - Verify "Select all" option is vertically centered (not shifted toward bottom)
   - Type in search to filter items
   - Verify "Select all" remains centered
   - Clear search and verify alignment is maintained
3. **Test Large Size:**
   - Set `size="lg"` and enable `selectAll`
   - Open the dropdown
   - Verify "Select all" option is vertically centered (not shifted toward top)
   - Type in search to filter items
   - Verify "Select all" remains centered
   - Clear search and verify alignment is maintained
4. **Test Medium Size (baseline):**
   - Set `size="md"` and enable `selectAll`
   - Verify "Select all" remains properly centered (should already work)

**Expected Result:** The "Select all" option should be vertically centered in its row for all sizes, both before and after filtering.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

**Note:** Documentation and storybook examples don't need updates as this is a visual bug fix with no API changes. The fix uses existing layout utilities and maintains consistency with other menu items.

https://github.com/user-attachments/assets/bf400134-5508-4014-82b5-8b96501c10b7

