### PR TITLE
fix(popover): apply hover styles only on supported devices

### DIFF
--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -120,8 +120,10 @@ $popover-caret-height: custom-property.get-var(
     @include focus-outline('outline');
   }
 
-  &:hover {
-    background-color: theme.$layer-hover;
+  @media (any-hover: hover) {
+    &:hover {
+      background-color: theme.$layer-hover;
+    }
   }
 
   svg {


### PR DESCRIPTION
Closes #22596

Apply Popover hover styles only on devices that support hover to avoid sticky hover behavior on touch and hybrid devices.

### Changelog

**New**

- None

**Changed**

- Updated Popover tab-tip button hover styles to use `@media (any-hover: hover)`

**Removed**

- None


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- <del>[ ] Updated documentation and storybook examples</del>
- <del>[ ] Wrote passing tests that cover this change</del>
- [x] Addressed any impact on accessibility (a11y)
- <del>[ ] Tested for cross-browser consistency</del>
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
