### PR TITLE
feat: notify consumers about feature flags effectively

### DIFF
--- a/packages/react/.storybook/templates/WithFeatureFlags/index.js
+++ b/packages/react/.storybook/templates/WithFeatureFlags/index.js
@@ -9,18 +9,41 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import LinkTo from '@storybook/addon-links/react';
 
-import { FeatureFlags as FeatureFlagScope } from '@carbon/feature-flags';
 import { FeatureFlags } from '../../../src/components/FeatureFlags';
 
 import { Annotation } from '../Annotation';
 
-const allFlagsEnabled = Object.fromEntries(
-  Array.from(FeatureFlagScope.flags.keys()).map((k) => [k, true])
-);
-
-function WithFeatureFlags({ children }) {
+function WithFeatureFlags({
+  children,
+  enableV12TileDefaultIcons = true,
+  enableV12TileRadioIcons = true,
+  enableV12Overflowmenu = true,
+  enableTreeviewControllable = true,
+  enableFocusWrapWithoutSentinels = true,
+  enableDialogElement = true,
+  enableV12DynamicFloatingStyles = true,
+  enableEnhancedFileUploader = true,
+  enablePresence = true,
+  enableTileContrast = true,
+  enableV12StructuredListVisibleIcons = true,
+  enableV12ToggleReducedLabelSpacing = true,
+  ...rest
+}) {
   return (
-    <FeatureFlags flags={allFlagsEnabled}>
+    <FeatureFlags
+      enableV12TileDefaultIcons={enableV12TileDefaultIcons}
+      enableV12TileRadioIcons={enableV12TileRadioIcons}
+      enableV12Overflowmenu={enableV12Overflowmenu}
+      enableTreeviewControllable={enableTreeviewControllable}
+      enableFocusWrapWithoutSentinels={enableFocusWrapWithoutSentinels}
+      enableDialogElement={enableDialogElement}
+      enableV12DynamicFloatingStyles={enableV12DynamicFloatingStyles}
+      enableEnhancedFileUploader={enableEnhancedFileUploader}
+      enablePresence={enablePresence}
+      enableTileContrast={enableTileContrast}
+      enableV12StructuredListVisibleIcons={enableV12StructuredListVisibleIcons}
+      enableV12ToggleReducedLabelSpacing={enableV12ToggleReducedLabelSpacing}
+      {...rest}>
       <Annotation
         type="feature-flags"
         text={
@@ -44,10 +67,18 @@ WithFeatureFlags.propTypes = {
    */
   children: PropTypes.node,
 
-  /**
-   * Provide the feature flags to enabled or disabled in the current React tree
-   */
-  flags: PropTypes.objectOf(PropTypes.bool),
+  enableV12TileDefaultIcons: PropTypes.bool,
+  enableV12TileRadioIcons: PropTypes.bool,
+  enableV12Overflowmenu: PropTypes.bool,
+  enableTreeviewControllable: PropTypes.bool,
+  enableFocusWrapWithoutSentinels: PropTypes.bool,
+  enableDialogElement: PropTypes.bool,
+  enableV12DynamicFloatingStyles: PropTypes.bool,
+  enableEnhancedFileUploader: PropTypes.bool,
+  enablePresence: PropTypes.bool,
+  enableTileContrast: PropTypes.bool,
+  enableV12StructuredListVisibleIcons: PropTypes.bool,
+  enableV12ToggleReducedLabelSpacing: PropTypes.bool,
 };
 
 export { WithFeatureFlags };

--- a/packages/react/src/components/ComboBox/ComboBox.featureflag.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.featureflag.stories.js
@@ -15,10 +15,7 @@ export default {
   tags: ['!autodocs'],
   decorators: [
     (Story) => (
-      <WithFeatureFlags
-        flags={{
-          'enable-v12-dynamic-floating-styles': true,
-        }}>
+      <WithFeatureFlags enableV12DynamicFloatingStyles>
         <Story />
       </WithFeatureFlags>
     ),

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -184,6 +184,12 @@ export interface ComboBoxProps<ItemType>
    * element to avoid collisions with the viewport and being clipped by
    * ancestor elements. Requires React v17+
    * @see https://github.com/carbon-design-system/carbon/issues/18714
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables this
+   * behaviour globally without needing to set `autoAlign` on each instance.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   autoAlign?: boolean;
 

--- a/packages/react/src/components/ComboButton/ComboButton.featureflag.stories.js
+++ b/packages/react/src/components/ComboButton/ComboButton.featureflag.stories.js
@@ -16,10 +16,7 @@ export default {
   tags: ['!autodocs'],
   decorators: [
     (Story) => (
-      <WithFeatureFlags
-        flags={{
-          'enable-v12-dynamic-floating-styles': true,
-        }}>
+      <WithFeatureFlags enableV12DynamicFloatingStyles>
         <Story />
       </WithFeatureFlags>
     ),

--- a/packages/react/src/components/ComboButton/index.tsx
+++ b/packages/react/src/components/ComboButton/index.tsx
@@ -69,7 +69,13 @@ interface ComboButtonProps extends TranslateWithId<TranslationKey> {
   label: React.ComponentProps<typeof Button>['title'];
 
   /**
-   * Experimental property. Specify how the menu should align with the button element
+   * Experimental property. Specify how the menu should align with the button element.
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables precise
+   * viewport-collision avoidance for the menu's floating position globally.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   menuAlignment?: MenuAlignment;
 

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -173,6 +173,24 @@ ModalBody.propTypes = {
   hasScrollingContent: PropTypes.bool,
 };
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-dialog-element` — renders using the native `<dialog>` element,
+ *   enabling browser-native focus management and accessibility semantics.
+ *   Enable via `<FeatureFlags enableDialogElement>`.
+ *
+ * - `enable-presence` — keeps the modal unmounted when closed and mounts it
+ *   only when opened, reducing the initial DOM footprint.
+ *   Enable via `<FeatureFlags enablePresence>`.
+ *
+ * - `enable-focus-wrap-without-sentinels` — uses a sentinel-free focus-trap
+ *   implementation. Mutually exclusive with `enable-dialog-element`.
+ *   Enable via `<FeatureFlags enableFocusWrapWithoutSentinels>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface ComposedModalProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify the aria-label for cds--modal-container

--- a/packages/react/src/components/Dropdown/Dropdown.featureflag.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.featureflag.stories.js
@@ -17,10 +17,7 @@ export default {
   tags: ['!autodocs'],
   decorators: [
     (Story) => (
-      <WithFeatureFlags
-        flags={{
-          'enable-v12-dynamic-floating-styles': true,
-        }}>
+      <WithFeatureFlags enableV12DynamicFloatingStyles>
         <Story />
       </WithFeatureFlags>
     ),

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -91,6 +91,12 @@ export interface DropdownProps<ItemType>
    * to avoid collisions with the viewport and being clipped by ancestor
    * elements. Requires React v17+
    * @see https://github.com/carbon-design-system/carbon/issues/18714
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables this
+   * behaviour globally without needing to set `autoAlign` on each instance.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   autoAlign?: boolean;
 

--- a/packages/react/src/components/FeatureFlags/FeatureFlags.stories.js
+++ b/packages/react/src/components/FeatureFlags/FeatureFlags.stories.js
@@ -1,0 +1,336 @@
+/**
+ * Copyright IBM Corp. 2015, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Grid, Column } from '../Grid';
+import { Stack } from '../Stack';
+
+import Button from '../Button';
+import { ComboBox } from '../ComboBox';
+import { ComboButton } from '../ComboButton';
+import {
+  ComposedModal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '../ComposedModal';
+import { default as Dropdown } from '../Dropdown';
+import {
+  FileUploader,
+  FileUploaderButton,
+  FileUploaderDropContainer,
+} from '../FileUploader';
+import { MenuButton } from '../MenuButton';
+import { Modal } from '../Modal';
+import { MultiSelect, FilterableMultiSelect } from '../MultiSelect';
+import { ActionableNotification } from '../Notification';
+import { OverflowMenu } from '../OverflowMenu';
+import { OverflowMenuItem } from '../OverflowMenuItem';
+import { Popover, PopoverContent } from '../Popover';
+import { default as RadioTile } from '../RadioTile';
+import { TileGroup } from '../TileGroup';
+import { ClickableTile } from '../Tile';
+import { default as TextInput } from '../TextInput';
+import { TreeView, TreeNode } from '../TreeView';
+import { MenuItem, MenuItemDivider } from '../Menu';
+import { Information, Folder, Document } from '@carbon/icons-react';
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default {
+  title: 'Components/FeatureFlags/KitchenSink',
+  parameters: { layout: 'fullscreen' },
+};
+
+// ── Shared data ───────────────────────────────────────────────────────────────
+const dropdownItems = [
+  { id: 'opt-1', text: 'Option 1' },
+  { id: 'opt-2', text: 'Option 2' },
+  { id: 'opt-3', text: 'Option 3' },
+];
+const comboItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'];
+
+// ── Section label ─────────────────────────────────────────────────────────────
+function Section({ flag, children }) {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid var(--cds-border-subtle)',
+        paddingTop: '1rem',
+        paddingBottom: '0.5rem',
+        marginBottom: '0.5rem',
+      }}>
+      <p
+        style={{
+          fontSize: '0.75rem',
+          fontFamily: 'var(--cds-code-01-font-family, monospace)',
+          color: 'var(--cds-text-secondary)',
+          marginBottom: '0.75rem',
+        }}>
+        {flag}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kitchen Sink — only components that use useFeatureFlag
+// ─────────────────────────────────────────────────────────────────────────────
+function KitchenSinkContent() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [composedModalOpen, setComposedModalOpen] = useState(false);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <Grid>
+        {/* ── enable-v12-dynamic-floating-styles ───────────────────────────── */}
+        <Column sm={4} md={4} lg={4}>
+          <Section flag="enable-v12-dynamic-floating-styles">
+            <Stack gap={5}>
+              <Dropdown
+                id="ff-dd"
+                titleText="Dropdown"
+                label="Select"
+                items={dropdownItems}
+                itemToString={(item) => (item ? item.text : '')}
+              />
+              <ComboBox
+                id="ff-cb"
+                titleText="ComboBox"
+                placeholder="Filter…"
+                items={comboItems}
+                itemToString={(item) => item ?? ''}
+              />
+              <MultiSelect
+                id="ff-ms"
+                titleText="MultiSelect"
+                label="Select all"
+                items={dropdownItems}
+                itemToString={(item) => (item ? item.text : '')}
+              />
+              <FilterableMultiSelect
+                id="ff-fms"
+                titleText="FilterableMultiSelect"
+                placeholder="Filter…"
+                items={dropdownItems}
+                itemToString={(item) => (item ? item.text : '')}
+              />
+            </Stack>
+          </Section>
+        </Column>
+
+        <Column sm={4} md={4} lg={4}>
+          <Section flag="enable-v12-dynamic-floating-styles (cont.)">
+            <Stack gap={5}>
+              <div>
+                <p
+                  style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--cds-text-secondary)',
+                    marginBottom: '0.5rem',
+                  }}>
+                  ComboButton
+                </p>
+                <ComboButton label="Primary action">
+                  <MenuItem label="Edit" />
+                  <MenuItem label="Duplicate" />
+                  <MenuItemDivider />
+                  <MenuItem label="Delete" kind="danger" />
+                </ComboButton>
+              </div>
+              <div>
+                <p
+                  style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--cds-text-secondary)',
+                    marginBottom: '0.5rem',
+                  }}>
+                  MenuButton
+                </p>
+                <MenuButton label="Options">
+                  <MenuItem label="Edit" />
+                  <MenuItem label="Duplicate" />
+                  <MenuItemDivider />
+                  <MenuItem label="Delete" kind="danger" />
+                </MenuButton>
+              </div>
+              <div>
+                <p
+                  style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--cds-text-secondary)',
+                    marginBottom: '0.5rem',
+                  }}>
+                  Popover
+                </p>
+                <Popover open={popoverOpen} align="bottom-left">
+                  <button
+                    type="button"
+                    aria-label="Toggle popover"
+                    onClick={() => setPopoverOpen((o) => !o)}>
+                    <Information />
+                  </button>
+                  <PopoverContent>
+                    <p style={{ padding: '1rem' }}>Popover content</p>
+                  </PopoverContent>
+                </Popover>
+              </div>
+            </Stack>
+          </Section>
+        </Column>
+
+        {/* ── enable-v12-overflowmenu ───────────────────────────────────────── */}
+        <Column sm={4} md={4} lg={4}>
+          <Section flag="enable-v12-overflowmenu">
+            <OverflowMenu>
+              <OverflowMenuItem itemText="Edit" />
+              <OverflowMenuItem itemText="Duplicate" />
+              <OverflowMenuItem itemText="Delete" isDelete hasDivider />
+            </OverflowMenu>
+          </Section>
+        </Column>
+
+        {/* ── enable-v12-tile-default-icons ─────────────────────────────────── */}
+        <Column sm={4} md={4} lg={4}>
+          <Section flag="enable-v12-tile-default-icons">
+            <Stack gap={4}>
+              <ClickableTile href="#">Clickable tile</ClickableTile>
+              <ClickableTile href="#" disabled>
+                Disabled clickable tile
+              </ClickableTile>
+            </Stack>
+          </Section>
+        </Column>
+
+        {/* ── enable-v12-tile-radio-icons ───────────────────────────────────── */}
+        <Column sm={4} md={4} lg={4}>
+          <Section flag="enable-v12-tile-radio-icons">
+            <TileGroup
+              name="ff-tg"
+              defaultSelected="rt-2"
+              legend="Select region">
+              <RadioTile id="rt-1" value="rt-1">
+                US East
+              </RadioTile>
+              <RadioTile id="rt-2" value="rt-2">
+                US West
+              </RadioTile>
+              <RadioTile id="rt-3" value="rt-3" disabled>
+                EU (disabled)
+              </RadioTile>
+            </TileGroup>
+          </Section>
+        </Column>
+
+        {/* ── enable-treeview-controllable ──────────────────────────────────── */}
+        <Column sm={4} md={4} lg={4}>
+          <Section flag="enable-treeview-controllable">
+            <TreeView label="File tree">
+              <TreeNode id="tv-1" label="src" renderIcon={Folder} isExpanded>
+                <TreeNode id="tv-1a" label="index.tsx" renderIcon={Document} />
+                <TreeNode id="tv-1b" label="App.tsx" renderIcon={Document} />
+              </TreeNode>
+              <TreeNode id="tv-2" label="public" renderIcon={Folder}>
+                <TreeNode id="tv-2a" label="index.html" renderIcon={Document} />
+              </TreeNode>
+            </TreeView>
+          </Section>
+        </Column>
+
+        {/* ── enable-enhanced-file-uploader ─────────────────────────────────── */}
+        <Column sm={4} md={8} lg={8}>
+          <Section flag="enable-enhanced-file-uploader">
+            <Stack gap={4}>
+              <FileUploaderButton labelText="Upload files" />
+              <FileUploaderDropContainer labelText="Drag and drop files here or click to upload" />
+              <FileUploader
+                labelTitle="Upload document"
+                labelDescription="Max file size is 500mb."
+                buttonLabel="Add file"
+                filenameStatus="edit"
+                accept={['.jpg', '.pdf']}
+              />
+            </Stack>
+          </Section>
+        </Column>
+
+        {/* ── enable-focus-wrap-without-sentinels / enable-dialog-element ──── */}
+        {/* ── enable-presence ──────────────────────────────────────────────── */}
+        <Column sm={4} md={8} lg={8}>
+          <Section flag="enable-presence · enable-dialog-element · enable-focus-wrap-without-sentinels">
+            <Stack orientation="horizontal" gap={4}>
+              <Button onClick={() => setModalOpen(true)}>Open Modal</Button>
+              <Button
+                kind="secondary"
+                onClick={() => setComposedModalOpen(true)}>
+                Open ComposedModal
+              </Button>
+            </Stack>
+
+            <Modal
+              open={modalOpen}
+              modalHeading="Modal"
+              modalLabel="Label"
+              primaryButtonText="Confirm"
+              secondaryButtonText="Cancel"
+              onRequestClose={() => setModalOpen(false)}
+              onRequestSubmit={() => setModalOpen(false)}>
+              <p>Modal body content.</p>
+            </Modal>
+
+            <ComposedModal
+              open={composedModalOpen}
+              onClose={() => setComposedModalOpen(false)}>
+              <ModalHeader title="ComposedModal" label="Label" />
+              <ModalBody>
+                <TextInput
+                  id="cm-input"
+                  labelText="Domain"
+                  placeholder="example.com"
+                />
+              </ModalBody>
+              <ModalFooter
+                primaryButtonText="Add"
+                secondaryButtonText="Cancel"
+                onRequestClose={() => setComposedModalOpen(false)}
+                onRequestSubmit={() => setComposedModalOpen(false)}
+              />
+            </ComposedModal>
+          </Section>
+        </Column>
+
+        {/* ── enable-focus-wrap-without-sentinels (ActionableNotification) ─── */}
+        <Column sm={4} md={8} lg={8}>
+          <Section flag="enable-focus-wrap-without-sentinels (ActionableNotification)">
+            <ActionableNotification
+              kind="info"
+              title="Action required:"
+              subtitle="Click the action button to continue."
+              actionButtonLabel="Take action"
+            />
+          </Section>
+        </Column>
+      </Grid>
+    </div>
+  );
+}
+
+export const KitchenSink = {
+  argTypes: {
+    instances: {
+      control: { type: 'number', min: 1, max: 10, step: 1 },
+      description: 'Number of times to render the kitchen sink',
+    },
+  },
+  args: {
+    instances: 1,
+  },
+  render: ({ instances }) =>
+    Array.from({ length: instances }, (_, i) => <KitchenSinkContent key={i} />),
+};

