### PR TITLE
fix(popover): set color for tab tip button

### DIFF
--- a/packages/web-components/src/components/popover/popover.scss
+++ b/packages/web-components/src/components/popover/popover.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -47,7 +47,7 @@ $popover-border-color: custom-property.get-var(
   ::slotted(.#{$prefix}--popover--tab-tip__button) {
     @include popover-tab-tip-button;
 
-    color: theme.$icon-primary;
+    // color: theme.$icon-primary;
   }
 }
 

--- a/packages/web-components/src/components/popover/popover.scss
+++ b/packages/web-components/src/components/popover/popover.scss
@@ -47,7 +47,7 @@ $popover-border-color: custom-property.get-var(
   ::slotted(.#{$prefix}--popover--tab-tip__button) {
     @include popover-tab-tip-button;
 
-    // color: theme.$icon-primary;
+    color: theme.$icon-primary;
   }
 }
 

--- a/packages/web-components/src/components/popover/popover.scss
+++ b/packages/web-components/src/components/popover/popover.scss
@@ -46,6 +46,8 @@ $popover-border-color: custom-property.get-var(
 :host(#{$prefix}-popover) {
   ::slotted(.#{$prefix}--popover--tab-tip__button) {
     @include popover-tab-tip-button;
+
+    color: theme.$icon-primary;
   }
 }
 


### PR DESCRIPTION
Closes #22650

The issue states that the trigger button svg isn't visible in white theme, but for me it's the dark theme that the svg isn't visible. This PR sets the `color` style for the tab-tip button as the button is slotted. 

<img width="1226" height="726" alt="Screenshot 2026-07-08 at 5 41 40 PM" src="https://github.com/user-attachments/assets/15ed5d5d-fad0-47b3-8625-0f61b5b8d5d1" />

```
::slotted(.cds--popover--tab-tip__button) {
  svg {
    fill: theme.$icon-primary;
  }
}
```

doesn't work as with `::slotted` you can't reach further down to its descendants. Solution here to to apply the fill color to the button itself.

### Changelog

**New**

- add `color` to tab tip button

#### Testing / Reviewing

Go to [web components deploy preview](https://deploy-preview-22654--v11-carbon-web-components.netlify.app/?path=/story/components-popover--tab-tip&globals=backgrounds.value:g90) and change the theme settings in the toolbar. Confirm the icon color adapts to theme and is visible with the theme changes.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
