### PR TITLE
fix(Modal): preserve default dialog role on non-alert modals

### DIFF
--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -1671,33 +1671,28 @@ describe.each([
   });
 });
 
-describe('Modal - enableDialogElement role attribute', () => {
-  // Regression for #22666: with the enableDialogElement flag, a non-alert Modal set
-  // role="" on the <dialog>, hiding its implicit "dialog" role from assistive tech and
-  // breaking *ByRole('dialog') queries. The attribute should be omitted (undefined) so
-  // the native dialog role is preserved; only alert modals get role="alertdialog".
-  it('does not set an empty role on the dialog element for non-alert modals', () => {
-    const { container } = render(
+describe('enableDialogElement role attribute', () => {
+  it('should preserve the native dialog role for non-alert modals', () => {
+    render(
       <FeatureFlags enableDialogElement>
         <Modal open aria-label="Non-alert modal" modalHeading="Heading">
           <p>Body</p>
         </Modal>
       </FeatureFlags>
     );
-    const dialog = container.querySelector('dialog');
-    expect(dialog).toBeInTheDocument();
-    expect(dialog).not.toHaveAttribute('role');
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('sets role="alertdialog" on the dialog element for alert modals', () => {
-    const { container } = render(
+  it('should set role="alertdialog" for alert modals', () => {
+    render(
       <FeatureFlags enableDialogElement>
         <Modal open danger alert aria-label="Alert modal" modalHeading="Heading">
           <p>Body</p>
         </Modal>
       </FeatureFlags>
     );
-    const dialog = container.querySelector('dialog');
-    expect(dialog).toHaveAttribute('role', 'alertdialog');
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -1670,3 +1670,34 @@ describe.each([
     expect(onRequestClose).toHaveBeenCalled();
   });
 });
+
+describe('Modal - enableDialogElement role attribute', () => {
+  // Regression for #22666: with the enableDialogElement flag, a non-alert Modal set
+  // role="" on the <dialog>, hiding its implicit "dialog" role from assistive tech and
+  // breaking *ByRole('dialog') queries. The attribute should be omitted (undefined) so
+  // the native dialog role is preserved; only alert modals get role="alertdialog".
+  it('does not set an empty role on the dialog element for non-alert modals', () => {
+    const { container } = render(
+      <FeatureFlags enableDialogElement>
+        <Modal open aria-label="Non-alert modal" modalHeading="Heading">
+          <p>Body</p>
+        </Modal>
+      </FeatureFlags>
+    );
+    const dialog = container.querySelector('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).not.toHaveAttribute('role');
+  });
+
+  it('sets role="alertdialog" on the dialog element for alert modals', () => {
+    const { container } = render(
+      <FeatureFlags enableDialogElement>
+        <Modal open danger alert aria-label="Alert modal" modalHeading="Heading">
+          <p>Body</p>
+        </Modal>
+      </FeatureFlags>
+    );
+    const dialog = container.querySelector('dialog');
+    expect(dialog).toHaveAttribute('role', 'alertdialog');
+  });
+});

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -1672,27 +1672,37 @@ describe.each([
 });
 
 describe('enableDialogElement role attribute', () => {
-  it('should preserve the native dialog role for non-alert modals', () => {
+  it('should preserve native dialog attributes for non-alert modals', () => {
     render(
       <FeatureFlags enableDialogElement>
-        <Modal open aria-label="Non-alert modal" modalHeading="Heading">
+        <Modal open>
           <p>Body</p>
         </Modal>
       </FeatureFlags>
     );
 
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const modal = screen.getByRole('dialog');
+
+    expect(modal).toBeInTheDocument();
+    expect(modal).not.toHaveAttribute('role');
+    expect(modal).not.toHaveAttribute('aria-describedby');
   });
 
-  it('should set role="alertdialog" for alert modals', () => {
+  it('should set alertdialog attributes for alert modals', () => {
     render(
       <FeatureFlags enableDialogElement>
-        <Modal open danger alert aria-label="Alert modal" modalHeading="Heading">
+        <Modal open danger alert>
           <p>Body</p>
         </Modal>
       </FeatureFlags>
     );
 
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    const modal = screen.getByRole('alertdialog');
+    const modalBodyId = modal.getAttribute('aria-describedby');
+
+    expect(modal).toBeInTheDocument();
+    expect(modal).toHaveAttribute('role', 'alertdialog');
+    expect(modalBodyId).toMatch(/^cds--modal-body--modal-id-/);
+    expect(document.getElementById(modalBodyId)).toHaveTextContent('Body');
   });
 });

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -738,8 +738,8 @@ const ModalDialog = React.forwardRef(function ModalDialog(
       focusAfterCloseRef={launcherButtonRef}
       modal
       ref={innerModal}
-      role={isAlertDialog ? 'alertdialog' : ''}
-      aria-describedby={isAlertDialog ? modalBodyId : ''}
+      role={isAlertDialog ? 'alertdialog' : undefined}
+      aria-describedby={isAlertDialog ? modalBodyId : undefined}
       className={containerClasses}
       aria-label={ariaLabel}
       data-exiting={presenceContext?.isExiting || undefined}>


### PR DESCRIPTION
Closes #22666

With the `enableDialogElement` feature flag, a non-alert `Modal` renders `role=""` on the `<dialog>` element. An empty `role` hides the element's implicit **dialog** role from assistive technology and breaks `*ByRole('dialog')` queries — the reporter hit this with `cy.findByRole`. (`ComposedModal` never sets `role`.) The fix emits `undefined` instead of an empty string for the non-alert case, so the native dialog role is preserved; only alert modals get `role="alertdialog"`. The adjacent `aria-describedby` had the identical empty-string pattern and is fixed the same way.

### Changelog

**Changed**

- `Modal` no longer renders an empty `role=""` (and empty `aria-describedby`) on the `<dialog>` element for non-alert modals when `enableDialogElement` is enabled; the attribute is omitted so the default dialog role is preserved. Alert modals still get `role="alertdialog"`.

#### Testing / Reviewing

- Open the [`enable-dialog-element` Modal story](https://react.carbondesignsystem.com/?path=/story/components-modal-feature-flags--enable-dialog-element), launch the modal, and inspect the `<dialog>` — it should no longer have an empty `role` attribute.
- Added regression tests in `Modal-test.js`: a non-alert dialog has no empty `role`, and alert modals keep `role="alertdialog"`.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~Updated documentation and storybook examples~ (no API/behavior surface change; existing stories unaffected)
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- ~Tested for cross-browser consistency~ (change only omits an attribute; no browser-specific behavior)
- [x] Validated that this code is ready for review and status checks should pass