### PR TITLE
fix(web-components): replace querySelector usage with @query decorator in accordion (#22500)

### DIFF
--- a/packages/web-components/src/components/accordion/accordion-item.ts
+++ b/packages/web-components/src/components/accordion/accordion-item.ts
@@ -262,10 +262,6 @@ class CDSAccordionItem extends FocusMixin(LitElement) {
     return `${prefix}-accordion-item-toggled`;
   }
 
-  static get selectorAccordionContent() {
-    return `.${prefix}--accordion__content`;
-  }
-
   static styles = styles;
 }
 

--- a/packages/web-components/src/components/accordion/accordion-item.ts
+++ b/packages/web-components/src/components/accordion/accordion-item.ts
@@ -7,7 +7,7 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import ChevronRight16 from '@carbon/icons/es/chevron--right/16.js';
 import { iconLoader } from '../../globals/internal/icon-loader';
@@ -52,6 +52,12 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
 @customElement(`${prefix}-accordion-item`)
 class CDSAccordionItem extends FocusMixin(LitElement) {
   /**
+   * The accordion content container.
+   */
+  @query(`.${prefix}--accordion__content`)
+  private _accordionContent!: HTMLDivElement;
+
+  /**
    * The current breakpoint.
    */
   private _currentBreakpoint?: ACCORDION_ITEM_BREAKPOINT;
@@ -83,18 +89,12 @@ class CDSAccordionItem extends FocusMixin(LitElement) {
         )
       )
     ) {
-      const { selectorAccordionContent } = this
-        .constructor as typeof CDSAccordionItem;
-
       if (!this.open) {
         this.setAttribute('expanding', '');
       } else {
         this.setAttribute('collapsing', '');
       }
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      this.shadowRoot!.querySelector(
-        selectorAccordionContent
-      )!.addEventListener('animationend', () => {
+      this._accordionContent?.addEventListener('animationend', () => {
         this.removeAttribute('expanding');
         this.removeAttribute('collapsing');
       });

--- a/packages/web-components/src/components/accordion/accordion-skeleton.ts
+++ b/packages/web-components/src/components/accordion/accordion-skeleton.ts
@@ -7,7 +7,7 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAll } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import { ACCORDION_ALIGNMENT } from './accordion';
 import { forEach } from '../../globals/internal/collection-helpers';
@@ -48,15 +48,17 @@ class CDSAccordionSkeleton extends LitElement {
   @property({ type: Boolean, reflect: true })
   open = true;
 
+  /**
+   * The accordion item skeleton elements.
+   */
+  @queryAll(`${prefix}-accordion-item-skeleton`)
+  private _accordionItemSkeletons!: NodeListOf<HTMLElement>;
+
   updated(changedProperties) {
     if (changedProperties.has('alignment')) {
       // Propagate `alignment` attribute to descendants until `:host-context()` gets supported in all major browsers
       forEach(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-        this.shadowRoot!.querySelectorAll(
-          (this.constructor as typeof CDSAccordionSkeleton)
-            .selectorAccordionItemSkeletons
-        ),
+        this._accordionItemSkeletons,
         (elem) => {
           elem.setAttribute('alignment', this.alignment);
         }
@@ -68,11 +70,7 @@ class CDSAccordionSkeleton extends LitElement {
     ) {
       // Propagate `isFlush` attribute to descendants until `:host-context()` gets supported in all major browsers
       forEach(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-        this.shadowRoot!.querySelectorAll(
-          (this.constructor as typeof CDSAccordionSkeleton)
-            .selectorAccordionItemSkeletons
-        ),
+        this._accordionItemSkeletons,
         (elem) => {
           if (this.isFlush && this.alignment !== 'start') {
             elem.setAttribute('isFlush', '');

--- a/packages/web-components/src/components/accordion/accordion-skeleton.ts
+++ b/packages/web-components/src/components/accordion/accordion-skeleton.ts
@@ -57,28 +57,22 @@ class CDSAccordionSkeleton extends LitElement {
   updated(changedProperties) {
     if (changedProperties.has('alignment')) {
       // Propagate `alignment` attribute to descendants until `:host-context()` gets supported in all major browsers
-      forEach(
-        this._accordionItemSkeletons,
-        (elem) => {
-          elem.setAttribute('alignment', this.alignment);
-        }
-      );
+      forEach(this._accordionItemSkeletons, (elem) => {
+        elem.setAttribute('alignment', this.alignment);
+      });
     }
     if (
       changedProperties.has('isFlush') ||
       changedProperties.has('alignment')
     ) {
       // Propagate `isFlush` attribute to descendants until `:host-context()` gets supported in all major browsers
-      forEach(
-        this._accordionItemSkeletons,
-        (elem) => {
-          if (this.isFlush && this.alignment !== 'start') {
-            elem.setAttribute('isFlush', '');
-          } else {
-            elem.removeAttribute('isFlush');
-          }
+      forEach(this._accordionItemSkeletons, (elem) => {
+        if (this.isFlush && this.alignment !== 'start') {
+          elem.setAttribute('isFlush', '');
+        } else {
+          elem.removeAttribute('isFlush');
         }
-      );
+      });
     }
   }
 
@@ -119,10 +113,6 @@ class CDSAccordionSkeleton extends LitElement {
             arr.length - 1}></cds-accordion-item-skeleton>`
       )}
     `;
-  }
-
-  static get selectorAccordionItemSkeletons() {
-    return `${prefix}-accordion-item-skeleton`;
   }
 
   static styles = styles;


### PR DESCRIPTION
Closes #22500

Replaces `querySelector` usage in the accordion web component with Lit’s `@query` decorator for cleaner, declarative element access and improved maintainability.


### Changelog

**New**

- {{new thing}}

**Changed**
- Replaced `querySelector` with `@query` in `packages/web-components/src/components/accordion/accordion-item.ts`
- Replaced `querySelectorAll` with `@queryAll` in `packages/web-components/src/components/accordion/accordion-skeleton.ts`

**Removed**

- {{removed thing}}

#### Testing / Reviewing
This is a purely internal refactor. No visual or functional changes have been made. Reviewers can verify by ensuring the automated tests pass successfully.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
