### PR TITLE
fix: MenuButton container is wider than the visible button in Firefox…

### DIFF
--- a/packages/styles/scss/components/menu-button/_menu-button.scss
+++ b/packages/styles/scss/components/menu-button/_menu-button.scss
@@ -16,7 +16,7 @@
 /// @group menu-button
 @mixin menu-button {
   .#{$prefix}--menu-button__container {
-    display: contents;
+    display: inline-flex;
   }
 
   .#{$prefix}--menu-button__trigger:not(.#{$prefix}--btn--ghost) {


### PR DESCRIPTION
Closes #22088

Fixes MenuButton container is wider than the visible button issue in Firefox

### Changelog


**Changed**

- Changed `.cds--menu-button__container` display property from `contents` to `inline-flex` to fix Firefox-specific sizing issue where the container was wider than the visible button
**Root cause**
The display: contents CSS property has known compatibility issues in Firefox, particularly with sizing and layout calculations. Changing to display: inline-flex ensures proper containing block behavior across all browsers.
<img width="1062" height="899" alt="image" src="https://github.com/user-attachments/assets/3496ef53-be1a-4c2e-b9fa-1abfdf921399" />
<img width="1049" height="871" alt="image" src="https://github.com/user-attachments/assets/b7588ff7-18f2-4a92-ae08-dd5f184ff390" />

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [✓] Reviewed every line of the diff
- [ ] <del>Updated documentation and storybook examples</del>
- [ ]  <del>Wrote passing tests that cover this change</del>
- [ ]  <del>Addressed any impact on accessibility (a11y)</del>
- [✓] Tested for cross-browser consistency
- [✓] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
