### PR TITLE
fix(overflow-menu): improve color contrast for danger button option

### DIFF
--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -206,6 +206,10 @@
     color: $text-on-color;
   }
 
+  .#{$prefix}--menu-item--danger:focus {
+    box-shadow: inset 0 0 0 convert.to-rem(3px) $background;
+  }
+
   // MenuItemDivider
 
   .#{$prefix}--menu-item-divider {

--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -344,6 +344,11 @@
     }
   }
 
+  .#{$prefix}--overflow-menu-options__option--danger
+    .#{$prefix}--overflow-menu-options__btn:focus {
+    box-shadow: inset 0 0 0 3px $background;
+  }
+
   .#{$prefix}--overflow-menu-options__option--disabled:hover {
     background-color: $layer;
     cursor: not-allowed;

--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -346,7 +346,7 @@
 
   .#{$prefix}--overflow-menu-options__option--danger
     .#{$prefix}--overflow-menu-options__btn:focus {
-    box-shadow: inset 0 0 0 3px $background;
+    box-shadow: inset 0 0 0 convert.to-rem(3px) $background;
   }
 
   .#{$prefix}--overflow-menu-options__option--disabled:hover {

--- a/packages/web-components/src/components/menu/menu-item.scss
+++ b/packages/web-components/src/components/menu/menu-item.scss
@@ -92,6 +92,10 @@ $css--plex: true !default;
   color: $text-on-color;
 }
 
+:host(.#{$prefix}--menu-item--danger:focus) {
+  box-shadow: inset 0 0 0 to-rem(3px) $background;
+}
+
 .#{$prefix}--menu-item__icon,
 .#{$prefix}--menu-item__selection-icon {
   display: none;


### PR DESCRIPTION
Closes #21327

In the overflow menu, the danger option fails the WCAG 2.2 contrast requirement of 3:1 against the adjacent background. 

<img  height="300" alt="Screenshot 2026-06-30 at 4 17 11 PM" src="https://github.com/user-attachments/assets/250fb98a-410e-424f-b01e-5bdd313d25f6" />

The solution is to add an inset box shadow to separate the red background from the focus outline, just as is done with our button component - danger variant.

Same change has been made for the Menu Button and Combo Button as well.

<img  height="300" alt="Screenshot 2026-06-30 at 4 09 41 PM" src="https://github.com/user-attachments/assets/6e397089-ff4a-4764-a2f1-1b358bf37eca" />
<img height="300" alt="Screenshot 2026-07-01 at 10 05 17 AM" src="https://github.com/user-attachments/assets/a9f98209-a358-4b00-a1fe-ed975aec3499" />

<img height="300" alt="Screenshot 2026-07-01 at 10 09 39 AM" src="https://github.com/user-attachments/assets/68d1f7e6-28ed-4c32-acd5-231f1abba373" />


### Changelog

**Changed**

- add inset box-shadow styles for the danger option in the overflow menu, menu button when focused

#### Testing / Reviewing

Check the React and WC deploy previews - the overflow menu default story - use arrow keys to focus on the danger "Delete" option.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
