### PR TITLE
fix(Button): clamp unsupported sizes to lg for icon-only buttons

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -201,15 +201,14 @@ const Button: ButtonComponent = React.forwardRef(
         align = tooltipPosition;
       }
 
+      // `IconButton` only supports a subset of the `size`s that `Button`
+      // supports. Coerce the larger sizes (`xl`, `2xl`) down to the largest
+      // size `IconButton` supports (`lg`) so icon-only buttons render at a
+      // valid size instead of forwarding an unsupported value.
+      const iconButtonSize =
+        size === 'xl' || size === '2xl' ? 'lg' : size;
+
       return (
-        // @ts-expect-error - `IconButton` does not support all `size`s that
-        // `Button` supports.
-        //
-        // TODO: What should be done here?
-        // 1. Should the `IconButton` not be rendered if the `size` is not
-        //    supported?
-        // 2. Should an error be thrown?
-        // 3. Something else?
         <IconButton
           {...rest}
           ref={ref}
@@ -217,7 +216,7 @@ const Button: ButtonComponent = React.forwardRef(
           align={align}
           label={iconDescription}
           kind={kind}
-          size={size}
+          size={iconButtonSize}
           highContrast={tooltipHighContrast}
           dropShadow={tooltipDropShadow}
           onMouseEnter={onMouseEnter}

--- a/packages/react/src/components/Button/__tests__/Button-test.js
+++ b/packages/react/src/components/Button/__tests__/Button-test.js
@@ -162,6 +162,23 @@ describe('Button', () => {
       expect(screen.getByLabelText('test')).toHaveClass('cds--btn--icon-only');
     });
 
+    it('should clamp unsupported sizes down to `lg` for icon-only buttons', () => {
+      render(
+        <Button hasIconOnly iconDescription="test" renderIcon={Add} size="2xl" />
+      );
+      const button = screen.getByLabelText('test');
+      expect(button).toHaveClass('cds--btn--lg');
+      expect(button).not.toHaveClass('cds--btn--2xl');
+    });
+
+    it('should forward supported sizes unchanged for icon-only buttons', () => {
+      render(
+        <Button hasIconOnly iconDescription="test" renderIcon={Add} size="sm" />
+      );
+      const button = screen.getByLabelText('test');
+      expect(button).toHaveClass('cds--btn--sm');
+    });
+
     it('should support badge indicator', () => {
       render(
         <Button


### PR DESCRIPTION
## Summary

`IconButton` only supports a subset of the `size`s that `Button` supports. When an icon-only `Button` (`hasIconOnly`) was given one of the larger sizes (`xl`, `2xl`), that value was forwarded to `IconButton` unchanged — behind a `@ts-expect-error` with a `TODO` asking what to do — producing an unsupported size.

This PR coerces `xl`/`2xl` down to `lg` (the largest size `IconButton` supports) before forwarding, so icon-only buttons always render at a valid size. The `@ts-expect-error` is removed since the value is now correctly typed.

## Changes

- `Button.tsx`: derive `iconButtonSize`, clamping `xl`/`2xl` → `lg`, and pass it to `IconButton`.
- `Button-test.js`: add tests asserting unsupported sizes clamp to `lg` and supported sizes pass through unchanged.

## Testing

- Added unit tests covering both the clamped (`2xl` → `lg`) and pass-through (`sm`) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)