### PR TITLE
fix(textInput): prevent invalid/warn states when disabled/readonly

### DIFF
--- a/packages/react/src/components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react/src/components/TextInput/__tests__/TextInput-test.js
@@ -481,4 +481,246 @@ describe('TextInput', () => {
       expect(screen.getByText('9/15')).toBeInTheDocument();
     });
   });
+
+  describe('invalid and warn states are suppressed when not interactive', () => {
+    describe('disabled', () => {
+      it('should not apply invalid CSS class when disabled', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-input--invalid`
+        );
+      });
+
+      it('should not render the invalid icon when disabled', () => {
+        const { container } = render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(`svg.${prefix}--text-input__invalid-icon`)
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the invalidText message when disabled', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.queryByText('Some error')).not.toBeInTheDocument();
+      });
+
+      it('should not set aria-invalid when disabled', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+      });
+
+      it('should not set aria-errormessage when disabled', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveAttribute(
+          'aria-errormessage'
+        );
+      });
+
+      it('should not apply warn CSS class when disabled', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            warn
+            warnText="Some warning"
+            disabled
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-input--warning`
+        );
+      });
+
+      it('should not render the warn icon when disabled', () => {
+        const { container } = render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            warn
+            warnText="Some warning"
+            disabled
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(
+            `svg.${prefix}--text-input__invalid-icon--warning`
+          )
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the warnText message when disabled', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            warn
+            warnText="Some warning"
+            disabled
+          />
+        );
+        expect(screen.queryByText('Some warning')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('readOnly', () => {
+      it('should not apply invalid CSS class when readOnly', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-input--invalid`
+        );
+      });
+
+      it('should not render the invalid icon when readOnly', () => {
+        const { container } = render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(`svg.${prefix}--text-input__invalid-icon`)
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the invalidText message when readOnly', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.queryByText('Some error')).not.toBeInTheDocument();
+      });
+
+      it('should not set aria-invalid when readOnly', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+      });
+
+      it('should not set aria-errormessage when readOnly', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            invalid
+            invalidText="Some error"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveAttribute(
+          'aria-errormessage'
+        );
+      });
+
+      it('should not apply warn CSS class when readOnly', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            warn
+            warnText="Some warning"
+            readOnly
+          />
+        );
+        expect(screen.getByRole('textbox')).not.toHaveClass(
+          `${prefix}--text-input--warning`
+        );
+      });
+
+      it('should not render the warn icon when readOnly', () => {
+        const { container } = render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            warn
+            warnText="Some warning"
+            readOnly
+          />
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(
+          container.querySelector(
+            `svg.${prefix}--text-input__invalid-icon--warning`
+          )
+        ).not.toBeInTheDocument();
+      });
+
+      it('should not render the warnText message when readOnly', () => {
+        render(
+          <TextInput
+            id="input-1"
+            labelText="TextInput"
+            warn
+            warnText="Some warning"
+            readOnly
+          />
+        );
+        expect(screen.queryByText('Some warning')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/web-components/src/components/text-input/__tests__/text-input-test.js
+++ b/packages/web-components/src/components/text-input/__tests__/text-input-test.js
@@ -302,4 +302,212 @@ describe('cds-text-input', () => {
     expect(wrapper.classList.contains('cds--text-input-wrapper--inline')).to.be
       .true;
   });
+
+  describe('invalid and warn states are suppressed when not interactive', () => {
+    describe('disabled', () => {
+      it('should not apply invalid CSS class when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const input = el.shadowRoot.querySelector('input');
+        expect(input.classList.contains('cds--text-input--invalid')).to.be
+          .false;
+      });
+
+      it('should not render the invalid icon when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-input__invalid-icon:not(.cds--text-input__invalid-icon--warning)'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the invalid message when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement).to.not.exist;
+      });
+
+      it('should not set data-invalid on the input when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const input = el.shadowRoot.querySelector('input');
+        expect(input.hasAttribute('data-invalid')).to.be.false;
+      });
+
+      it('should not apply warn CSS class when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            warn
+            warn-text="Some warning"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const input = el.shadowRoot.querySelector('input');
+        expect(input.classList.contains('cds--text-input--warning')).to.be
+          .false;
+      });
+
+      it('should not render the warn icon when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            warn
+            warn-text="Some warning"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-input__invalid-icon--warning'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the warn message when disabled', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            disabled
+            warn
+            warn-text="Some warning"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement).to.not.exist;
+      });
+    });
+
+    describe('readonly', () => {
+      it('should not apply invalid CSS class when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const input = el.shadowRoot.querySelector('input');
+        expect(input.classList.contains('cds--text-input--invalid')).to.be
+          .false;
+      });
+
+      it('should not render the invalid icon when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-input__invalid-icon:not(.cds--text-input__invalid-icon--warning)'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the invalid message when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement).to.not.exist;
+      });
+
+      it('should not set data-invalid on the input when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            invalid
+            invalid-text="Some error"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const input = el.shadowRoot.querySelector('input');
+        expect(input.hasAttribute('data-invalid')).to.be.false;
+      });
+
+      it('should not apply warn CSS class when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            warn
+            warn-text="Some warning"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const input = el.shadowRoot.querySelector('input');
+        expect(input.classList.contains('cds--text-input--warning')).to.be
+          .false;
+      });
+
+      it('should not render the warn icon when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            warn
+            warn-text="Some warning"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const icon = el.shadowRoot.querySelector(
+          '.cds--text-input__invalid-icon--warning'
+        );
+        expect(icon).to.not.exist;
+      });
+
+      it('should hide the warn message when readonly', async () => {
+        const el = await fixture(html`
+          <cds-text-input
+            readonly
+            warn
+            warn-text="Some warning"
+            label-text="TextInput"></cds-text-input>
+        `);
+        await el.updateComplete;
+        const requirement = el.shadowRoot.querySelector(
+          '.cds--form-requirement'
+        );
+        expect(requirement).to.not.exist;
+      });
+    });
+  });
 });

--- a/packages/web-components/src/components/text-input/text-input.ts
+++ b/packages/web-components/src/components/text-input/text-input.ts
@@ -362,8 +362,8 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
       icon: ReturnType<typeof iconLoader>;
     } = {
       disabled: !readonly && disabled,
-      invalid: !readonly && invalid,
-      warn: !readonly && !invalid && warn,
+      invalid: !readonly && !disabled && invalid,
+      warn: !readonly && !disabled && !invalid && warn,
       'slot-name': '',
       'slot-text': '',
       icon: null,
@@ -516,13 +516,15 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
               ${labelWrapper}
             </div>`}
         <div class="${fieldOuterWrapperClasses}">
-          <div class="${fieldWrapperClasses}" ?data-invalid="${invalid}">
+          <div
+            class="${fieldWrapperClasses}"
+            ?data-invalid="${normalizedProps.invalid}">
             <input
               autocomplete="${this.autocomplete}"
               ?autofocus="${this.autofocus}"
               class="${inputClasses}"
-              ?data-invalid="${invalid}"
-              ?disabled="${disabled}"
+              ?data-invalid="${normalizedProps.invalid}"
+              ?disabled="${normalizedProps.disabled}"
               ?aria-describedby="${hasHelperText ? 'helper-text' : undefined}"
               id="input"
               name="${ifNonEmpty(this.name)}"


### PR DESCRIPTION
Closes #20733

Fixed TextInput components in both React and Web Components to not show invalid/warn states when in disabled or readonly state, as users cannot interact with these components in those states.

### Changelog

**Changed**

- Modified TextInput component to disallow invalid & warn states when readonly or disabled.
- Added tests to verify the behavior


#### Testing / Reviewing

- Verify that ComboBox does not display invalid or warning states when readonly or disabled
- Run tests for the web component version to ensure all tests pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
