### PR TITLE
fix: filterableMultiSelect clear icon does not fire input change call…

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -713,6 +713,10 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
         setHighlightedIndex(changes.selectedItem);
         return changes;
       case InputBlur:
+        setInputValue('');
+        setInputFocused(false);
+        setIsOpen(false);
+        return changes;
       case InputKeyDownEscape:
         setIsOpen(false);
         return changes;
@@ -824,6 +828,17 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
       setInputValue('');
     } else {
       setInputValue(value ?? '');
+    }
+
+    // Only trigger callback for mouse events (clear button clicks)
+    // Keyboard events will trigger InputChange naturally through Downshift
+    if (onInputValueChange && event && !('key' in event)) {
+      setInputValue('');
+      onInputValueChange({
+        inputValue: '',
+        type: InputChange,
+      });
+      setIsOpen(false);
     }
 
     if (textInput.current) {
@@ -938,10 +953,6 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
         }
       },
       onFocus: () => setInputFocused(true),
-      onBlur: () => {
-        setInputFocused(false);
-        setInputValue('');
-      },
     })
   );
 

--- a/packages/react/src/components/MultiSelect/__tests__/FilterableMultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/FilterableMultiSelect-test.js
@@ -327,6 +327,38 @@ describe('FilterableMultiSelect', () => {
 
     expect(screen.getByPlaceholderText('test')).toHaveDisplayValue('');
   });
+  it('should trigger onInputValueChange when clicking clear button', async () => {
+    const onInputValueChange = jest.fn();
+    render(
+      <FilterableMultiSelect
+        {...mockProps}
+        placeholder="test"
+        onInputValueChange={onInputValueChange}
+      />
+    );
+    await openMenu();
+
+    // Type some text
+    await userEvent.type(screen.getByPlaceholderText('test'), '3');
+
+    // Clear the callback mock to ignore typing events
+    onInputValueChange.mockClear();
+
+    // Click the clear button
+    const clearButton = screen.getByRole('button', {
+      name: 'Clear selected item',
+    });
+    await userEvent.click(clearButton);
+
+    // Verify the input is cleared
+    expect(screen.getByPlaceholderText('test')).toHaveDisplayValue('');
+
+    // Verify onInputValueChange was called with empty string
+    expect(onInputValueChange).toHaveBeenCalledTimes(1);
+    expect(onInputValueChange).toHaveBeenCalledWith(
+      expect.objectContaining({ inputValue: '' })
+    );
+  });
 
   it('should respect slug prop', async () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
…back

Closes [ISSUE: 22316](https://github.com/carbon-design-system/carbon/issues/22316)

We are seeing an issue with FilterableMultiSelect when using it with server-side search.

When the user types into the filter input, the input callback is triggered correctly. However, when the user clicks the clear icon (X) inside the input, the visible input value is cleared but none of the available callbacks seem to fire.

This leaves the external search state out of sync with the internal input state.

### Changelog

**New**

- {{new thing}}

**Changed**

- Fixed FilterableMultiSelect to properly trigger onInputValueChange callback when the clear button is clicked
- Refactored input blur handling in FilterableMultiSelect to use Downshift's InputBlur state reducer instead of inline onBlur handler
- Updated clear button handler to distinguish between mouse events (clear button clicks) and keyboard events, ensuring callback is only triggered for clear button clicks

**Removed**

- Removed inline onBlur handler from input props in favor of centralized state management through Downshift's state reducer. Also the inline onBlur was calling on click of close icon and which prevents onclick of close button.

#### Testing / Reviewing
- Open the FilterableMultiSelect component in Storybook
- Add an onInputValueChange callback that logs to console
- Type some text in the input field
- Click the clear button (X icon)
- Verify that:
- The input field is cleared
- The onInputValueChange callback is called with inputValue: ''
- The dropdown closes

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
