### PR TITLE
fix(textArea): prevent invalid/warn states when disabled/readonly

### DIFF
--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -642,6 +642,52 @@ describe('TextArea', () => {
   });
 
   describe('invalid and warn states are suppressed when not interactive', () => {
+    describe('normal (interactive) inputs still show validation states', () => {
+      it('should apply invalid CSS class when invalid and interactive', () => {
+        const { container } = render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+          />
+        );
+        expect(screen.getByRole('textbox')).toHaveClass(
+          `${prefix}--text-area--invalid`
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(`svg.${prefix}--text-area__invalid-icon`)
+        ).toBeInTheDocument();
+        expect(screen.getByText('Some error')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+          'aria-invalid',
+          'true'
+        );
+      });
+
+      it('should apply warn CSS class when warn and interactive', () => {
+        const { container } = render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+          />
+        );
+        expect(screen.getByRole('textbox')).toHaveClass(
+          `${prefix}--text-area--warn`
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(
+            `svg.${prefix}--text-area__invalid-icon--warning`
+          )
+        ).toBeInTheDocument();
+        expect(screen.getByText('Some warning')).toBeInTheDocument();
+      });
+    });
+
     describe('disabled', () => {
       it('should not apply invalid CSS class when disabled', () => {
         render(

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -640,4 +640,252 @@ describe('TextArea', () => {
       });
     });
   });
+
+  describe('invalid and warn states are suppressed when not interactive', () => {
+    describe('disabled', () => {
+      it('should not apply invalid CSS class when disabled', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-area--invalid`
+        );
+      });
+
+      it('should not render the invalid icon when disabled', () => {
+        const { container } = render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(`svg.${prefix}--text-area__invalid-icon`)
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the invalidText message when disabled', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.queryByText('Some error')).not.toBeInTheDocument();
+      });
+
+      it('should set aria-invalid to false when disabled', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+          'aria-invalid',
+          'false'
+        );
+      });
+
+      it('should not set aria-errormessage when disabled', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveAttribute(
+          'aria-errormessage'
+        );
+      });
+
+      it('should not apply warn CSS class when disabled', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-area--warn`
+        );
+      });
+
+      it('should not render the warn icon when disabled', () => {
+        const { container } = render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+            disabled
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(
+            `svg.${prefix}--text-area__invalid-icon--warning`
+          )
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the warnText message when disabled', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+            disabled
+          />
+        );
+        expect(screen.queryByText('Some warning')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('readOnly', () => {
+      it('should not apply invalid CSS class when readOnly', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-area--invalid`
+        );
+      });
+
+      it('should not render the invalid icon when readOnly', () => {
+        const { container } = render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(`svg.${prefix}--text-area__invalid-icon`)
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the invalidText message when readOnly', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.queryByText('Some error')).not.toBeInTheDocument();
+      });
+
+      it('should set aria-invalid to false when readOnly', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+          'aria-invalid',
+          'false'
+        );
+      });
+
+      it('should not set aria-errormessage when readOnly', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveAttribute(
+          'aria-errormessage'
+        );
+      });
+
+      it('should not apply warn CSS class when readOnly', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-area--warn`
+        );
+      });
+
+      it('should not render the warn icon when readOnly', () => {
+        const { container } = render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+            readOnly
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(
+            `svg.${prefix}--text-area__invalid-icon--warning`
+          )
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the warnText message when readOnly', () => {
+        render(
+          <TextArea
+            id="textarea-1"
+            labelText="TextArea label"
+            warn
+            warnText="Some warning"
+            readOnly
+          />
+        );
+        expect(screen.queryByText('Some warning')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -18,6 +18,7 @@ import React, {
 import classNames from 'classnames';
 import { deprecate } from '../../prop-types/deprecate';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
+import { useNormalizedInputProps } from '../../internal/useNormalizedInputProps';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { getAnnouncement } from '../../internal/getAnnouncement';
@@ -196,6 +197,16 @@ const TextArea = frFn((props, forwardRef) => {
   const { isFluid } = useContext(FormContext);
   const { defaultValue, value } = other;
 
+  const normalizedProps = useNormalizedInputProps({
+    id: id ?? '',
+    readOnly: other.readOnly,
+    disabled,
+    invalid,
+    invalidText,
+    warn,
+    warnText,
+  });
+
   const textAreaInstanceId = useId();
 
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -356,29 +367,29 @@ const TextArea = frFn((props, forwardRef) => {
   const textAreaWrapperClasses = classNames(`${prefix}--text-area__wrapper`, {
     [`${prefix}--text-area__wrapper--cols`]: other.cols,
     [`${prefix}--text-area__wrapper--readonly`]: other.readOnly,
-    [`${prefix}--text-area__wrapper--warn`]: warn,
+    [`${prefix}--text-area__wrapper--warn`]: normalizedProps.warn,
     [`${prefix}--text-area__wrapper--slug`]: slug,
     [`${prefix}--text-area__wrapper--decorator`]: decorator,
   });
 
   const labelClasses = classNames(`${prefix}--label`, {
     [`${prefix}--visually-hidden`]: hideLabel && !isFluid,
-    [`${prefix}--label--disabled`]: disabled,
+    [`${prefix}--label--disabled`]: normalizedProps.disabled,
   });
 
   const textareaClasses = classNames(`${prefix}--text-area`, {
     [`${prefix}--text-area--light`]: light,
-    [`${prefix}--text-area--invalid`]: invalid,
-    [`${prefix}--text-area--warn`]: warn,
+    [`${prefix}--text-area--invalid`]: normalizedProps.invalid,
+    [`${prefix}--text-area--warn`]: normalizedProps.warn,
   });
 
   const counterClasses = classNames(`${prefix}--label`, {
-    [`${prefix}--label--disabled`]: disabled,
+    [`${prefix}--label--disabled`]: normalizedProps.disabled,
     [`${prefix}--text-area__label-counter`]: true,
   });
 
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
-    [`${prefix}--form__helper-text--disabled`]: disabled,
+    [`${prefix}--form__helper-text--disabled`]: normalizedProps.disabled,
   });
 
   const label = typeof labelText !== 'undefined' && labelText !== null && (
@@ -415,14 +426,12 @@ const TextArea = frFn((props, forwardRef) => {
     </Text>
   );
 
-  const errorId = id + '-error-msg';
-
-  const error = invalid ? (
+  const error = normalizedProps.invalid ? (
     <Text
       as="div"
       role="alert"
       className={`${prefix}--form-requirement`}
-      id={errorId}
+      id={normalizedProps.invalidId}
       ref={errorTextRef}>
       {invalidText}
       {isFluid && (
@@ -431,14 +440,12 @@ const TextArea = frFn((props, forwardRef) => {
     </Text>
   ) : null;
 
-  const warnId = id + '-warn-msg';
-
-  const warning = warn ? (
+  const warning = normalizedProps.warn ? (
     <Text
       as="div"
       role="alert"
       className={`${prefix}--form-requirement`}
-      id={warnId}
+      id={normalizedProps.warnId}
       ref={warnTextRef}>
       {warnText}
       {isFluid && (
@@ -451,10 +458,10 @@ const TextArea = frFn((props, forwardRef) => {
 
   let ariaDescribedBy;
   let ariaErrorMessage;
-  if (invalid) {
-    ariaErrorMessage = errorId;
-  } else if (warn && !isFluid) {
-    ariaDescribedBy = warnId;
+  if (normalizedProps.invalid) {
+    ariaErrorMessage = normalizedProps.invalidId;
+  } else if (normalizedProps.warn && !isFluid) {
+    ariaDescribedBy = normalizedProps.warnId;
   } else {
     const ids: string[] = [];
     if (!isFluid && hasHelper && helperId) ids.push(helperId);
@@ -512,10 +519,10 @@ const TextArea = frFn((props, forwardRef) => {
       placeholder={placeholder}
       aria-readonly={other.readOnly}
       className={textareaClasses}
-      aria-invalid={invalid}
+      aria-invalid={normalizedProps.invalid}
       aria-describedby={ariaDescribedBy}
       aria-errormessage={ariaErrorMessage}
-      disabled={disabled}
+      disabled={normalizedProps.disabled}
       rows={rows}
       readOnly={other.readOnly}
       ref={ref}
@@ -547,11 +554,11 @@ const TextArea = frFn((props, forwardRef) => {
       <div
         ref={wrapperRef}
         className={textAreaWrapperClasses}
-        data-invalid={invalid || null}>
-        {invalid && !isFluid && (
+        data-invalid={normalizedProps.invalid || null}>
+        {normalizedProps.invalid && !isFluid && (
           <WarningFilled className={`${prefix}--text-area__invalid-icon`} />
         )}
-        {warn && !invalid && !isFluid && (
+        {normalizedProps.warn && !isFluid && (
           <WarningAltFilled
             className={`${prefix}--text-area__invalid-icon ${prefix}--text-area__invalid-icon--warning`}
           />
@@ -575,12 +582,14 @@ const TextArea = frFn((props, forwardRef) => {
           {ariaAnnouncement}
         </span>
         {isFluid && <hr className={`${prefix}--text-area__divider`} />}
-        {isFluid && invalid ? error : null}
-        {isFluid && warn && !invalid ? warning : null}
+        {isFluid && normalizedProps.invalid ? error : null}
+        {isFluid && normalizedProps.warn ? warning : null}
       </div>
-      {!invalid && !warn && !isFluid ? helper : null}
-      {invalid && !isFluid ? error : null}
-      {warn && !invalid && !isFluid ? warning : null}
+      {!normalizedProps.invalid && !normalizedProps.warn && !isFluid
+        ? helper
+        : null}
+      {normalizedProps.invalid && !isFluid ? error : null}
+      {normalizedProps.warn && !isFluid ? warning : null}
     </div>
   );
 });

--- a/packages/web-components/src/components/fluid-textarea/__tests__/fluid-textarea-test.js
+++ b/packages/web-components/src/components/fluid-textarea/__tests__/fluid-textarea-test.js
@@ -41,14 +41,34 @@ describe('cds-fluid-textarea', () => {
     expect(el.value).to.equal('Updated content');
   });
 
-  it('should support readonly and disabled attributes', async () => {
+  it('should support readonly attribute', async () => {
+    const el = await fixture(html`
+      <cds-fluid-textarea readonly></cds-fluid-textarea>
+    `);
+
+    const textarea = el.shadowRoot.querySelector('textarea');
+    expect(textarea.readOnly).to.be.true;
+    expect(textarea.disabled).to.be.false;
+  });
+
+  it('should support disabled attribute', async () => {
+    const el = await fixture(html`
+      <cds-fluid-textarea disabled></cds-fluid-textarea>
+    `);
+
+    const textarea = el.shadowRoot.querySelector('textarea');
+    expect(textarea.disabled).to.be.true;
+    expect(textarea.readOnly).to.be.false;
+  });
+
+  it('should not disable the textarea when both readonly and disabled are set (readonly takes precedence)', async () => {
     const el = await fixture(html`
       <cds-fluid-textarea readonly disabled></cds-fluid-textarea>
     `);
 
     const textarea = el.shadowRoot.querySelector('textarea');
     expect(textarea.readOnly).to.be.true;
-    expect(textarea.disabled).to.be.true;
+    expect(textarea.disabled).to.be.false;
   });
 
   it('should show invalid text when invalid is set', async () => {

--- a/packages/web-components/src/components/textarea/__tests__/textarea-test.js
+++ b/packages/web-components/src/components/textarea/__tests__/textarea-test.js
@@ -253,4 +253,178 @@ describe('cds-textarea', () => {
       expect(content.textContent.trim()).to.equal('Slotted Warning');
     });
   });
+
+  describe('invalid and warn states are suppressed when not interactive', () => {
+    describe('disabled', () => {
+      it('should not apply invalid CSS class when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            disabled
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const textarea = el.shadowRoot.querySelector('textarea');
+        expect(textarea.classList.contains('cds--text-area--invalid')).to.be
+          .false;
+      });
+
+      it('should not render the invalid icon when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            disabled
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-area__invalid-icon:not(.cds--text-area__invalid-icon--warning)'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the invalid message when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            disabled
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement.hidden).to.be.true;
+      });
+
+      it('should not set data-invalid on the wrapper when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            disabled
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const wrapper = el.shadowRoot.querySelector('.cds--text-area__wrapper');
+        expect(wrapper.hasAttribute('data-invalid')).to.be.false;
+      });
+
+      it('should not apply warn CSS class when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea disabled warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const textarea = el.shadowRoot.querySelector('textarea');
+        expect(textarea.classList.contains('cds--text-area--warn')).to.be.false;
+      });
+
+      it('should not render the warn icon when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea disabled warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-area__invalid-icon--warning'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the warn message when disabled', async () => {
+        const el = await fixture(html`
+          <cds-textarea disabled warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement.hidden).to.be.true;
+      });
+    });
+
+    describe('readonly', () => {
+      it('should not apply invalid CSS class when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            readonly
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const textarea = el.shadowRoot.querySelector('textarea');
+        expect(textarea.classList.contains('cds--text-area--invalid')).to.be
+          .false;
+      });
+
+      it('should not render the invalid icon when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            readonly
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-area__invalid-icon:not(.cds--text-area__invalid-icon--warning)'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the invalid message when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            readonly
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement.hidden).to.be.true;
+      });
+
+      it('should not set data-invalid on the wrapper when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea
+            readonly
+            invalid
+            invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const wrapper = el.shadowRoot.querySelector('.cds--text-area__wrapper');
+        expect(wrapper.hasAttribute('data-invalid')).to.be.false;
+      });
+
+      it('should not apply warn CSS class when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea readonly warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const textarea = el.shadowRoot.querySelector('textarea');
+        expect(textarea.classList.contains('cds--text-area--warn')).to.be.false;
+      });
+
+      it('should not render the warn icon when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea readonly warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-area__invalid-icon--warning'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the warn message when readonly', async () => {
+        const el = await fixture(html`
+          <cds-textarea readonly warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement.hidden).to.be.true;
+      });
+    });
+  });
 });

--- a/packages/web-components/src/components/textarea/__tests__/textarea-test.js
+++ b/packages/web-components/src/components/textarea/__tests__/textarea-test.js
@@ -52,14 +52,30 @@ describe('cds-textarea', () => {
     expect(el.value).to.equal('Updated content');
   });
 
-  it('should support readonly and disabled attributes', async () => {
+  it('should support readonly attribute', async () => {
+    const el = await fixture(html` <cds-textarea readonly></cds-textarea> `);
+
+    const textarea = el.shadowRoot.querySelector('textarea');
+    expect(textarea.readOnly).to.be.true;
+    expect(textarea.disabled).to.be.false;
+  });
+
+  it('should support disabled attribute', async () => {
+    const el = await fixture(html` <cds-textarea disabled></cds-textarea> `);
+
+    const textarea = el.shadowRoot.querySelector('textarea');
+    expect(textarea.disabled).to.be.true;
+    expect(textarea.readOnly).to.be.false;
+  });
+
+  it('should not disable the textarea when both readonly and disabled are set (readonly takes precedence)', async () => {
     const el = await fixture(html`
       <cds-textarea readonly disabled></cds-textarea>
     `);
 
     const textarea = el.shadowRoot.querySelector('textarea');
     expect(textarea.readOnly).to.be.true;
-    expect(textarea.disabled).to.be.true;
+    expect(textarea.disabled).to.be.false;
   });
 
   it('should show invalid text when invalid is set', async () => {
@@ -255,6 +271,50 @@ describe('cds-textarea', () => {
   });
 
   describe('invalid and warn states are suppressed when not interactive', () => {
+    describe('normal (interactive) inputs still show validation states', () => {
+      it('should apply invalid CSS class and show message when invalid and interactive', async () => {
+        const el = await fixture(html`
+          <cds-textarea invalid invalid-text="Some error"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const textarea = el.shadowRoot.querySelector('textarea');
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-area__invalid-icon:not(.cds--text-area__invalid-icon--warning)'
+        );
+        expect(textarea.classList.contains('cds--text-area--invalid')).to.be
+          .true;
+        expect(requirement.hidden).to.be.false;
+        expect(requirement.textContent).to.include('Some error');
+        expect(icon).to.exist;
+        expect(
+          el.shadowRoot
+            .querySelector('.cds--text-area__wrapper')
+            .hasAttribute('data-invalid')
+        ).to.be.true;
+      });
+
+      it('should apply warn CSS class and show message when warn and interactive', async () => {
+        const el = await fixture(html`
+          <cds-textarea warn warn-text="Some warning"></cds-textarea>
+        `);
+        await el.updateComplete;
+        const textarea = el.shadowRoot.querySelector('textarea');
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-area__invalid-icon--warning'
+        );
+        expect(textarea.classList.contains('cds--text-area--warn')).to.be.true;
+        expect(requirement.hidden).to.be.false;
+        expect(requirement.textContent).to.include('Some warning');
+        expect(icon).to.exist;
+      });
+    });
+
     describe('disabled', () => {
       it('should not apply invalid CSS class when disabled', async () => {
         const el = await fixture(html`

--- a/packages/web-components/src/components/textarea/textarea.ts
+++ b/packages/web-components/src/components/textarea/textarea.ts
@@ -181,35 +181,63 @@ class CDSTextarea extends CDSTextInput {
       class: `${prefix}--text-area__invalid-icon ${prefix}--text-area__invalid-icon--warning`,
     });
 
+    // Suppress invalid/warn when the field is readonly or disabled, matching
+    // the behaviour of CDSTextInput and the React useNormalizedInputProps hook.
+    const normalizedProps: {
+      disabled: boolean;
+      invalid: boolean;
+      warn: boolean;
+      'slot-name': string;
+      'slot-text': string;
+      icon: ReturnType<typeof iconLoader>;
+    } = {
+      disabled: !this.readonly && this.disabled,
+      invalid: !this.readonly && this.invalid,
+      warn: !this.readonly && !this.invalid && this.warn,
+      'slot-name': '',
+      'slot-text': '',
+      icon: null,
+    };
+
+    if (normalizedProps.invalid) {
+      normalizedProps.icon = invalidIcon;
+      normalizedProps['slot-name'] = 'invalid-text';
+      normalizedProps['slot-text'] = this.invalidText;
+    } else if (normalizedProps.warn) {
+      normalizedProps.icon = warnIcon;
+      normalizedProps['slot-name'] = 'warn-text';
+      normalizedProps['slot-text'] = this.warnText;
+    }
+
     const textareaClasses = classMap({
       [`${prefix}--text-area`]: true,
-      [`${prefix}--text-area--warn`]: this.warn,
-      [`${prefix}--text-area--invalid`]: this.invalid,
+      [`${prefix}--text-area--warn`]: normalizedProps.warn,
+      [`${prefix}--text-area--invalid`]: normalizedProps.invalid,
       [`${prefix}--text-area__wrapper--decorator`]: this._hasAILabel,
     });
 
     const textareaWrapperClasses = classMap({
       [`${prefix}--text-area__wrapper`]: true,
       [`${prefix}--text-area__wrapper--cols`]: this.cols,
-      [`${prefix}--text-area__wrapper--warn`]: this.warn,
+      [`${prefix}--text-area__wrapper--warn`]: normalizedProps.warn,
       [`${prefix}--text-area__wrapper--readonly`]: this.readonly,
     });
 
     const labelClasses = classMap({
       [`${prefix}--label`]: true,
       [`${prefix}--visually-hidden`]: this.hideLabel,
-      [`${prefix}--label--disabled`]: this.disabled,
+      [`${prefix}--label--disabled`]: normalizedProps.disabled,
     });
 
     const counterClasses = classMap({
       [`${prefix}--label`]: true,
-      [`${prefix}--label--disabled`]: this.disabled,
+      [`${prefix}--label--disabled`]: normalizedProps.disabled,
       [`${prefix}--text-area__label-counter`]: true,
     });
 
     const helperTextClasses = classMap({
       [`${prefix}--form__helper-text`]: true,
-      [`${prefix}--form__helper-text--disabled`]: this.disabled,
+      [`${prefix}--form__helper-text--disabled`]: normalizedProps.disabled,
     });
 
     const counter =
@@ -223,34 +251,19 @@ class CDSTextarea extends CDSTextInput {
           </label>`
         : null;
 
-    const icon = () => {
-      if (this.invalid) {
-        return invalidIcon;
-      } else if (this.warn && !this.invalid) {
-        return warnIcon;
-      }
-      return null;
-    };
-
     const helper = html`
       <div class="${helperTextClasses}" id="helper-text">
         <slot name="helper-text">${this.helperText}</slot>
       </div>
     `;
 
-    const normalizedProps = {
-      invalid: this.invalid,
-      warn: this.warn,
-      'slot-name': this.invalid ? 'invalid-text' : 'warn-text',
-      'slot-text': this.invalid ? this.invalidText : this.warnText,
-    };
-
     const validationMessage = html`
       <div
         class="${prefix}--form-requirement"
         ?hidden="${!normalizedProps.invalid && !normalizedProps.warn}">
         <slot name="${normalizedProps['slot-name']}">
-          ${normalizedProps['slot-text']} ${this.isFluid ? icon() : null}
+          ${normalizedProps['slot-text']}
+          ${this.isFluid ? normalizedProps.icon : null}
         </slot>
       </div>
     `;
@@ -262,15 +275,17 @@ class CDSTextarea extends CDSTextInput {
         </label>
         ${counter}
       </div>
-      <div class="${textareaWrapperClasses}" ?data-invalid="${this.invalid}">
-        ${!this.isFluid ? icon() : null}
+      <div
+        class="${textareaWrapperClasses}"
+        ?data-invalid="${normalizedProps.invalid}">
+        ${!this.isFluid ? normalizedProps.icon : null}
         <textarea
           autocomplete="${this.autocomplete}"
           ?autofocus="${this.autofocus}"
           class="${textareaClasses}"
           cols="${ifDefined(this.cols)}"
-          ?data-invalid="${this.invalid}"
-          ?disabled="${this.disabled}"
+          ?data-invalid="${normalizedProps.invalid}"
+          ?disabled="${normalizedProps.disabled}"
           id="input"
           name="${ifNonEmpty(this.name)}"
           pattern="${ifNonEmpty(this.pattern)}"

--- a/packages/web-components/src/components/textarea/textarea.ts
+++ b/packages/web-components/src/components/textarea/textarea.ts
@@ -192,8 +192,8 @@ class CDSTextarea extends CDSTextInput {
       icon: ReturnType<typeof iconLoader>;
     } = {
       disabled: !this.readonly && this.disabled,
-      invalid: !this.readonly && this.invalid,
-      warn: !this.readonly && !this.invalid && this.warn,
+      invalid: !this.readonly && !this.disabled && this.invalid,
+      warn: !this.readonly && !this.disabled && !this.invalid && this.warn,
       'slot-name': '',
       'slot-text': '',
       icon: null,


### PR DESCRIPTION
Closes #20726

Fixed TextArea components in both React and Web Components to not show invalid/warn states when in disabled or readonly state, as users cannot interact with these components in those states.


### Changelog

**Changed**

- Modified TextArea component to disallow invalid & warn states when readonly or disabled.
- Added tests to verify the behavior


#### Testing / Reviewing

-Verify that ComboBox does not display invalid or warning states when readonly or disabled
- Run tests for the web component version to ensure all tests pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
