### PR TITLE
fix(search): hide collapsed expandable input from AT and added tests

### DIFF
--- a/packages/react/src/components/ExpandableSearch/ExpandableSearch.tsx
+++ b/packages/react/src/components/ExpandableSearch/ExpandableSearch.tsx
@@ -32,6 +32,7 @@ const ExpandableSearch = frFn((props, forwardedRef) => {
     isSearchValuePresent(defaultValue)
   );
   const searchRef = useRef<HTMLInputElement>(null);
+  const shouldFocusSearchRef = useRef(false);
   const prefix = usePrefix();
 
   function handleBlur(evt) {
@@ -48,13 +49,20 @@ const ExpandableSearch = frFn((props, forwardedRef) => {
     setExpanded(!!isExpanded);
   }, [isExpanded]);
 
+  useEffect(() => {
+    if (expanded && shouldFocusSearchRef.current) {
+      shouldFocusSearchRef.current = false;
+      searchRef.current?.focus?.();
+    }
+  }, [expanded]);
+
   function handleChange(evt) {
     setHasContent(evt.target.value !== '');
   }
 
   function handleExpand() {
+    shouldFocusSearchRef.current = true;
     setExpanded(true);
-    searchRef.current?.focus?.();
   }
 
   function handleKeyDown(evt) {

--- a/packages/react/src/components/Search/Search-test.js
+++ b/packages/react/src/components/Search/Search-test.js
@@ -187,16 +187,68 @@ describe('Search', () => {
     });
 
     it('should have tabbable button and untabbable input if expandable and not expanded', async () => {
-      render(
+      const { container } = render(
         <Search
           labelText="test-search"
           onExpand={() => {}}
           isExpanded={false}
         />
       );
+      const input = container.querySelector('input');
 
       expect(screen.getAllByRole('button')[0]).toHaveAttribute('tabIndex', '0');
-      expect(screen.getByRole('searchbox')).toHaveAttribute('tabIndex', '-1');
+      expect(input).toHaveAttribute('inert');
+      expect(input).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('should not make the input inert if expandable and expanded', () => {
+      const { container } = render(
+        <Search labelText="test-search" onExpand={() => {}} isExpanded />
+      );
+
+      expect(container.querySelector('input')).not.toHaveAttribute('inert');
+    });
+
+    it('should respect input tabIndex and inert props if not expandable', () => {
+      const { container } = render(
+        <Search labelText="test-search" inert tabIndex={-1} />
+      );
+      const input = container.querySelector('input');
+
+      expect(input).toHaveAttribute('inert');
+      expect(input).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('should respect input tabIndex and inert props if expandable and expanded', () => {
+      const { container } = render(
+        <Search
+          labelText="test-search"
+          onExpand={() => {}}
+          isExpanded
+          inert
+          tabIndex={-1}
+        />
+      );
+      const input = container.querySelector('input');
+
+      expect(input).toHaveAttribute('inert');
+      expect(input).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('should enforce collapsed input a11y state even if input props attempt to override it', () => {
+      const { container } = render(
+        <Search
+          labelText="test-search"
+          onExpand={() => {}}
+          isExpanded={false}
+          inert={false}
+          tabIndex={0}
+        />
+      );
+      const input = container.querySelector('input');
+
+      expect(input).toHaveAttribute('inert');
+      expect(input).toHaveAttribute('tabIndex', '-1');
     });
 
     it('should have tabbable input and untabbable button if not expandable', async () => {

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -135,6 +135,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       defaultValue,
       disabled,
       isExpanded = true,
+      inert,
       id,
       labelText,
       // @ts-expect-error: deprecated prop
@@ -147,6 +148,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       renderIcon,
       role,
       size,
+      tabIndex,
       type = 'search',
       value,
       ...rest
@@ -164,6 +166,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
     const uniqueId = id || inputId;
     const searchId = `${uniqueId}-search`;
     const [hasContent, setHasContent] = useState(hasPropValue || false);
+    const isExpandableCollapsed = !!onExpand && !isExpanded;
     const searchClasses = cx(
       {
         [`${prefix}--search`]: true,
@@ -254,7 +257,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
         className={`${prefix}--search-magnifier`}
         onClick={onExpand}
         onKeyDown={handleExpandButtonKeyDown}
-        tabIndex={onExpand && !isExpanded ? 0 : -1}
+        tabIndex={isExpandableCollapsed ? 0 : -1}
         ref={expandButtonRef}
         aria-expanded={
           onExpand && isExpanded
@@ -303,8 +306,9 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
           placeholder={placeholder}
           type={type}
           value={value}
-          tabIndex={onExpand && !isExpanded ? -1 : undefined}
           {...rest}
+          inert={isExpandableCollapsed ? true : inert}
+          tabIndex={isExpandableCollapsed ? -1 : tabIndex}
         />
         <button
           aria-label={closeButtonLabelText}


### PR DESCRIPTION
Closes #16636

Fixes an accessibility issue where collapsed `ExpandableSearch` could still expose the hidden input to screen-reader browse/arrow navigation.

I first looked at using [`visibility: hidden`](https://github.com/carbon-design-system/carbon/issues/16636#issuecomment-4612632216), but in testing that caused regressions around the expandable search tooltip caret.

<img width="216" height="200" alt="image" src="https://github.com/user-attachments/assets/51f2968f-171b-4f69-904f-23d6c3f9ad76" />

We already treated the collapsed input as unavailable to keyboard Tab navigation. So, this PR extends that same behavior to screen-reader browse/arrow navigation by making the collapsed input inert until the search is expanded.

Divya from the a11y team confirmed that the browse/arrow navigation issue is fixed in the deploy preview. See manual verification screenshot below.

### Changelog

**New**

- Added tests for collapsed expandable Search input `inert` and `tabIndex` behavior.

**Changed**

- Collapsed `ExpandableSearch` now prevents the hidden input from being reached by screen-reader browse/arrow navigation.

**Removed**

- ~None.~

#### Testing / Reviewing

yarn tests should pass 

- Go to `React Deploy Preview` > `Search` > `Expandable with layer`
- With each search collapsed, verify `Tab` lands on the magnifier button, not the hidden input
- With a screen reader, use browse/arrow navigation through the collapsed searches
- Verify the collapsed hidden input is not announced as an edit/search field and the placeholder is not announced
- Expand a search and verify the input is focused and announced normally

Like this:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/86608db9-d02e-43ba-b7c9-69bdf711b6d7" />

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)