--- a/packages/react/src/components/FeatureFlags/__tests__/FeatureFlags-test.js
+++ b/packages/react/src/components/FeatureFlags/__tests__/FeatureFlags-test.js
@@ -834,5 +834,163 @@ describe('FeatureFlags', () => {
         enablePresence: true,
       });
     });
+
+    it('enable-tile-contrast - enableTileContrast', () => {
+      const checkFlags = jest.fn();
+      const checkFlag = jest.fn();
+
+      function TestComponent() {
+        const featureFlags = useFeatureFlags();
+        const enableTileContrast = useFeatureFlag('enable-tile-contrast');
+
+        checkFlags({
+          enableTileContrast: featureFlags.enabled('enable-tile-contrast'),
+        });
+
+        checkFlag({
+          enableTileContrast,
+        });
+
+        return null;
+      }
+
+      // Render the default
+      const { rerender } = render(
+        <FeatureFlags>
+          <TestComponent />
+        </FeatureFlags>
+      );
+
+      // Ensure the default value is as defined and as expected
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        enableTileContrast: false,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        enableTileContrast: false,
+      });
+
+      // Enable the flag
+      rerender(
+        <FeatureFlags enableTileContrast>
+          <TestComponent />
+        </FeatureFlags>
+      );
+
+      // Ensure that when enabled, this flag does not error
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        enableTileContrast: true,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        enableTileContrast: true,
+      });
+    });
+
+    it('enable-v12-structured-list-visible-icons - enableV12StructuredListVisibleIcons', () => {
+      const checkFlags = jest.fn();
+      const checkFlag = jest.fn();
+
+      function TestComponent() {
+        const featureFlags = useFeatureFlags();
+        const enableV12StructuredListVisibleIcons = useFeatureFlag(
+          'enable-v12-structured-list-visible-icons'
+        );
+
+        checkFlags({
+          enableV12StructuredListVisibleIcons: featureFlags.enabled(
+            'enable-v12-structured-list-visible-icons'
+          ),
+        });
+
+        checkFlag({
+          enableV12StructuredListVisibleIcons,
+        });
+
+        return null;
+      }
+
+      // Render the default
+      const { rerender } = render(
+        <FeatureFlags>
+          <TestComponent />
+        </FeatureFlags>
+      );
+
+      // Ensure the default value is as defined and as expected
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        enableV12StructuredListVisibleIcons: false,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        enableV12StructuredListVisibleIcons: false,
+      });
+
+      // Enable the flag
+      rerender(
+        <FeatureFlags enableV12StructuredListVisibleIcons>
+          <TestComponent />
+        </FeatureFlags>
+      );
+
+      // Ensure that when enabled, this flag does not error
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        enableV12StructuredListVisibleIcons: true,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        enableV12StructuredListVisibleIcons: true,
+      });
+    });
+
+    it('enable-v12-toggle-reduced-label-spacing - enableV12ToggleReducedLabelSpacing', () => {
+      const checkFlags = jest.fn();
+      const checkFlag = jest.fn();
+
+      function TestComponent() {
+        const featureFlags = useFeatureFlags();
+        const enableV12ToggleReducedLabelSpacing = useFeatureFlag(
+          'enable-v12-toggle-reduced-label-spacing'
+        );
+
+        checkFlags({
+          enableV12ToggleReducedLabelSpacing: featureFlags.enabled(
+            'enable-v12-toggle-reduced-label-spacing'
+          ),
+        });
+
+        checkFlag({
+          enableV12ToggleReducedLabelSpacing,
+        });
+
+        return null;
+      }
+
+      // Render the default
+      const { rerender } = render(
+        <FeatureFlags>
+          <TestComponent />
+        </FeatureFlags>
+      );
+
+      // Ensure the default value is as defined and as expected
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        enableV12ToggleReducedLabelSpacing: false,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        enableV12ToggleReducedLabelSpacing: false,
+      });
+
+      // Enable the flag
+      rerender(
+        <FeatureFlags enableV12ToggleReducedLabelSpacing>
+          <TestComponent />
+        </FeatureFlags>
+      );
+
+      // Ensure that when enabled, this flag does not error
+      expect(checkFlags).toHaveBeenLastCalledWith({
+        enableV12ToggleReducedLabelSpacing: true,
+      });
+      expect(checkFlag).toHaveBeenLastCalledWith({
+        enableV12ToggleReducedLabelSpacing: true,
+      });
+    });
   });
 });

