### PR TITLE
chore: sync README contributor table with all-contributors generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,6 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/saiteja-nizam"><img src="https://avatars.githubusercontent.com/u/88249670?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Saiteja Nizam</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=saiteja-nizam" title="Code">💻</a></td>
-  </tr>
-  <tr>
     <td align="center"><a href="https://github.com/wkeese"><img src="https://avatars.githubusercontent.com/u/69599?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bill Keese</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=wkeese" title="Code">💻</a></td>
   </tr>
 </table>


### PR DESCRIPTION
Closes N/A

saiteja-nizam and wkeese were manually split across two rows in #22490 using --no-verify. With 233 contributors at 7 per line the tool places both in the same last row. Run all-contributors generate to restore canonical output so the pre-commit hook no longer rewrites README on every touch.

### Changelog

**Removed**

- removed new row by running all-contributors generate

#### Testing / Reviewing
this must look good once merged

<img width="912" height="701" alt="Screenshot 2026-06-27 at 1 12 24 AM" src="https://github.com/user-attachments/assets/c6f73d2b-d29a-46f7-b08e-de983dc9550f" />

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
