### PR TITLE
test(ProgressIndicator): use web-first state assertions

### DIFF
--- a/e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js
+++ b/e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js
@@ -54,7 +54,7 @@ test.describe('@avt ProgressIndicator', () => {
     });
 
     // Checking if the 'complete' prop is adding the correct class
-    expect(page.locator('.cds--progress-step--complete')).toBeTruthy();
+    await expect(page.locator('.cds--progress-step--complete')).toBeVisible();
   });
 
   test('@avt-advanced-states', async ({ page }) => {
@@ -67,7 +67,7 @@ test.describe('@avt ProgressIndicator', () => {
     });
 
     // Checking if the 'current' prop is adding the correct class
-    expect(page.locator('.cds--progress-step--current')).toBeTruthy();
+    await expect(page.locator('.cds--progress-step--current')).toBeVisible();
   });
 
   test('@avt-advanced-states - interactive onHover', async ({ page }) => {


### PR DESCRIPTION
Closes #

Update ProgressIndicator AVT assertions to verify the rendered complete/current steps are visible instead of checking the Locator object itself.

### Changelog

**Changed**

- Updated ProgressIndicator AVT assertions to use Playwright web-first visibility checks.

#### Testing / Reviewing

- Reviewed every line of the diff.
- `git diff --check origin/main..HEAD`
- `/Users/yongjae/Documents/e2e-skills/skills/e2e-reviewer/scripts/scan.sh e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js` — no P0 findings; one existing P1/P2 heuristic remains outside this assertion fix.
- `yarn exec playwright test e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js --project=chromium --config=/tmp/carbon-playwright.chrome.config.js --reporter=line` — 7 passed locally.

## PR Checklist

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples — not required for this test-only assertion change
- [x] Wrote passing tests that cover this change — updated the existing ProgressIndicator AVT coverage and ran the targeted spec locally
- [x] Addressed any impact on accessibility (a11y) — no production markup, styling, or interaction behavior changed
- [x] Tested for cross-browser consistency — no cross-browser production behavior changed; targeted Chromium AVT run passed locally
- [x] Validated that this code is ready for review and status checks should pass

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