--- a/packages/react/src/components/FeatureFlags/index.tsx
+++ b/packages/react/src/components/FeatureFlags/index.tsx
@@ -299,12 +299,86 @@ FeatureFlags.propTypes = {
 };
 
 /**
+ * Tracks which (flag, component) pairs have already been warned about so
+ * each warning appears at most once per flag per component.
+ */
+const warnedFlags = new Set<string>();
+
+/**
+ * Best-effort extraction of the calling React component name from the current
+ * call stack. Returns an empty string when the name cannot be determined.
+ */
+function getCallerComponentName(): string {
+  try {
+    const stack = new Error().stack ?? '';
+    // Drop the "Error" header line, then skip the useFeatureFlag frame itself.
+    const frames = stack.split('\n').slice(1);
+    let pastOwnFrame = false;
+    for (const frame of frames) {
+      // Skip frames until we're past useFeatureFlag's own source file.
+      if (!pastOwnFrame) {
+        if (frame.includes('FeatureFlags')) {
+          pastOwnFrame = true;
+        }
+        continue;
+      }
+
+      // 1. PascalCase function name — regular function components and named forwardRef.
+      const namedMatch = frame.match(/^\s+at\s+([A-Z][A-Za-z0-9$_.]+)/);
+      if (namedMatch) {
+        const name = namedMatch[1];
+        if (
+          name.startsWith('Object.') ||
+          name.startsWith('React.') ||
+          name.startsWith('ReactDOM')
+        ) {
+          continue;
+        }
+        return name;
+      }
+
+      // 2. Anonymous render function inside a named directory (forwardRef pattern).
+      //    e.g. ".../MenuButton/index.tsx" → "MenuButton".
+      //    Skip FeatureFlags itself to avoid reporting the wrapper as the caller.
+      const fileMatch = frame.match(
+        /[/\\]([A-Z][A-Za-z0-9$_]+)[/\\]index\.[jt]sx?/
+      );
+      if (fileMatch && fileMatch[1] !== 'FeatureFlags') {
+        return fileMatch[1];
+      }
+    }
+  } catch {
+    // Ignore — stack traces are not guaranteed
+  }
+  return '';
+}
+
+/**
  * Access whether a given flag is enabled or disabled in a given
  * FeatureFlagContext
  */
 export const useFeatureFlag = (flag: string) => {
   const scope = useContext(FeatureFlagContext);
-  return scope.enabled(flag);
+  const enabled = scope.enabled(flag);
+
+  // update the version numbers per each major release.
+  // this will auto announce all next major flags without additional setup.
+  if (flag.startsWith('enable-v12-') && !enabled) {
+    const component = getCallerComponentName();
+    const warnKey = `${flag}::${component}`;
+    if (!warnedFlags.has(warnKey)) {
+      warnedFlags.add(warnKey);
+      const location = component ? ` (called from <${component}>)` : '';
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[Carbon] The feature flag "${flag}" will be enabled by default in v12. ` +
+          `Consider adopting it early for a smoother migration${location}. ` +
+          `See https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md`
+      );
+    }
+  }
+
+  return enabled;
 };
 
 /**

--- a/packages/react/src/components/FeatureFlags/index.tsx
+++ b/packages/react/src/components/FeatureFlags/index.tsx
@@ -20,17 +20,172 @@ import { deprecate } from '../../prop-types/deprecate';
 
 export interface FeatureFlagsProps {
   children?: ReactNode;
+
+  /**
+   * @deprecated Use the individual boolean props instead (e.g. `enableDialogElement`).
+   * Run the codemod to migrate:
+   * `npx @carbon/upgrade migrate featureflag-deprecate-flags-prop --write`
+   *
+   * Provide feature flag values as a plain object. Useful for flags that do
+   * not have a dedicated boolean prop (e.g. Sass-only flags).
+   */
   flags?: Record<string, boolean>;
+
+  /**
+   * Enable default icons for `ClickableTile` components. When enabled,
+   * `ClickableTile` renders an `ArrowRight` icon by default and an `Error`
+   * icon when disabled.
+   *
+   * Feature flag: `enable-v12-tile-default-icons`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableV12TileDefaultIcons?: boolean;
+
+  /**
+   * Enable updated radio icon rendering in `RadioTile` components. When
+   * enabled, selected tiles show a `RadioButtonChecked` icon and unselected
+   * tiles show a `RadioButton` icon.
+   *
+   * Feature flag: `enable-v12-tile-radio-icons`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableV12TileRadioIcons?: boolean;
+
+  /**
+   * Enable the v12 `OverflowMenu` component that leverages `Menu` subcomponents
+   * instead of the legacy implementation.
+   *
+   * Feature flag: `enable-v12-overflowmenu`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableV12Overflowmenu?: boolean;
+
+  /**
+   * Enable the new controllable API for `TreeView`, allowing `selected` and
+   * `active` state to be managed externally. Also unlocks `defaultIsExpanded`
+   * on `TreeNode` and the `onActivate` callback on `TreeView`.
+   *
+   * Feature flag: `enable-treeview-controllable`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableTreeviewControllable?: boolean;
+
+  /**
+   * @deprecated Use `enableFocusWrapWithoutSentinels` instead.
+   *
+   * Enable the focus-wrap behavior that does not rely on sentinel nodes.
+   * Affects `Modal`, `ComposedModal`, and `ActionableNotification`.
+   *
+   * Feature flag: `enable-experimental-focus-wrap-without-sentinels`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableExperimentalFocusWrapWithoutSentinels?: boolean;
+
+  /**
+   * Enable the focus-wrap behavior that does not rely on sentinel nodes.
+   * Affects `Modal`, `ComposedModal`, and `ActionableNotification`.
+   *
+   * Feature flag: `enable-focus-wrap-without-sentinels`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableFocusWrapWithoutSentinels?: boolean;
+
+  /**
+   * Enable components to utilize the native HTML `<dialog>` element. Affects
+   * `Modal` and `ComposedModal`. When enabled, the browser's built-in dialog
+   * semantics and focus management are used.
+   *
+   * **Note:** This flag is mutually exclusive with
+   * `enableFocusWrapWithoutSentinels` — enabling both simultaneously has no
+   * additional effect and will produce a console warning.
+   *
+   * Feature flag: `enable-dialog-element`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableDialogElement?: boolean;
+
+  /**
+   * Enable dynamic floating styles for components such as `Popover`,
+   * `Tooltip`, `Dropdown`, `ComboBox`, `MultiSelect`, `MenuButton`,
+   * `ComboButton`, and `OverflowMenu`. This enables precise viewport-collision
+   * avoidance powered by floating-ui regardless of whether `autoAlign` is set
+   * on the individual component.
+   *
+   * Feature flag: `enable-v12-dynamic-floating-styles`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableV12DynamicFloatingStyles?: boolean;
+
+  /**
+   * Enable enhanced `FileUploader` callbacks with richer data and expanded
+   * triggers. When enabled, `onChange` also fires for file deletions and
+   * `clearFiles` operations, and `onDelete` receives deleted file metadata.
+   * Also exposes `getCurrentFiles` and `setCurrentFiles` on the imperative
+   * handle.
+   *
+   * Feature flag: `enable-enhanced-file-uploader`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enableEnhancedFileUploader?: boolean;
+
+  /**
+   * Enable components to remain unmounted in their closed state and mount only
+   * when opened. Affects `Modal` and `ComposedModal`. Useful for reducing the
+   * initial DOM footprint.
+   *
+   * Feature flag: `enable-presence`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
   enablePresence?: boolean;
+
+  /**
+   * Enable improved contrast styling for tile components by adding a border.
+   * This is a **Sass-only** flag — it has no effect unless the corresponding
+   * SCSS flag is also enabled in your stylesheet:
+   *
+   * ```scss
+   * @use '@carbon/react' with (
+   *   $feature-flags: ('enable-tile-contrast': true)
+   * );
+   * ```
+   *
+   * Feature flag: `enable-tile-contrast`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
+  enableTileContrast?: boolean;
+
+  /**
+   * Enable icon components within `StructuredList` to always be visible.
+   * This is a **Sass-only** flag — it has no effect unless the corresponding
+   * SCSS flag is also enabled in your stylesheet:
+   *
+   * ```scss
+   * @use '@carbon/react' with (
+   *   $feature-flags: ('enable-v12-structured-list-visible-icons': true)
+   * );
+   * ```
+   *
+   * Feature flag: `enable-v12-structured-list-visible-icons`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
+  enableV12StructuredListVisibleIcons?: boolean;
+
+  /**
+   * Enable reduced spacing between the `Toggle` control and its label to
+   * improve visual consistency with other form inputs.
+   * This is a **Sass-only** flag — it has no effect unless the corresponding
+   * SCSS flag is also enabled in your stylesheet:
+   *
+   * ```scss
+   * @use '@carbon/react' with (
+   *   $feature-flags: ('enable-v12-toggle-reduced-label-spacing': true)
+   * );
+   * ```
+   *
+   * Feature flag: `enable-v12-toggle-reduced-label-spacing`
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+   */
+  enableV12ToggleReducedLabelSpacing?: boolean;
 }
 
 // Reuse the runtime scope shape from `@carbon/feature-flags` directly. A local
@@ -62,6 +217,9 @@ export const FeatureFlags = ({
   enableV12DynamicFloatingStyles = false,
   enableEnhancedFileUploader = false,
   enablePresence = false,
+  enableTileContrast = false,
+  enableV12StructuredListVisibleIcons = false,
+  enableV12ToggleReducedLabelSpacing = false,
 }: FeatureFlagsProps) => {
   const parentScope = useContext(FeatureFlagContext);
 
@@ -78,6 +236,11 @@ export const FeatureFlags = ({
       'enable-v12-dynamic-floating-styles': enableV12DynamicFloatingStyles,
       'enable-enhanced-file-uploader': enableEnhancedFileUploader,
       'enable-presence': enablePresence,
+      'enable-tile-contrast': enableTileContrast,
+      'enable-v12-structured-list-visible-icons':
+        enableV12StructuredListVisibleIcons,
+      'enable-v12-toggle-reduced-label-spacing':
+        enableV12ToggleReducedLabelSpacing,
       ...flags,
     };
 
@@ -95,6 +258,9 @@ export const FeatureFlags = ({
     enableV12DynamicFloatingStyles,
     enableEnhancedFileUploader,
     enablePresence,
+    enableTileContrast,
+    enableV12StructuredListVisibleIcons,
+    enableV12ToggleReducedLabelSpacing,
     flags,
     parentScope,
   ]);
@@ -109,7 +275,7 @@ export const FeatureFlags = ({
 FeatureFlags.propTypes = {
   children: PropTypes.node,
   /**
-   * Provide the feature flags to enabled or disabled in the current Rea,ct tree
+   * Provide the feature flags to enabled or disabled in the current React tree
    */
   flags: deprecate(
     PropTypes.objectOf(PropTypes.bool),
@@ -127,6 +293,9 @@ FeatureFlags.propTypes = {
   enableV12DynamicFloatingStyles: PropTypes.bool,
   enableEnhancedFileUploader: PropTypes.bool,
   enablePresence: PropTypes.bool,
+  enableTileContrast: PropTypes.bool,
+  enableV12StructuredListVisibleIcons: PropTypes.bool,
+  enableV12ToggleReducedLabelSpacing: PropTypes.bool,
 };
 
 /**

--- a/packages/react/src/components/FileUploader/FileUploader.featureflag.stories.js
+++ b/packages/react/src/components/FileUploader/FileUploader.featureflag.stories.js
@@ -15,10 +15,7 @@ export default {
   tags: ['!autodocs'],
   decorators: [
     (Story) => (
-      <WithFeatureFlags
-        flags={{
-          'enable-enhanced-file-uploader': true,
-        }}>
+      <WithFeatureFlags enableEnhancedFileUploader>
         <Story />
       </WithFeatureFlags>
     ),

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -42,6 +42,20 @@ export interface FileDeleteData {
   remainingFiles: FileItem[];
 }
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-enhanced-file-uploader` — enables richer callbacks and expanded
+ *   trigger coverage:
+ *   - `onChange` also fires on file deletions and `clearFiles` operations,
+ *     receiving a `FileChangeData` object as the second argument.
+ *   - `onDelete` receives a `FileDeleteData` object with deleted file info.
+ *   - Exposes `getCurrentFiles` and `setCurrentFiles` on the imperative ref.
+ *   Enable via `<FeatureFlags enableEnhancedFileUploader>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface FileUploaderProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Specify the types of files that this input should be able to receive

--- a/packages/react/src/components/Grid/GridTypes.ts
+++ b/packages/react/src/components/Grid/GridTypes.ts
@@ -8,6 +8,16 @@
 import { PolymorphicComponentPropWithRef } from '../../internal/PolymorphicProps';
 import PropTypes from 'prop-types';
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-css-grid` — switches the `Grid` implementation from the legacy
+ *   flexbox-based `FlexGrid` to the CSS Grid-based `CSSGrid`.
+ *   Enable via `<FeatureFlags flags={{ 'enable-css-grid': true }}>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface GridBaseProps {
   /**
    * Specify grid alignment. Default is center

--- a/packages/react/src/components/MenuButton/index.tsx
+++ b/packages/react/src/components/MenuButton/index.tsx
@@ -99,7 +99,6 @@ export interface MenuButtonProps extends ComponentProps<'div'> {
   menuTarget?: Element;
 }
 
- 
 const MenuButton = forwardRef<HTMLDivElement, MenuButtonProps>(
   (
     {

--- a/packages/react/src/components/MenuButton/index.tsx
+++ b/packages/react/src/components/MenuButton/index.tsx
@@ -99,7 +99,7 @@ export interface MenuButtonProps extends ComponentProps<'div'> {
   menuTarget?: Element;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
+ 
 const MenuButton = forwardRef<HTMLDivElement, MenuButtonProps>(
   (
     {
@@ -317,5 +317,7 @@ MenuButton.propTypes = {
     typeof Element !== 'undefined' ? Element : Object
   ) as PropTypes.Validator<Element | null | undefined>,
 };
+
+MenuButton.displayName = 'MenuButton';
 
 export { MenuButton };

--- a/packages/react/src/components/MenuButton/index.tsx
+++ b/packages/react/src/components/MenuButton/index.tsx
@@ -63,7 +63,13 @@ export interface MenuButtonProps extends ComponentProps<'div'> {
   label: string;
 
   /**
-   * Experimental property. Specify how the menu should align with the button element
+   * Experimental property. Specify how the menu should align with the button element.
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables precise
+   * viewport-collision avoidance for the menu's floating position globally.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   menuAlignment?: MenuAlignment;
 

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -71,6 +71,24 @@ export interface ModalSecondaryButton {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-dialog-element` — renders using the native `<dialog>` element,
+ *   enabling browser-native focus management and accessibility semantics.
+ *   Enable via `<FeatureFlags enableDialogElement>`.
+ *
+ * - `enable-presence` — keeps the modal unmounted when closed and mounts it
+ *   only when opened, reducing the initial DOM footprint.
+ *   Enable via `<FeatureFlags enablePresence>`.
+ *
+ * - `enable-focus-wrap-without-sentinels` — uses a sentinel-free focus-trap
+ *   implementation. Mutually exclusive with `enable-dialog-element`.
+ *   Enable via `<FeatureFlags enableFocusWrapWithoutSentinels>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify whether the Modal is displaying an alert, error or warning

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -101,6 +101,12 @@ export interface MultiSelectProps<ItemType>
    * element to avoid collisions with the viewport and being clipped by
    * ancestor elements. Requires React v17+
    * @see https://github.com/carbon-design-system/carbon/issues/18714
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables this
+   * behaviour globally without needing to set `autoAlign` on each instance.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   autoAlign?: boolean;
 

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -818,6 +818,16 @@ InlineNotification.propTypes = {
  * ======================
  */
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-focus-wrap-without-sentinels` — uses a sentinel-free focus-trap
+ *   implementation when `role="alertdialog"`.
+ *   Enable via `<FeatureFlags enableFocusWrapWithoutSentinels>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface ActionableNotificationProps
   extends HTMLAttributes<HTMLDivElement> {
   /**

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.featureflag.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.featureflag.stories.js
@@ -68,11 +68,7 @@ export const AutoAlign = () => {
 
 export const Nested = () => {
   return (
-    <FeatureFlags
-      flags={{
-        'enable-v12-overflowmenu': true,
-        'enable-v12-dynamic-floating-styles': false,
-      }}>
+    <FeatureFlags enableV12Overflowmenu enableV12DynamicFloatingStyles={false}>
       <OverflowMenu>
         <MenuItem label="Level 1" />
         <MenuItem label="Level 1" />

--- a/packages/react/src/components/OverflowMenu/next/index.tsx
+++ b/packages/react/src/components/OverflowMenu/next/index.tsx
@@ -31,6 +31,17 @@ interface OverflowMenuProps {
    * to avoid collisions with the viewport and being clipped by ancestor
    * elements. Requires React v17+
    * @see https://github.com/carbon-design-system/carbon/issues/18714
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables this
+   * behaviour globally without needing to set `autoAlign` on each instance.
+   *
+   * The `enable-v12-overflowmenu` feature flag replaces the legacy
+   * `OverflowMenu` implementation with this v12 variant (using `Menu`
+   * subcomponents) as the default.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>` or
+   * `<FeatureFlags enableV12Overflowmenu>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   autoAlign?: boolean;
 

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -100,6 +100,13 @@ export interface PopoverBaseProps {
    * is currently experimental and is subject to future changes. Requires
    * React v17+
    * @see https://github.com/carbon-design-system/carbon/issues/18714
+   *
+   * The `enable-v12-dynamic-floating-styles` feature flag enables floating-ui
+   * styles globally for all Popover-based components, making `autoAlign`
+   * behaviour the default regardless of this prop.
+   *
+   * Enable via `<FeatureFlags enableV12DynamicFloatingStyles>`.
+   * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
    */
   autoAlign?: boolean;
 

--- a/packages/react/src/components/RadioTile/RadioTile.tsx
+++ b/packages/react/src/components/RadioTile/RadioTile.tsx
@@ -23,6 +23,16 @@ import { useFeatureFlag } from '../FeatureFlags';
 import { AILabel } from '../AILabel';
 import { isComponentElement } from '../../internal';
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-v12-tile-radio-icons` — renders a `RadioButtonChecked` icon on
+ *   selected tiles and a `RadioButton` icon on unselected tiles.
+ *   Enable via `<FeatureFlags enableV12TileRadioIcons>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface RadioTileProps {
   /**
    * Specify whether the `RadioTile` should be checked.

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -152,6 +152,17 @@ Tile.propTypes = {
   ),
 };
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-v12-tile-default-icons` — when no `renderIcon` is provided, an
+ *   `ArrowRight` icon is rendered by default; when `disabled`, an `Error` icon
+ *   is shown instead.
+ *   Enable via `<FeatureFlags enableV12TileDefaultIcons>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export interface ClickableTileProps extends HTMLAttributes<HTMLAnchorElement> {
   children?: ReactNode;
   className?: string;

--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -36,6 +36,16 @@ type UncontrolledOnToggle = (
 
 type ControlledOnToggle = (isExpanded: TreeNodeProps['isExpanded']) => void;
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-treeview-controllable` — enables `defaultIsExpanded` on
+ *   `TreeNode` for setting an initial expansion state without controlling it.
+ *   Enable via `<FeatureFlags enableTreeviewControllable>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export type TreeNodeProps = {
   /**
    * **Note:** this is controlled by the parent TreeView component, do not set manually.

--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -25,6 +25,18 @@ type UncontrolledOnSelect = (
 
 type ControlledOnSelect = (selected: TreeViewProps['selected']) => void;
 
+/**
+ * @remarks
+ * **Feature flags that affect this component:**
+ *
+ * - `enable-treeview-controllable` — enables a controllable API where
+ *   `selected` and `active` state can be managed externally. Also enables the
+ *   `onActivate` callback. When disabled, the component uses uncontrolled
+ *   internal state for selection.
+ *   Enable via `<FeatureFlags enableTreeviewControllable>`.
+ *
+ * @see https://github.com/carbon-design-system/carbon/blob/main/docs/feature-flags.md
+ */
 export type TreeViewProps = {
   /**
    * Mark the active node in the tree, represented by its ID


### PR DESCRIPTION
Closes #18206

1. Adds ts annotation docs
2. Add console.warn once per component instance for next major prefixed flags

> [!NOTE]
> Covers only react currently

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

1. `FeatureFlags` component must have each flag prop annotated
2. Each component shipped with feature flags must have ts annotations showing the supported flags for the component

check the typescript docs after building
- packages/react/es/components/FeatureFlags/index.d.ts
- packages/react/es/components/ComposedModal/ComposedModal.d.ts
- packages/react/es/components/Modal/Modal.d.ts
- packages/react/es/components/Notification/Notification.d.ts
- packages/react/es/components/Grid/GridTypes.d.ts
- packages/react/es/components/Tile/Tile.d.ts
- packages/react/es/components/RadioTile/RadioTile.d.ts
- packages/react/es/components/TreeView/TreeView.d.ts
- packages/react/es/components/TreeView/TreeNode.d.ts
- packages/react/es/components/Popover/index.d.ts
- packages/react/es/components/OverflowMenu/next/index.d.ts
- packages/react/es/components/MenuButton/index.d.ts
- packages/react/es/components/ComboButton/index.d.ts

3. console warn should show for the flags - can be tested in the temporary [kitchen sink story](https://deploy-preview-22645--v11-carbon-react.netlify.app/?path=/story/components-featureflags-kitchensink--kitchen-sink) opening in isolation mode. (will be removed after the review)

scss flags doesn't show
enable-v12-toggle-reduced-label-spacing
enable-v12-structured-list-visible-icons

4. component warn assertions added - TODO

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
