### PR TITLE
fix(popover): close on Esc

### DIFF
--- a/e2e/components/Popover/Popover-test.avt.e2e.js
+++ b/e2e/components/Popover/Popover-test.avt.e2e.js
@@ -64,6 +64,11 @@ test.describe('@avt Popover', () => {
     await page.keyboard.press('Space');
     await expect(page.locator('.cds--popover--open')).toBeVisible();
     await page.keyboard.press('Escape');
+
+    // should not close on Esc, focus is not inside the content
+    await expect(page.locator('.cds--popover--open')).toBeVisible();
+
+    await page.keyboard.press('Space');
     await expect(page.locator('.cds--popover--open')).toBeHidden();
 
     // Testing right popover

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -14,9 +14,6 @@ import RadioButtonGroup from '../RadioButtonGroup';
 import { default as Checkbox } from '../Checkbox';
 import mdx from './Popover.mdx';
 import { Settings } from '@carbon/icons-react';
-import { keys, match } from '../../internal/keyboard';
-import OverflowMenu from '../OverflowMenu/OverflowMenu';
-import OverflowMenuItem from '../OverflowMenuItem';
 
 const prefix = 'cds';
 
@@ -80,11 +77,6 @@ export const TabTip = (args) => {
       <Popover
         align={align}
         open={open}
-        onKeyDown={(evt) => {
-          if (match(evt, keys.Escape)) {
-            setOpen(false);
-          }
-        }}
         isTabTip
         onRequestClose={() => setOpen(false)}
         {...args}>

--- a/packages/react/src/components/Popover/__tests__/Popover-test.js
+++ b/packages/react/src/components/Popover/__tests__/Popover-test.js
@@ -375,6 +375,48 @@ describe('Popover', () => {
 
       expect(onRequestClose).toHaveBeenCalled();
     });
+
+    it('should call onRequestClose when pressing Escape while the popover content is focused', async () => {
+      const onRequestClose = jest.fn();
+      render(
+        <Popover open onRequestClose={() => onRequestClose()}>
+          <button type="button" data-testid="trigger">
+            Settings
+          </button>
+          <PopoverContent>
+            <button data-testid="inside-button">Inside Button</button>
+          </PopoverContent>
+        </Popover>
+      );
+
+      screen.getByTestId('inside-button').focus();
+      await userEvent.keyboard('{Escape}');
+
+      expect(onRequestClose).toHaveBeenCalled();
+
+      // focus should return to trigger
+      expect(screen.getByTestId('trigger')).toHaveFocus();
+    });
+
+    it('should NOT call onRequestClose when pressing Escape while the trigger is focused', async () => {
+      const onRequestClose = jest.fn();
+      render(
+        <Popover open onRequestClose={() => onRequestClose()}>
+          <button type="button" data-testid="trigger">
+            Settings
+          </button>
+          <PopoverContent>test</PopoverContent>
+        </Popover>
+      );
+
+      screen.getByTestId('trigger').focus();
+      await userEvent.keyboard('{Escape}');
+
+      expect(onRequestClose).not.toHaveBeenCalled();
+
+      // focus should remain on trigger
+      expect(screen.getByTestId('trigger')).toHaveFocus();
+    });
   });
 
   it('should NOT call onRequestClose when clicking inside the popover content', async () => {

--- a/packages/react/src/components/Popover/__tests__/Popover-test.js
+++ b/packages/react/src/components/Popover/__tests__/Popover-test.js
@@ -444,6 +444,31 @@ describe('Popover', () => {
 
       expect(onRequestClose).not.toHaveBeenCalled();
     });
+
+    it('should only call onRequestClose for the innermost nested popover on Escape', async () => {
+      const onOuterRequestClose = jest.fn();
+      const onInnerRequestClose = jest.fn();
+
+      render(
+        <Popover open onRequestClose={onOuterRequestClose}>
+          <button>Outer trigger</button>
+          <PopoverContent>
+            <Popover open onRequestClose={onInnerRequestClose}>
+              <button>Inner trigger</button>
+              <PopoverContent>
+                <button data-testid="inner-button">Inner button</button>
+              </PopoverContent>
+            </Popover>
+          </PopoverContent>
+        </Popover>
+      );
+
+      screen.getByTestId('inner-button').focus();
+      await userEvent.keyboard('{Escape}');
+
+      expect(onInnerRequestClose).toHaveBeenCalled();
+      expect(onOuterRequestClose).not.toHaveBeenCalled();
+    });
   });
 
   it('should NOT call onRequestClose when clicking inside the popover content', async () => {

--- a/packages/react/src/components/Popover/__tests__/Popover-test.js
+++ b/packages/react/src/components/Popover/__tests__/Popover-test.js
@@ -417,6 +417,33 @@ describe('Popover', () => {
       // focus should remain on trigger
       expect(screen.getByTestId('trigger')).toHaveFocus();
     });
+
+    it('should NOT call onRequestClose when a control inside the content handles Escape via preventDefault', async () => {
+      const onRequestClose = jest.fn();
+      render(
+        <Popover open onRequestClose={() => onRequestClose()}>
+          <button type="button" data-testid="trigger">
+            Settings
+          </button>
+          <PopoverContent>
+            <button
+              data-testid="inside-button"
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                }
+              }}>
+              Inside Button
+            </button>
+          </PopoverContent>
+        </Popover>
+      );
+
+      screen.getByTestId('inside-button').focus();
+      await userEvent.keyboard('{Escape}');
+
+      expect(onRequestClose).not.toHaveBeenCalled();
+    });
   });
 
   it('should NOT call onRequestClose when clicking inside the popover content', async () => {

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -280,7 +280,8 @@ export const Popover: PopoverComponent & {
   useWindowEvent('keydown', (event) => {
     if (!open || event.key !== 'Escape' || event.defaultPrevented) return;
 
-    // Esc should only close the popover if focus is inside the popover content
+    // Esc should only close the popover if focus is inside the popover content,
+    // it should also only close its direct parent in the case of nesting
     const target = event.target;
     if (
       !(target instanceof Element) ||

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -20,6 +20,7 @@ import { isComponentElement } from '../../internal';
 import { useMergedRefs } from '../../internal/useMergedRefs';
 import { usePrefix } from '../../internal/usePrefix';
 import { useWindowEvent, useEvent } from '../../internal/useEvent';
+import { selectorTabbable } from '../../internal/keyboard/navigation';
 import { mapPopoverAlign } from '../../tools/mapPopoverAlign';
 import {
   useFloating,
@@ -274,6 +275,23 @@ export const Popover: PopoverComponent & {
         onRequestClose?.();
       }
     }
+  });
+
+  useEvent(popover, 'keydown', (event) => {
+    if (event.key !== 'Escape') return;
+
+    // Esc should only close the popover if focus lives inside the popover content
+    if (!refs.floating.current?.contains(document.activeElement)) {
+      return;
+    }
+    onRequestClose?.();
+
+    // Return focus to the trigger. It's rendered before `PopoverContent`, so
+    // the first tabbable element in the container is the trigger's focusable
+    // element.
+    const trigger =
+      popover.current?.querySelector<HTMLElement>(selectorTabbable);
+    trigger?.focus();
   });
 
   useWindowEvent('click', ({ target }) => {

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -277,8 +277,8 @@ export const Popover: PopoverComponent & {
     }
   });
 
-  useEvent(popover, 'keydown', (event) => {
-    if (event.key !== 'Escape') return;
+  useWindowEvent('keydown', (event) => {
+    if (!open || event.key !== 'Escape' || event.defaultPrevented) return;
 
     // Esc should only close the popover if focus is inside the popover content
     if (!refs.floating.current?.contains(document.activeElement)) {

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -280,8 +280,7 @@ export const Popover: PopoverComponent & {
   useWindowEvent('keydown', (event) => {
     if (!open || event.key !== 'Escape' || event.defaultPrevented) return;
 
-    // Esc should only close the popover if focus is inside the popover content,
-    // it should also only close its direct parent in the case of nesting
+    // Esc should only close the popover if focus is inside the popover content
     const target = event.target;
     if (
       !(target instanceof Element) ||

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -280,15 +280,13 @@ export const Popover: PopoverComponent & {
   useEvent(popover, 'keydown', (event) => {
     if (event.key !== 'Escape') return;
 
-    // Esc should only close the popover if focus lives inside the popover content
+    // Esc should only close the popover if focus is inside the popover content
     if (!refs.floating.current?.contains(document.activeElement)) {
       return;
     }
     onRequestClose?.();
 
-    // Return focus to the trigger. It's rendered before `PopoverContent`, so
-    // the first tabbable element in the container is the trigger's focusable
-    // element.
+    // return focus to the trigger while making sure it is tabbable
     const trigger =
       popover.current?.querySelector<HTMLElement>(selectorTabbable);
     trigger?.focus();

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -281,7 +281,11 @@ export const Popover: PopoverComponent & {
     if (!open || event.key !== 'Escape' || event.defaultPrevented) return;
 
     // Esc should only close the popover if focus is inside the popover content
-    if (!refs.floating.current?.contains(document.activeElement)) {
+    const target = event.target;
+    if (
+      !(target instanceof Element) ||
+      target.closest(`.${prefix}--popover-content`) !== refs.floating.current
+    ) {
       return;
     }
     onRequestClose?.();

--- a/packages/web-components/src/components/popover/__tests__/popover-test.js
+++ b/packages/web-components/src/components/popover/__tests__/popover-test.js
@@ -561,6 +561,71 @@ describe('cds-popover focusout/outsideclick', () => {
     expect(document.activeElement).to.equal(outside);
   });
 
+  it('closes when pressing Escape while focus is inside the popover content', async () => {
+    const el = await fixture(html`
+      <div>
+        <cds-popover open id="popover">
+          <button id="trigger" type="button">Test</button>
+          <cds-popover-content>
+            <button id="inside">Inside</button>
+          </cds-popover-content>
+        </cds-popover>
+      </div>
+    `);
+
+    await el.updateComplete;
+    const popover = el.querySelector('#popover');
+    const trigger = popover.querySelector('#trigger');
+    const inside = popover.querySelector('#inside');
+
+    let eventFired = false;
+    popover.addEventListener('cds-popover-closed', () => {
+      eventFired = true;
+    });
+
+    expect(popover.hasAttribute('open')).to.be.true;
+
+    inside.focus();
+    await el.updateComplete;
+
+    await sendKeys({ press: 'Escape' });
+    await el.updateComplete;
+
+    expect(eventFired).to.be.true;
+    expect(popover.hasAttribute('open')).to.be.false;
+
+    // focus should return to trigger
+    expect(document.activeElement).to.equal(trigger);
+  });
+
+  it('does NOT close when pressing Escape while the trigger is focused', async () => {
+    const el = await fixture(html`
+      <div>
+        <cds-popover open id="popover">
+          <button id="trigger" type="button">Test</button>
+          <cds-popover-content></cds-popover-content>
+        </cds-popover>
+      </div>
+    `);
+
+    await el.updateComplete;
+    const popover = el.querySelector('#popover');
+    const trigger = popover.querySelector('#trigger');
+
+    expect(popover.hasAttribute('open')).to.be.true;
+
+    trigger.focus();
+    await el.updateComplete;
+
+    await sendKeys({ press: 'Escape' });
+    await el.updateComplete;
+
+    expect(popover.hasAttribute('open')).to.be.true;
+
+    // focus should remain on trigger
+    expect(document.activeElement).to.equal(trigger);
+  });
+
   it('should properly handle keyboard nav within elements inside popover', async () => {
     const el = await fixture(html`
       <cds-popover open id="popover">

--- a/packages/web-components/src/components/popover/__tests__/popover-test.js
+++ b/packages/web-components/src/components/popover/__tests__/popover-test.js
@@ -657,6 +657,38 @@ describe('cds-popover focusout/outsideclick', () => {
     expect(popover.hasAttribute('open')).to.be.true;
   });
 
+  it('only closes the innermost popover when nested and pressing Escape', async () => {
+    const el = await fixture(html`
+      <div>
+        <cds-popover open id="outer">
+          <button id="outer-trigger" type="button">Outer</button>
+          <cds-popover-content>
+            <cds-popover open id="inner">
+              <button id="inner-trigger" type="button">Inner</button>
+              <cds-popover-content>
+                <button id="inner-button">Inner button</button>
+              </cds-popover-content>
+            </cds-popover>
+          </cds-popover-content>
+        </cds-popover>
+      </div>
+    `);
+
+    await el.updateComplete;
+    const outer = el.querySelector('#outer');
+    const inner = el.querySelector('#inner');
+    const innerButton = el.querySelector('#inner-button');
+
+    innerButton.focus();
+    await el.updateComplete;
+
+    await sendKeys({ press: 'Escape' });
+    await el.updateComplete;
+
+    expect(inner.hasAttribute('open')).to.be.false;
+    expect(outer.hasAttribute('open')).to.be.true;
+  });
+
   it('should properly handle keyboard nav within elements inside popover', async () => {
     const el = await fixture(html`
       <cds-popover open id="popover">

--- a/packages/web-components/src/components/popover/__tests__/popover-test.js
+++ b/packages/web-components/src/components/popover/__tests__/popover-test.js
@@ -626,6 +626,37 @@ describe('cds-popover focusout/outsideclick', () => {
     expect(document.activeElement).to.equal(trigger);
   });
 
+  it('does NOT close when a control inside the content handles Escape via preventDefault', async () => {
+    const el = await fixture(html`
+      <div>
+        <cds-popover open id="popover">
+          <button id="trigger" type="button">Test</button>
+          <cds-popover-content>
+            <button id="inside">Inside</button>
+          </cds-popover-content>
+        </cds-popover>
+      </div>
+    `);
+
+    await el.updateComplete;
+    const popover = el.querySelector('#popover');
+    const inside = popover.querySelector('#inside');
+
+    inside.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+      }
+    });
+
+    inside.focus();
+    await el.updateComplete;
+
+    await sendKeys({ press: 'Escape' });
+    await el.updateComplete;
+
+    expect(popover.hasAttribute('open')).to.be.true;
+  });
+
   it('should properly handle keyboard nav within elements inside popover', async () => {
     const el = await fixture(html`
       <cds-popover open id="popover">

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -150,6 +150,48 @@ class CDSPopover extends HostListenerMixin(LitElement) {
     } else {
       this._tabKeyPressed = false;
     }
+
+    if (event.key === 'Escape') {
+      // Esc should only close the popover if focus lives inside the popover content
+      const content = this.querySelector(
+        (this.constructor as typeof CDSPopover).selectorPopoverContent
+      );
+      if (!content || !deepShadowContains(content, event.target)) {
+        return;
+      }
+
+      if (
+        this.dispatchEvent(
+          new CustomEvent(
+            (this.constructor as typeof CDSPopover).eventBeforeClose,
+            {
+              bubbles: true,
+              cancelable: true,
+              composed: true,
+              detail: {
+                triggeredBy: event.target,
+              },
+            }
+          )
+        )
+      ) {
+        this.open = false;
+        this.dispatchEvent(
+          new CustomEvent(
+            (this.constructor as typeof CDSPopover).eventOnClose,
+            {
+              bubbles: true,
+              composed: true,
+            }
+          )
+        );
+
+        // return focus to the trigger
+        const trigger =
+          this._triggerSlotNode.assignedElements()[0] as HTMLElement;
+        trigger?.focus();
+      }
+    }
   }
 
   @HostListener('focusout')

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -157,7 +157,7 @@ class CDSPopover extends HostListenerMixin(LitElement) {
       }
 
       // Esc should only close the popover if focus is inside the popover content,
-      // it should also only close the innermost popover in the case of nesting
+      // it should also only close its direct parent in the case of nesting
       const selectorPopoverContent = (this.constructor as typeof CDSPopover)
         .selectorPopoverContent;
 

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -156,8 +156,7 @@ class CDSPopover extends HostListenerMixin(LitElement) {
         return;
       }
 
-      // Esc should only close the popover if focus is inside the popover content,
-      // it should also only close its direct parent in the case of nesting
+      // Esc should only close the popover if focus is inside the popover content
       const selectorPopoverContent = (this.constructor as typeof CDSPopover)
         .selectorPopoverContent;
 

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -155,21 +155,20 @@ class CDSPopover extends HostListenerMixin(LitElement) {
       if (event.defaultPrevented) {
         return;
       }
-      // Esc should only close the popover if focus is inside the popover content
-      const content = this.querySelector(
-        (this.constructor as typeof CDSPopover).selectorPopoverContent
-      );
-      if (!content || !deepShadowContains(content, event.target)) {
-        return;
-      }
 
-      const target = event.target;
-      if (
-        target instanceof Element &&
-        target.closest(
-          (this.constructor as typeof CDSPopover).selectorPopoverContent
-        ) !== content
-      ) {
+      // Esc should only close the popover if focus is inside the popover content,
+      // it should also only close the innermost popover in the case of nesting
+      const selectorPopoverContent = (this.constructor as typeof CDSPopover)
+        .selectorPopoverContent;
+
+      const parentPopoverContent = event
+        .composedPath()
+        .find(
+          (node) =>
+            node instanceof Element && node.matches(selectorPopoverContent)
+        );
+
+      if (parentPopoverContent !== this.querySelector(selectorPopoverContent)) {
         return;
       }
 

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -152,6 +152,9 @@ class CDSPopover extends HostListenerMixin(LitElement) {
     }
 
     if (event.key === 'Escape') {
+      if (event.defaultPrevented) {
+        return;
+      }
       // Esc should only close the popover if focus is inside the popover content
       const content = this.querySelector(
         (this.constructor as typeof CDSPopover).selectorPopoverContent
@@ -187,9 +190,10 @@ class CDSPopover extends HostListenerMixin(LitElement) {
         );
 
         // return focus to the trigger
-        const trigger =
-          this._triggerSlotNode.assignedElements()[0] as HTMLElement;
-        trigger?.focus();
+        const trigger = this._triggerSlotNode.assignedElements()[0];
+        if (trigger instanceof HTMLElement) {
+          trigger.focus();
+        }
       }
     }
   }

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -152,7 +152,7 @@ class CDSPopover extends HostListenerMixin(LitElement) {
     }
 
     if (event.key === 'Escape') {
-      // Esc should only close the popover if focus lives inside the popover content
+      // Esc should only close the popover if focus is inside the popover content
       const content = this.querySelector(
         (this.constructor as typeof CDSPopover).selectorPopoverContent
       );

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -163,6 +163,16 @@ class CDSPopover extends HostListenerMixin(LitElement) {
         return;
       }
 
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(
+          (this.constructor as typeof CDSPopover).selectorPopoverContent
+        ) !== content
+      ) {
+        return;
+      }
+
       if (
         this.dispatchEvent(
           new CustomEvent(

--- a/packages/web-components/src/components/popover/popover.ts
+++ b/packages/web-components/src/components/popover/popover.ts
@@ -199,7 +199,9 @@ class CDSPopover extends HostListenerMixin(LitElement) {
         );
 
         // return focus to the trigger
-        const trigger = this._triggerSlotNode.assignedElements()[0];
+        const trigger = this._triggerSlotNode.assignedElements({
+          flatten: true,
+        })[0];
         if (trigger instanceof HTMLElement) {
           trigger.focus();
         }


### PR DESCRIPTION
Closes #21972

Adds close on `Esc` functionality to Popover in React and Web Components. Users can click `Esc` when focus is within the popover content to close it as per the [docs](https://preview.carbondesignsystem.com/building-blocks/core/components/popover/accessibility#keyboard-interactions)

### Changelog

**New**

- Added `keydown` handlers to close the popover when popover content is focused, and return focus to the trigger button
- Added tests to cover this change

**Removed**

- In `packages/react/src/components/Popover/Popover.stories.js`, cleaned up some imports and removed the `onKeyDown` in the Tabtip story that would close the popover by clicking `Esc` on the trigger

#### Testing / Reviewing

- Go to the Popover stories in React and WC
- Focus the trigger button and click Esc, popover should not close
- Go to the Tabtip story and focus on anything inside the popover content and click Esc, popover should close and focus should return to the trigger button
- CI should pass

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~~[ ] Updated documentation and storybook examples~~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass