### PR TITLE
fix(tile): add hover styles on supported devices

### DIFF
--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -122,8 +122,10 @@
       color: $text-disabled;
     }
 
-    &:disabled:hover {
-      border-block-end: 1px solid transparent;
+    @media (any-hover: hover) {
+      &:disabled:hover {
+        border-block-end: 1px solid transparent;
+      }
     }
 
     &::placeholder {

--- a/packages/styles/scss/components/date-picker/_flatpickr.scss
+++ b/packages/styles/scss/components/date-picker/_flatpickr.scss
@@ -236,8 +236,10 @@
       transition: none;
     }
 
-    &:hover {
-      background-color: $layer-hover;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $layer-hover;
+      }
     }
   }
 
@@ -247,9 +249,11 @@
     fill: $icon-disabled;
   }
 
-  .flatpickr-next-month.disabled:hover svg,
-  .flatpickr-prev-month.disabled:hover svg {
-    fill: $icon-disabled;
+  @media (any-hover: hover) {
+    .flatpickr-next-month.disabled:hover svg,
+    .flatpickr-prev-month.disabled:hover svg {
+      fill: $icon-disabled;
+    }
   }
 
   .flatpickr-current-month {
@@ -265,8 +269,10 @@
   .flatpickr-current-month .cur-month {
     margin-inline: $spacing-02 $spacing-02;
 
-    &:hover {
-      background-color: $layer-hover;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $layer-hover;
+      }
     }
   }
 
@@ -274,8 +280,10 @@
     position: relative;
     inline-size: convert.to-rem(60px);
 
-    &:hover {
-      background-color: $background-hover;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $background-hover;
+      }
     }
   }
 
@@ -351,9 +359,11 @@
       inset-block-start: 33%;
     }
 
-    &:hover::after {
-      border-block-end-color: $button-primary;
-      border-block-start-color: $button-primary;
+    @media (any-hover: hover) {
+      &:hover::after {
+        border-block-end-color: $button-primary;
+        border-block-start-color: $button-primary;
+      }
     }
 
     &:active::after {
@@ -370,14 +380,16 @@
     border-block-start-color: $text-disabled;
   }
 
-  .numInputWrapper:hover .arrowUp,
-  .numInputWrapper:hover .arrowDown {
-    opacity: 1;
-  }
+  @media (any-hover: hover) {
+    .numInputWrapper:hover .arrowUp,
+    .numInputWrapper:hover .arrowDown {
+      opacity: 1;
+    }
 
-  .numInputWrapper:hover .numInput[disabled] ~ .arrowUp,
-  .numInputWrapper:hover .numInput[disabled] ~ .arrowDown {
-    opacity: 0;
+    .numInputWrapper:hover .numInput[disabled] ~ .arrowUp,
+    .numInputWrapper:hover .numInput[disabled] ~ .arrowDown {
+      opacity: 0;
+    }
   }
 
   .flatpickr-weekdays {
@@ -445,8 +457,10 @@
     inline-size: convert.to-rem(40px);
     transition: all $duration-fast-01 motion(standard, productive);
 
-    &:hover {
-      background: $layer-hover;
+    @media (any-hover: hover) {
+      &:hover {
+        background: $layer-hover;
+      }
     }
 
     &:focus {
@@ -522,11 +536,13 @@
     background: $layer-01;
   }
 
-  .flatpickr-day.endRange:hover {
-    @include focus-outline('outline');
+  @media (any-hover: hover) {
+    .flatpickr-day.endRange:hover {
+      @include focus-outline('outline');
 
-    background: $layer-01;
-    color: $text-primary;
+      background: $layer-01;
+      color: $text-primary;
+    }
   }
 
   .flatpickr-day.endRange.inRange.selected {
@@ -538,8 +554,10 @@
     color: $text-disabled;
     cursor: not-allowed;
 
-    &:hover {
-      background-color: transparent;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: transparent;
+      }
     }
   }
 

--- a/packages/styles/scss/components/tile/_tile.scss
+++ b/packages/styles/scss/components/tile/_tile.scss
@@ -68,8 +68,10 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
     cursor: pointer;
     transition: $duration-moderate-01 motion(standard, productive);
 
-    &:hover {
-      background: $layer-hover;
+    @media (any-hover: hover) {
+      &:hover {
+        background: $layer-hover;
+      }
     }
   }
 
@@ -92,7 +94,14 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       text-decoration: none;
     }
 
-    &:hover,
+    @media (any-hover: hover) {
+      &:hover {
+        .#{$prefix}--tile__checkmark {
+          opacity: 1;
+        }
+      }
+    }
+
     &:focus {
       .#{$prefix}--tile__checkmark {
         opacity: 1;
@@ -105,17 +114,22 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
     border: 0;
   }
 
-  .#{$prefix}--tile--clickable:hover,
+  @media (any-hover: hover) {
+    .#{$prefix}--tile--clickable:hover,
+    .#{$prefix}--tile--clickable:visited:hover {
+      color: $text-primary;
+      text-decoration: none;
+    }
+  }
+
   .#{$prefix}--tile--clickable:active,
-  .#{$prefix}--tile--clickable:visited,
-  .#{$prefix}--tile--clickable:visited:hover {
+  .#{$prefix}--tile--clickable:visited {
     color: $text-primary;
     text-decoration: none;
   }
 
   // Disabled ClickableTile
-  .#{$prefix}--tile--clickable.#{$prefix}--link--disabled,
-  .#{$prefix}--tile--clickable:hover.#{$prefix}--link--disabled {
+  .#{$prefix}--tile--clickable.#{$prefix}--link--disabled {
     display: block;
     padding: layout.density('padding-inline');
     background-color: $layer;
@@ -129,6 +143,25 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
         $enable-tile-contrast
     ) {
       border: 1px solid $border-disabled;
+    }
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--tile--clickable:hover.#{$prefix}--link--disabled {
+      display: block;
+      padding: layout.density('padding-inline');
+      background-color: $layer;
+      color: $text-disabled;
+      cursor: not-allowed;
+
+      @if (
+        enabled('enable-experimental-tile-contrast') or
+          $enable-experimental-tile-contrast or
+          enabled('enable-tile-contrast') or
+          $enable-tile-contrast
+      ) {
+        border: 1px solid $border-disabled;
+      }
     }
   }
 
@@ -249,9 +282,11 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       outline-offset: -2px;
     }
 
-    &:hover {
-      background-color: $layer-hover;
-      cursor: pointer;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $layer-hover;
+        cursor: pointer;
+      }
     }
   }
 
@@ -278,8 +313,10 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       border: 1px solid $border-tile;
     }
 
-    &:hover {
-      background: $layer-hover;
+    @media (any-hover: hover) {
+      &:hover {
+        background: $layer-hover;
+      }
     }
   }
 
@@ -288,8 +325,10 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
     cursor: default;
     transition: max-height $duration-moderate-01 motion(standard, productive);
 
-    &:hover {
-      background-color: $layer;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $layer;
+      }
     }
 
     &:focus {
@@ -459,11 +498,13 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       0 4px 8px 0 $ai-drop-shadow;
   }
 
-  .#{$prefix}--tile--decorator:has(
-      .#{$prefix}--ai-label
-    ).#{$prefix}--tile--expandable:hover,
-  .#{$prefix}--tile--slug.#{$prefix}--tile--expandable:hover {
-    @include ai-popover-gradient('default', 0, 'layer');
+  @media (any-hover: hover) {
+    .#{$prefix}--tile--decorator:has(
+        .#{$prefix}--ai-label
+      ).#{$prefix}--tile--expandable:hover,
+    .#{$prefix}--tile--slug.#{$prefix}--tile--expandable:hover {
+      @include ai-popover-gradient('default', 0, 'layer');
+    }
   }
 
   .#{$prefix}--tile--decorator.#{$prefix}--tile--selectable::before,
@@ -501,11 +542,13 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       0 4px 10px 2px $ai-drop-shadow;
   }
 
-  .#{$prefix}--tile--decorator.#{$prefix}--tile--selectable:hover::before,
-  .#{$prefix}--tile--decorator.#{$prefix}--tile--clickable:hover::before,
-  .#{$prefix}--tile--slug.#{$prefix}--tile--selectable:hover::before,
-  .#{$prefix}--tile--slug.#{$prefix}--tile--clickable:hover::before {
-    opacity: 1;
+  @media (any-hover: hover) {
+    .#{$prefix}--tile--decorator.#{$prefix}--tile--selectable:hover::before,
+    .#{$prefix}--tile--decorator.#{$prefix}--tile--clickable:hover::before,
+    .#{$prefix}--tile--slug.#{$prefix}--tile--selectable:hover::before,
+    .#{$prefix}--tile--slug.#{$prefix}--tile--clickable:hover::before {
+      opacity: 1;
+    }
   }
 
   .#{$prefix}--tile--decorator.#{$prefix}--tile--selectable:focus,
