### PR TITLE
fix(icon-button): allow xs size without prop-type warning

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5894,6 +5894,7 @@ Map {
       "size": {
         "args": [
           [
+            "xs",
             "sm",
             "md",
             "lg",

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -366,7 +366,7 @@ IconButton.propTypes = {
   /**
    * Specify the size of the Button.
    */
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * Optionally specify a `target` when using an `<a>` element.


### PR DESCRIPTION
  Closes #22701

`IconButton` accepts `size="xs"` in its TypeScript type and renders it correctly (`ButtonBase` applies the `--btn--xs` class), but its `propTypes.size` only listed `['sm', 'md', 'lg']`. Under React 18 this logged a console warning:
  
Failed prop type: Invalid prop size of value xs supplied to ForwardRef, expected one of ["sm","md","lg"].

The `xs` value was added to `Button` in #19435 but `IconButton.propTypes` was not updated to match. This aligns the runtime propType with the TypeScript type and the supported sizes.

### Changelog

**Changed**

- Added `xs` to `IconButton`'s `size` propType so it no longer logs a prop-type warning when `size="xs"` is used.


#### Testing / Reviewing

1. Render an icon-only `IconButton` with `size="xs"` under React 18 (repro from the issue: https://stackblitz.com/edit/github-coh3ks1l).
2. Open the browser console and confirm the `Failed prop type` warning is no longer shown.
3. `IconButton` unit tests still pass: `yarn test packages/react/src/components/IconButton/__tests__/IconButton-test.js`.
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

  - [x] Reviewed every line of the diff
  - [ ] ~Updated documentation and storybook examples~ (no API/behavior change; documented `xs` already works)
  - [ ] ~Wrote passing tests that cover this change~ (propType/type alignment only; existing IconButton tests pass)
  - [ ] ~Addressed any impact on accessibility (a11y)~ (no a11y impact)
  - [x] Tested for cross-browser consistency
  - [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
