### PR TITLE
fix(overflow-menu): preserve visible programmatic focus

### DIFF
--- a/packages/web-components/src/components/overflow-menu/__tests__/overflow-menu-test.js
+++ b/packages/web-components/src/components/overflow-menu/__tests__/overflow-menu-test.js
@@ -30,9 +30,109 @@ describe('cds-overflow-menu', () => {
     </cds-overflow-menu-body>
   </cds-overflow-menu>`;
 
+  const emulateMissingFocusPseudoClass = (el) => {
+    const triggerButton = el.shadowRoot.querySelector('button');
+    const matches = triggerButton.matches.bind(triggerButton);
+    triggerButton.matches = (selector) =>
+      selector === ':focus' ? false : matches(selector);
+  };
+
+  const emulateNativeFocusPseudoClass = (el) => {
+    const triggerButton = el.shadowRoot.querySelector('button');
+    const matches = triggerButton.matches.bind(triggerButton);
+    triggerButton.matches = (selector) =>
+      selector === ':focus' ? true : matches(selector);
+  };
+
   it('should render', async () => {
     const el = await fixture(basicOverflowMenu);
     expect(el);
+  });
+
+  it('should use the native programmatic focus state when available', async () => {
+    const el = await fixture(basicOverflowMenu);
+    const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+    const triggerButton = el.shadowRoot.querySelector('button');
+    tooltip.keyboardOnly = true;
+    emulateNativeFocusPseudoClass(el);
+
+    el.focus();
+
+    expect(document.activeElement).to.equal(el);
+    expect(el.shadowRoot?.activeElement).to.equal(triggerButton);
+    expect(el).not.to.have.attribute('data-programmatic-focus');
+    el.shadowRoot.querySelector('button').blur();
+  });
+
+  it('should remove programmatic focus styling on outside pointerdown', async () => {
+    const el = await fixture(basicOverflowMenu);
+    const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+    tooltip.keyboardOnly = true;
+
+    emulateMissingFocusPseudoClass(el);
+    el.focus();
+    expect(el).to.have.attribute('data-programmatic-focus');
+
+    document.body.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, composed: true })
+    );
+
+    expect(el).not.to.have.attribute('data-programmatic-focus');
+    el.shadowRoot.querySelector('button').blur();
+  });
+
+  it('should remove programmatic focus styling when focus moves outside', async () => {
+    const el = await fixture(basicOverflowMenu);
+    const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+    tooltip.keyboardOnly = true;
+
+    emulateMissingFocusPseudoClass(el);
+    el.focus();
+    expect(el).to.have.attribute('data-programmatic-focus');
+
+    document.body.dispatchEvent(
+      new FocusEvent('focusin', { bubbles: true, composed: true })
+    );
+
+    expect(el).not.to.have.attribute('data-programmatic-focus');
+    el.shadowRoot.querySelector('button').blur();
+  });
+
+  it('should open the tooltip when the native focus event is missing', async () => {
+    const el = await fixture(html`
+      <cds-overflow-menu enter-delay-ms="0">
+        <span slot="tooltip-content">Options</span>
+        <cds-overflow-menu-body>
+          <cds-overflow-menu-item>Filter A</cds-overflow-menu-item>
+        </cds-overflow-menu-body>
+      </cds-overflow-menu>
+    `);
+    const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+
+    emulateMissingFocusPseudoClass(el);
+    el.focus();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tooltip.updateComplete;
+
+    expect(tooltip.open).to.be.true;
+    el.shadowRoot.querySelector('button').blur();
+  });
+
+  it('should not style programmatic focus when disabled', async () => {
+    const el = await fixture(html`
+      <cds-overflow-menu disabled>
+        <span slot="tooltip-content">Options</span>
+        <cds-overflow-menu-body>
+          <cds-overflow-menu-item>Filter A</cds-overflow-menu-item>
+        </cds-overflow-menu-body>
+      </cds-overflow-menu>
+    `);
+    const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+    tooltip.keyboardOnly = true;
+
+    el.focus();
+
+    expect(el).not.to.have.attribute('data-programmatic-focus');
   });
 
   describe('supports size', () => {

--- a/packages/web-components/src/components/overflow-menu/__tests__/overflow-menu-test.js
+++ b/packages/web-components/src/components/overflow-menu/__tests__/overflow-menu-test.js
@@ -30,19 +30,21 @@ describe('cds-overflow-menu', () => {
     </cds-overflow-menu-body>
   </cds-overflow-menu>`;
 
-  const emulateMissingFocusPseudoClass = (el) => {
+  const emulateFocusPseudoClass = (el, isFocused) => {
     const triggerButton = el.shadowRoot.querySelector('button');
     const matches = triggerButton.matches.bind(triggerButton);
     triggerButton.matches = (selector) =>
-      selector === ':focus' ? false : matches(selector);
+      selector === ':focus' ? isFocused : matches(selector);
+    return () => {
+      triggerButton.matches = matches;
+    };
   };
 
-  const emulateNativeFocusPseudoClass = (el) => {
-    const triggerButton = el.shadowRoot.querySelector('button');
-    const matches = triggerButton.matches.bind(triggerButton);
-    triggerButton.matches = (selector) =>
-      selector === ':focus' ? true : matches(selector);
-  };
+  const emulateMissingFocusPseudoClass = (el) =>
+    emulateFocusPseudoClass(el, false);
+
+  const emulateNativeFocusPseudoClass = (el) =>
+    emulateFocusPseudoClass(el, true);
 
   it('should render', async () => {
     const el = await fixture(basicOverflowMenu);
@@ -54,14 +56,18 @@ describe('cds-overflow-menu', () => {
     const tooltip = el.shadowRoot.querySelector('cds-tooltip');
     const triggerButton = el.shadowRoot.querySelector('button');
     tooltip.keyboardOnly = true;
-    emulateNativeFocusPseudoClass(el);
+    const restoreMatches = emulateNativeFocusPseudoClass(el);
 
-    el.focus();
+    try {
+      el.focus();
 
-    expect(document.activeElement).to.equal(el);
-    expect(el.shadowRoot?.activeElement).to.equal(triggerButton);
-    expect(el).not.to.have.attribute('data-programmatic-focus');
-    el.shadowRoot.querySelector('button').blur();
+      expect(document.activeElement).to.equal(el);
+      expect(el.shadowRoot?.activeElement).to.equal(triggerButton);
+      expect(el).not.to.have.attribute('data-programmatic-focus');
+    } finally {
+      restoreMatches();
+      el.shadowRoot.querySelector('button').blur();
+    }
   });
 
   it('should remove programmatic focus styling on outside pointerdown', async () => {
@@ -69,16 +75,21 @@ describe('cds-overflow-menu', () => {
     const tooltip = el.shadowRoot.querySelector('cds-tooltip');
     tooltip.keyboardOnly = true;
 
-    emulateMissingFocusPseudoClass(el);
-    el.focus();
-    expect(el).to.have.attribute('data-programmatic-focus');
+    const restoreMatches = emulateMissingFocusPseudoClass(el);
 
-    document.body.dispatchEvent(
-      new PointerEvent('pointerdown', { bubbles: true, composed: true })
-    );
+    try {
+      el.focus();
+      expect(el).to.have.attribute('data-programmatic-focus');
 
-    expect(el).not.to.have.attribute('data-programmatic-focus');
-    el.shadowRoot.querySelector('button').blur();
+      document.body.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+
+      expect(el).not.to.have.attribute('data-programmatic-focus');
+    } finally {
+      restoreMatches();
+      el.shadowRoot.querySelector('button').blur();
+    }
   });
 
   it('should remove programmatic focus styling when focus moves outside', async () => {
@@ -86,16 +97,21 @@ describe('cds-overflow-menu', () => {
     const tooltip = el.shadowRoot.querySelector('cds-tooltip');
     tooltip.keyboardOnly = true;
 
-    emulateMissingFocusPseudoClass(el);
-    el.focus();
-    expect(el).to.have.attribute('data-programmatic-focus');
+    const restoreMatches = emulateMissingFocusPseudoClass(el);
 
-    document.body.dispatchEvent(
-      new FocusEvent('focusin', { bubbles: true, composed: true })
-    );
+    try {
+      el.focus();
+      expect(el).to.have.attribute('data-programmatic-focus');
 
-    expect(el).not.to.have.attribute('data-programmatic-focus');
-    el.shadowRoot.querySelector('button').blur();
+      document.body.dispatchEvent(
+        new FocusEvent('focusin', { bubbles: true, composed: true })
+      );
+
+      expect(el).not.to.have.attribute('data-programmatic-focus');
+    } finally {
+      restoreMatches();
+      el.shadowRoot.querySelector('button').blur();
+    }
   });
 
   it('should open the tooltip when the native focus event is missing', async () => {
@@ -108,14 +124,46 @@ describe('cds-overflow-menu', () => {
       </cds-overflow-menu>
     `);
     const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+    const restoreMatches = emulateMissingFocusPseudoClass(el);
 
-    emulateMissingFocusPseudoClass(el);
-    el.focus();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await tooltip.updateComplete;
+    try {
+      el.focus();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await tooltip.updateComplete;
 
-    expect(tooltip.open).to.be.true;
-    el.shadowRoot.querySelector('button').blur();
+      expect(tooltip.open).to.be.true;
+    } finally {
+      restoreMatches();
+      el.shadowRoot.querySelector('button').blur();
+    }
+  });
+
+  it('should cancel a queued tooltip open when focus leaves early', async () => {
+    const el = await fixture(html`
+      <cds-overflow-menu enter-delay-ms="10">
+        <span slot="tooltip-content">Options</span>
+        <cds-overflow-menu-body>
+          <cds-overflow-menu-item>Filter A</cds-overflow-menu-item>
+        </cds-overflow-menu-body>
+      </cds-overflow-menu>
+    `);
+    const tooltip = el.shadowRoot.querySelector('cds-tooltip');
+    const restoreMatches = emulateMissingFocusPseudoClass(el);
+
+    try {
+      el.focus();
+      document.body.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await tooltip.updateComplete;
+
+      expect(tooltip.open).to.be.false;
+    } finally {
+      restoreMatches();
+      el.shadowRoot.querySelector('button').blur();
+    }
   });
 
   it('should not style programmatic focus when disabled', async () => {

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.scss
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.scss
@@ -10,10 +10,16 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/utilities/convert';
+@use '@carbon/styles/scss/utilities/focus-outline' as *;
 @use '@carbon/styles/scss/components/overflow-menu/overflow-menu' as *;
 
 // https://github.com/carbon-design-system/carbon/issues/11408
 @include overflow-menu;
+
+// Fallback visible focus style when the trigger's native focus ring is not shown.
+:host([data-programmatic-focus]) {
+  @include focus-outline('outline');
+}
 
 :host(#{$prefix}-overflow-menu),
 :host(#{$prefix}-breadcrumb-overflow-menu) {

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.scss
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.scss
@@ -18,7 +18,8 @@
 @include overflow-menu;
 
 // Fallback visible focus style when the trigger's native focus ring is not shown.
-:host(#{$prefix}-overflow-menu[data-programmatic-focus]) {
+:host(#{$prefix}-overflow-menu[data-programmatic-focus]),
+:host(#{$prefix}-breadcrumb-overflow-menu[data-programmatic-focus]) {
   @include focus-outline('outline');
 }
 

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.ts
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.ts
@@ -336,7 +336,11 @@ class CDSOverflowMenu
   };
 
   private _clearProgrammaticFocus() {
+    const triggerButton = this._getTriggerButton();
+    const hadProgrammaticFocus = this.hasAttribute('data-programmatic-focus');
+
     this.toggleAttribute('data-programmatic-focus', false);
+    triggerButton?.removeEventListener('blur', this._handleTriggerBlur);
     this.ownerDocument.removeEventListener(
       'pointerdown',
       this._handleDocumentInteraction,
@@ -347,6 +351,10 @@ class CDSOverflowMenu
       this._handleDocumentInteraction,
       true
     );
+
+    if (hadProgrammaticFocus) {
+      triggerButton?.dispatchEvent(new FocusEvent('focusout'));
+    }
   }
 
   connectedCallback() {
@@ -354,9 +362,7 @@ class CDSOverflowMenu
       this.setAttribute('aria-haspopup', 'true');
     }
     if (!this.shadowRoot) {
-      this.attachShadow(
-        (this.constructor as typeof CDSOverflowMenu).shadowRootOptions
-      );
+      this.attachShadow({ mode: 'open' });
     }
     super.connectedCallback();
 

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.ts
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.ts
@@ -281,12 +281,82 @@ class CDSOverflowMenu
     return this.getBoundingClientRect();
   }
 
+  /**
+   * Delegates host focus to the trigger and preserves visible focus when needed.
+   */
+  focus(options?: FocusOptions): void {
+    const triggerButton = this._getTriggerButton();
+    if (!triggerButton) {
+      HTMLElement.prototype.focus.call(this, options);
+      return;
+    }
+
+    HTMLElement.prototype.focus.call(this, options);
+
+    if (this.shadowRoot?.activeElement !== triggerButton) {
+      triggerButton.focus(options);
+    }
+
+    if (this.shadowRoot?.activeElement !== triggerButton) {
+      return;
+    }
+
+    if (triggerButton.matches(':focus')) {
+      return;
+    }
+
+    // Some browsers do not expose `:focus` or emit `focus` for the tooltip
+    // trigger after delegated programmatic focus.
+    triggerButton.dispatchEvent(new FocusEvent('focus'));
+    this.toggleAttribute('data-programmatic-focus', true);
+    triggerButton.addEventListener('blur', this._handleTriggerBlur, {
+      once: true,
+    });
+    this.ownerDocument.addEventListener(
+      'pointerdown',
+      this._handleDocumentInteraction,
+      true
+    );
+    this.ownerDocument.addEventListener(
+      'focusin',
+      this._handleDocumentInteraction,
+      true
+    );
+  }
+
+  private _handleTriggerBlur = () => {
+    this._clearProgrammaticFocus();
+  };
+
+  private _handleDocumentInteraction = (event: Event) => {
+    const triggerButton = this._getTriggerButton();
+    if (!triggerButton || !event.composedPath().includes(triggerButton)) {
+      this._clearProgrammaticFocus();
+    }
+  };
+
+  private _clearProgrammaticFocus() {
+    this.toggleAttribute('data-programmatic-focus', false);
+    this.ownerDocument.removeEventListener(
+      'pointerdown',
+      this._handleDocumentInteraction,
+      true
+    );
+    this.ownerDocument.removeEventListener(
+      'focusin',
+      this._handleDocumentInteraction,
+      true
+    );
+  }
+
   connectedCallback() {
     if (!this.hasAttribute('aria-haspopup')) {
       this.setAttribute('aria-haspopup', 'true');
     }
     if (!this.shadowRoot) {
-      this.attachShadow({ mode: 'open' });
+      this.attachShadow(
+        (this.constructor as typeof CDSOverflowMenu).shadowRootOptions
+      );
     }
     super.connectedCallback();
 
@@ -309,6 +379,7 @@ class CDSOverflowMenu
     this.removeEventListener('click', this._handleClickTrigger);
     this.removeEventListener('keydown', this._handleKeydownTrigger);
     this.removeEventListener('mousedown', this._handleMousedownTrigger);
+    this._clearProgrammaticFocus();
     super.disconnectedCallback();
   }
 


### PR DESCRIPTION
Closes #21513 

Add programmatic focus support to `cds-overflow-menu` and make the focus ring show when focus is set with JavaScript

### Changelog

**New**

- Added support for programmatic focus in `cds-overflow-menu`
- Added tests for native focus and fallback focus behavior

**Changed**

- Updated `cds-overflow-menu` to keep a visible focus style when the browser does not show the native focus ring
- Updated the fallback focus style to also cover breadcrumb overflow menu usage

**Removed**

- ~None~

#### Testing / Reviewing

1. Go to `WC Deploy Preview` > `Overflow Menu` > `Default`
2. Inspect the overflow menu element
3. Open the browser console and run `document.querySelector('cds-overflow-menu').focus()`
4. Confirm the overflow menu receives focus and shows a visible focus ring

You can also test Breadcrumb:

1. Go to `WC Deploy Preview` > `Breadcrumb` > `Breadcrumb With Overflow Menu`
2. Inspect the breadcrumb overflow menu element
3. Open the browser console and run `document.querySelector('cds-overflow-menu[breadcrumb]').focus()`
4. Confirm the breadcrumb overflow menu receives focus and shows a visible focus ring

<details>

<summary>You can follow the recording</summary>


https://github.com/user-attachments/assets/8e1a39d3-c09f-427d-9cf3-1c7608ecdd7d

</details>

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)