@@ -528,9 +571,11 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       0 4px 8px 0 $ai-drop-shadow;
   }
 
-  .#{$prefix}--tile--decorator.#{$prefix}--tile--selectable:hover::after,
-  .#{$prefix}--tile--slug.#{$prefix}--tile--selectable:hover::after {
-    opacity: 0;
+  @media (any-hover: hover) {
+    .#{$prefix}--tile--decorator.#{$prefix}--tile--selectable:hover::after,
+    .#{$prefix}--tile--slug.#{$prefix}--tile--selectable:hover::after {
+      opacity: 0;
+    }
   }
 
   .#{$prefix}--tile--decorator.#{$prefix}--tile--is-selected::after,

--- a/packages/web-components/src/components/date-picker/date-picker.scss
+++ b/packages/web-components/src/components/date-picker/date-picker.scss
@@ -46,8 +46,10 @@ $css--plex: true !default;
     cursor: not-allowed;
     opacity: 0.5;
 
-    &:hover {
-      background: transparent;
+    @media (any-hover: hover) {
+      &:hover {
+        background: transparent;
+      }
     }
   }
 
@@ -60,9 +62,11 @@ $css--plex: true !default;
       opacity: 0.5;
     }
 
-    &:hover {
-      svg {
-        fill: $layer-selected-inverse;
+    @media (any-hover: hover) {
+      &:hover {
+        svg {
+          fill: $layer-selected-inverse;
+        }
       }
     }
   }

--- a/packages/web-components/src/components/tile/tile.scss
+++ b/packages/web-components/src/components/tile/tile.scss
@@ -174,8 +174,10 @@ $css--plex: true !default;
   cursor: default;
   transition: max-height $duration-moderate-01 motion(standard, productive);
 
-  &:hover {
-    background-color: $layer;
+  @media (any-hover: hover) {
+    &:hover {
+      background-color: $layer;
+    }
   }
 
   &:focus {
@@ -238,8 +240,10 @@ $css--plex: true !default;
   transition: inset-inline-end $duration-fast-02 motion(standard, productive);
 }
 
-:host(#{$prefix}-expandable-tile[ai-label]):hover {
-  @include ai-popover-gradient('default', 0, 'layer');
+@media (any-hover: hover) {
+  :host(#{$prefix}-expandable-tile[ai-label]):hover {
+    @include ai-popover-gradient('default', 0, 'layer');
+  }
 }
 
 :host(#{$prefix}-radio-tile[ai-label]) .#{$prefix}--tile::before,
@@ -266,10 +270,12 @@ $css--plex: true !default;
   box-shadow: inset 0 -80px 70px -65px $ai-inner-shadow;
 }
 
-:host(#{$prefix}-radio-tile[ai-label]) .#{$prefix}--tile:hover::before,
-:host(#{$prefix}-selectable-tile[ai-label]) .#{$prefix}--tile:hover::before,
-:host(#{$prefix}-clickable-tile[ai-label]) .#{$prefix}--tile:hover::before {
-  opacity: 1;
+@media (any-hover: hover) {
+  :host(#{$prefix}-radio-tile[ai-label]) .#{$prefix}--tile:hover::before,
+  :host(#{$prefix}-selectable-tile[ai-label]) .#{$prefix}--tile:hover::before,
+  :host(#{$prefix}-clickable-tile[ai-label]) .#{$prefix}--tile:hover::before {
+    opacity: 1;
+  }
 }
 
 :host(#{$prefix}-radio-tile[ai-label]) .#{$prefix}--tile--is-selected,


### PR DESCRIPTION
Closes #22602

fix(tile): add hover styles on supported devices

Wrap tile hover styles with @media (any-hover: hover) to prevent sticky hover states on touch devices.

### Changelog

**Changed**
- Tile components now only show hover states on devices that support hover

#### Testing / Reviewing
1. Test on desktop with mouse - hover states should work normally
2. Test on mobile/touch device - hover states should not appear or get stuck

## PR Checklist

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples (N/A)
- [x] Wrote passing tests that cover this change (N/A - follows existing pattern)
- [x] Addressed any impact on accessibility (a11y) (improved - removes sticky hover)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass