### PR TITLE
feat: add single theme setting to web components storybook

### DIFF
--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -33,6 +33,7 @@
     flex-direction: column;
     align-items: center;
     padding: 42px;
+    transition: initial;
   }
 
   body #storybook-root {

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -101,16 +101,6 @@ export const globalTypes = {
       ],
     },
   },
-  theme: {
-    name: 'Theme',
-    description: 'Set the global theme for displaying components',
-    defaultValue: 'white',
-    toolbar: {
-      icon: 'paintbrush',
-      title: 'Theme',
-      items: ['white', 'g10', 'g90', 'g100'],
-    },
-  },
   ...(process.env.NODE_ENV === 'development' ? devTools : {}),
 };
 
@@ -141,24 +131,12 @@ export const parameters = {
       cellSize: 8,
       opacity: 0.5,
     },
-    values: [
-      {
-        name: 'white',
-        value: white.background,
-      },
-      {
-        name: 'g10',
-        value: g10.background,
-      },
-      {
-        name: 'g90',
-        value: g90.background,
-      },
-      {
-        name: 'g100',
-        value: g100.background,
-      },
-    ],
+    options: {
+      white: { name: 'white', value: white.background },
+      g10: { name: 'g10', value: g10.background },
+      g90: { name: 'g90', value: g90.background },
+      g100: { name: 'g100', value: g100.background },
+    },
   },
   controls: {
     expanded: true,
@@ -232,11 +210,28 @@ export const parameters = {
   },
 };
 
+// Helper function to map background values to theme names
+function getThemeFromBackground(backgroundValue) {
+  const backgroundThemeMap = {
+    [white.background]: 'white',
+    white: 'white',
+    [g10.background]: 'g10',
+    g10: 'g10',
+    [g90.background]: 'g90',
+    g90: 'g90',
+    [g100.background]: 'g100',
+    g100: 'g100',
+  };
+  return backgroundThemeMap[backgroundValue] ?? 'white';
+}
+
 export const decorators = [
   function decoratorContainer(story, context) {
     const result = story();
     const { hasMainTag } = result;
-    const { locale, dir, theme, layoutSize, layoutDensity } = context.globals;
+    const { locale, dir, layoutSize, layoutDensity } = context.globals;
+    const backgroundValue = context.globals.backgrounds?.value;
+    const theme = getThemeFromBackground(backgroundValue);
 
     if (process.env.STORYBOOK_USE_RTL === 'true') {
       document.documentElement.setAttribute('dir', 'rtl');


### PR DESCRIPTION
Web components version of #22458 which changes storybook to use a single theme selector.

### Changelog

**Changed**
- packages/web-components/.storybook/preview.js
- packages/web-components/.storybook/preview-head.html

#### Testing / Reviewing

Ran up storybook and rant tests

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
