### PR TITLE
fix(Button): clamp unsupported sizes to lg for icon-only buttons

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -201,15 +201,14 @@ const Button: ButtonComponent = React.forwardRef(
         align = tooltipPosition;
       }
 
+      // `IconButton` only supports a subset of the `size`s that `Button`
+      // supports. Coerce the larger sizes (`xl`, `2xl`) down to the largest
+      // size `IconButton` supports (`lg`) so icon-only buttons render at a
+      // valid size instead of forwarding an unsupported value.
+      const iconButtonSize =
+        size === 'xl' || size === '2xl' ? 'lg' : size;
+
       return (
-        // @ts-expect-error - `IconButton` does not support all `size`s that
-        // `Button` supports.
-        //
-        // TODO: What should be done here?
-        // 1. Should the `IconButton` not be rendered if the `size` is not
-        //    supported?
-        // 2. Should an error be thrown?
-        // 3. Something else?
         <IconButton
           {...rest}
           ref={ref}
@@ -217,7 +216,7 @@ const Button: ButtonComponent = React.forwardRef(
           align={align}
           label={iconDescription}
           kind={kind}
-          size={size}
+          size={iconButtonSize}
           highContrast={tooltipHighContrast}
           dropShadow={tooltipDropShadow}
           onMouseEnter={onMouseEnter}

--- a/packages/react/src/components/Button/__tests__/Button-test.js
+++ b/packages/react/src/components/Button/__tests__/Button-test.js
@@ -162,6 +162,23 @@ describe('Button', () => {
       expect(screen.getByLabelText('test')).toHaveClass('cds--btn--icon-only');
     });
 
+    it('should clamp unsupported sizes down to `lg` for icon-only buttons', () => {
+      render(
+        <Button hasIconOnly iconDescription="test" renderIcon={Add} size="2xl" />
+      );
+      const button = screen.getByLabelText('test');
+      expect(button).toHaveClass('cds--btn--lg');
+      expect(button).not.toHaveClass('cds--btn--2xl');
+    });
+
+    it('should forward supported sizes unchanged for icon-only buttons', () => {
+      render(
+        <Button hasIconOnly iconDescription="test" renderIcon={Add} size="sm" />
+      );
+      const button = screen.getByLabelText('test');
+      expect(button).toHaveClass('cds--btn--sm');
+    });
+
     it('should support badge indicator', () => {
       render(
         <Button


### PR DESCRIPTION
### Summary

Icon-only `Button`s forwarded their `size` straight to `IconButton`, but `IconButton` only supports a subset of the sizes `Button` allows (`xs`/`sm`/`md`/`lg`). The larger sizes (`xl`, `2xl`) were passed through unchanged behind a `@ts-expect-error` with an open `TODO`, producing an invalid size class on icon-only buttons.

This coerces `xl`/`2xl` down to the largest size `IconButton` supports (`lg`) and removes the `@ts-expect-error`/`TODO`.

### Changelog

**Changed**

- Icon-only `Button` now clamps unsupported sizes (`xl`, `2xl`) to `lg` instead of forwarding an invalid `size` to `IconButton`.

**Removed**

- The `@ts-expect-error` and accompanying `TODO` around the `IconButton` `size` prop in `Button`.

#### Testing / Reviewing

- Render `<Button hasIconOnly iconDescription="…" renderIcon={Add} size="2xl" />` and confirm it renders with the `cds--btn--lg` class (not `cds--btn--2xl`).
- Confirm supported sizes (`xs`/`sm`/`md`/`lg`) still pass through unchanged.
- Two unit tests added in `Button-test.js` cover both cases.

## PR Checklist

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples — ~no doc/storybook change needed; behavior is a bug fix for an invalid size~
- [x] Wrote passing tests that cover this change <!-- tests added; run locally was not possible in my environment, relying on CI -->
- [x] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency — ~no visual/markup change beyond size class~
- [ ] Validated that this code is ready for review and status checks should pass — opening as draft pending CI

> Note: opened as a **draft** because lint/test/build could not be run in my local environment; relying on CI to validate before marking ready.
