### PR TITLE
fix(code-snippet): apply styles via CSS object model

### DIFF
--- a/packages/web-components/src/components/code-snippet/__tests__/code-snippet-test.js
+++ b/packages/web-components/src/components/code-snippet/__tests__/code-snippet-test.js
@@ -361,13 +361,12 @@ describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumbe
     const showMoreButton = el.shadowRoot.querySelector(
       '.cds--snippet-btn--expand'
     );
-    if (showMoreButton) {
-      showMoreButton.click();
-      await el.updateComplete;
+    expect(showMoreButton).to.exist;
+    showMoreButton.click();
+    await el.updateComplete;
 
-      const container = el.shadowRoot.querySelector('.cds--snippet-container');
-      expect(container.style.maxHeight).to.equal(`${rows * rowHeight}px`);
-    }
+    const container = el.shadowRoot.querySelector('.cds--snippet-container');
+    expect(container.style.maxHeight).to.equal(`${rows * rowHeight}px`);
   });
 
   it('should apply minExpandedNumberOfRows as min-height on the snippet container when expanded', async () => {
@@ -386,13 +385,12 @@ describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumbe
     const showMoreButton = el.shadowRoot.querySelector(
       '.cds--snippet-btn--expand'
     );
-    if (showMoreButton) {
-      showMoreButton.click();
-      await el.updateComplete;
+    expect(showMoreButton).to.exist;
+    showMoreButton.click();
+    await el.updateComplete;
 
-      const container = el.shadowRoot.querySelector('.cds--snippet-container');
-      expect(container.style.minHeight).to.equal(`${rows * rowHeight}px`);
-    }
+    const container = el.shadowRoot.querySelector('.cds--snippet-container');
+    expect(container.style.minHeight).to.equal(`${rows * rowHeight}px`);
   });
 
   it('should not apply max-height when maxExpandedNumberOfRows is 0 (expanded)', async () => {
@@ -410,13 +408,12 @@ describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumbe
     const showMoreButton = el.shadowRoot.querySelector(
       '.cds--snippet-btn--expand'
     );
-    if (showMoreButton) {
-      showMoreButton.click();
-      await el.updateComplete;
+    expect(showMoreButton).to.exist;
+    showMoreButton.click();
+    await el.updateComplete;
 
-      const container = el.shadowRoot.querySelector('.cds--snippet-container');
-      expect(container.style.maxHeight).to.equal('');
-    }
+    const container = el.shadowRoot.querySelector('.cds--snippet-container');
+    expect(container.style.maxHeight).to.equal('');
   });
 
   it('should not apply max-height or min-height for non-multi snippet types', async () => {

--- a/packages/web-components/src/components/code-snippet/__tests__/code-snippet-test.js
+++ b/packages/web-components/src/components/code-snippet/__tests__/code-snippet-test.js
@@ -358,11 +358,12 @@ describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumbe
 
     await el.updateComplete;
 
-    const showMoreButton = el.shadowRoot.querySelector(
-      '.cds--snippet-btn--expand'
-    );
-    expect(showMoreButton).to.exist;
-    showMoreButton.click();
+    // ResizeObserver never fires with real dimensions in a headless environment,
+    // so _shouldShowMoreLessBtn stays false and the show-more button is not
+    // rendered. Drive the expanded state directly to test the style application.
+    el._shouldShowMoreLessBtn = true;
+    el._expandedCode = true;
+    el.requestUpdate();
     await el.updateComplete;
 
     const container = el.shadowRoot.querySelector('.cds--snippet-container');
@@ -382,11 +383,12 @@ describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumbe
 
     await el.updateComplete;
 
-    const showMoreButton = el.shadowRoot.querySelector(
-      '.cds--snippet-btn--expand'
-    );
-    expect(showMoreButton).to.exist;
-    showMoreButton.click();
+    // ResizeObserver never fires with real dimensions in a headless environment,
+    // so _shouldShowMoreLessBtn stays false and the show-more button is not
+    // rendered. Drive the expanded state directly to test the style application.
+    el._shouldShowMoreLessBtn = true;
+    el._expandedCode = true;
+    el.requestUpdate();
     await el.updateComplete;
 
     const container = el.shadowRoot.querySelector('.cds--snippet-container');
@@ -405,11 +407,12 @@ describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumbe
 
     await el.updateComplete;
 
-    const showMoreButton = el.shadowRoot.querySelector(
-      '.cds--snippet-btn--expand'
-    );
-    expect(showMoreButton).to.exist;
-    showMoreButton.click();
+    // ResizeObserver never fires with real dimensions in a headless environment,
+    // so _shouldShowMoreLessBtn stays false and the show-more button is not
+    // rendered. Drive the expanded state directly to test the style application.
+    el._shouldShowMoreLessBtn = true;
+    el._expandedCode = true;
+    el.requestUpdate();
     await el.updateComplete;
 
     const container = el.shadowRoot.querySelector('.cds--snippet-container');

--- a/packages/web-components/src/components/code-snippet/__tests__/code-snippet-test.js
+++ b/packages/web-components/src/components/code-snippet/__tests__/code-snippet-test.js
@@ -289,3 +289,150 @@ describe('cds-code-snippet', function () {
     });
   });
 });
+
+describe('maxCollapsedNumberOfRows / minCollapsedNumberOfRows / maxExpandedNumberOfRows / minExpandedNumberOfRows', () => {
+  const rowHeight = 16;
+
+  it('should reflect default values for the four row attributes', async () => {
+    const el = await fixture(html`
+      <cds-code-snippet type="multi">${multiLong}</cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    expect(el.maxCollapsedNumberOfRows).to.equal(15);
+    expect(el.minCollapsedNumberOfRows).to.equal(3);
+    expect(el.maxExpandedNumberOfRows).to.equal(0);
+    expect(el.minExpandedNumberOfRows).to.equal(16);
+  });
+
+  it('should set maxCollapsedNumberOfRows from attribute', async () => {
+    const el = await fixture(html`
+      <cds-code-snippet type="multi" maxCollapsedNumberOfRows="5">
+        ${multiLong}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+    expect(el.maxCollapsedNumberOfRows).to.equal(5);
+  });
+
+  it('should apply maxCollapsedNumberOfRows as max-height on the snippet container when collapsed', async () => {
+    const rows = 5;
+    const el = await fixture(html`
+      <cds-code-snippet type="multi" maxCollapsedNumberOfRows="${rows}">
+        ${multiLong}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    const container = el.shadowRoot.querySelector('.cds--snippet-container');
+    expect(container.style.maxHeight).to.equal(`${rows * rowHeight}px`);
+  });
+
+  it('should apply minCollapsedNumberOfRows as min-height on the snippet container when collapsed', async () => {
+    const rows = 3;
+    const el = await fixture(html`
+      <cds-code-snippet type="multi" minCollapsedNumberOfRows="${rows}">
+        ${multiLong}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    const container = el.shadowRoot.querySelector('.cds--snippet-container');
+    expect(container.style.minHeight).to.equal(`${rows * rowHeight}px`);
+  });
+
+  it('should apply maxExpandedNumberOfRows as max-height on the snippet container when expanded', async () => {
+    const rows = 20;
+    const el = await fixture(html`
+      <cds-code-snippet
+        type="multi"
+        maxCollapsedNumberOfRows="5"
+        maxExpandedNumberOfRows="${rows}">
+        ${multiLong}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    const showMoreButton = el.shadowRoot.querySelector(
+      '.cds--snippet-btn--expand'
+    );
+    if (showMoreButton) {
+      showMoreButton.click();
+      await el.updateComplete;
+
+      const container = el.shadowRoot.querySelector('.cds--snippet-container');
+      expect(container.style.maxHeight).to.equal(`${rows * rowHeight}px`);
+    }
+  });
+
+  it('should apply minExpandedNumberOfRows as min-height on the snippet container when expanded', async () => {
+    const rows = 10;
+    const el = await fixture(html`
+      <cds-code-snippet
+        type="multi"
+        maxCollapsedNumberOfRows="5"
+        minExpandedNumberOfRows="${rows}">
+        ${multiLong}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    const showMoreButton = el.shadowRoot.querySelector(
+      '.cds--snippet-btn--expand'
+    );
+    if (showMoreButton) {
+      showMoreButton.click();
+      await el.updateComplete;
+
+      const container = el.shadowRoot.querySelector('.cds--snippet-container');
+      expect(container.style.minHeight).to.equal(`${rows * rowHeight}px`);
+    }
+  });
+
+  it('should not apply max-height when maxExpandedNumberOfRows is 0 (expanded)', async () => {
+    const el = await fixture(html`
+      <cds-code-snippet
+        type="multi"
+        maxCollapsedNumberOfRows="5"
+        maxExpandedNumberOfRows="0">
+        ${multiLong}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    const showMoreButton = el.shadowRoot.querySelector(
+      '.cds--snippet-btn--expand'
+    );
+    if (showMoreButton) {
+      showMoreButton.click();
+      await el.updateComplete;
+
+      const container = el.shadowRoot.querySelector('.cds--snippet-container');
+      expect(container.style.maxHeight).to.equal('');
+    }
+  });
+
+  it('should not apply max-height or min-height for non-multi snippet types', async () => {
+    const el = await fixture(html`
+      <cds-code-snippet
+        type="single"
+        maxCollapsedNumberOfRows="5"
+        minCollapsedNumberOfRows="2">
+        ${single}
+      </cds-code-snippet>
+    `);
+
+    await el.updateComplete;
+
+    const container = el.shadowRoot.querySelector('.cds--snippet-container');
+    expect(container.style.maxHeight).to.equal('');
+    expect(container.style.minHeight).to.equal('');
+  });
+});

--- a/packages/web-components/src/components/code-snippet/code-snippet.stories.ts
+++ b/packages/web-components/src/components/code-snippet/code-snippet.stories.ts
@@ -20,7 +20,7 @@ const args = {
   maxCollapsedNumberOfRows: 15,
   maxExpandedNumberOfRows: 0,
   minCollapsedNumberOfRows: 3,
-  minExpandeddNumberOfRows: 16,
+  minExpandedNumberOfRows: 16,
   showLessText: 'Show less',
   showMoreText: 'Show more',
   type: 'single',
@@ -71,7 +71,7 @@ const argTypes = {
     description:
       'Specify the minimum number of rows to be shown when in collapsed view.',
   },
-  minExpandeddNumberOfRows: {
+  minExpandedNumberOfRows: {
     control: 'number',
     description:
       'Specify the minimum number of rows to be shown when in expanded view.',

--- a/packages/web-components/src/components/code-snippet/code-snippet.stories.ts
+++ b/packages/web-components/src/components/code-snippet/code-snippet.stories.ts
@@ -18,7 +18,7 @@ const args = {
   feedbackTimeout: 0,
   hideCopyButton: false,
   maxCollapsedNumberOfRows: 15,
-  maxExpandeddNumberOfRows: 0,
+  maxExpandedNumberOfRows: 0,
   minCollapsedNumberOfRows: 3,
   minExpandeddNumberOfRows: 16,
   showLessText: 'Show less',
@@ -61,7 +61,7 @@ const argTypes = {
     description:
       'Specify the maximum number of rows to be shown when in collapsed view.',
   },
-  maxExpandeddNumberOfRows: {
+  maxExpandedNumberOfRows: {
     control: 'number',
     description:
       'Specify the maximum number of rows to be shown when in expanded view.',

--- a/packages/web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/web-components/src/components/code-snippet/code-snippet.ts
@@ -253,25 +253,25 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
   /**
    * Specify the maximum number of rows to be shown when in collapsed view
    */
-  @property()
+  @property({ type: Number })
   maxCollapsedNumberOfRows = 15;
 
   /**
    * Specify the maximum number of rows to be shown when in expanded view
    */
-  @property()
+  @property({ type: Number })
   maxExpandedNumberOfRows = 0;
 
   /**
    * Specify the minimum number of rows to be shown when in collapsed view
    */
-  @property()
+  @property({ type: Number })
   minCollapsedNumberOfRows = 3;
 
   /**
    * Specify the minimum number of rows to be shown when in expanded view
    */
-  @property()
+  @property({ type: Number })
   minExpandedNumberOfRows = 16;
 
   /**

--- a/packages/web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/web-components/src/components/code-snippet/code-snippet.ts
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 /**  eslint-disable @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452 */
-import { styleMap } from 'lit/directives/style-map.js';
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import ChevronDown16 from '@carbon/icons/es/chevron--down/16.js';
 import FocusMixin from '../../globals/mixins/focus';
@@ -48,6 +47,12 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  */
 @customElement(`${prefix}-code-snippet`)
 class CDSCodeSnippet extends FocusMixin(LitElement) {
+  /**
+   * The code snippet container element.
+   */
+  @query(`.${prefix}--snippet-container`)
+  private _snippetContainer!: HTMLDivElement;
+
   /**
    * `true` to expand multi-line variant of code snippet.
    */
@@ -132,9 +137,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
    */
   private _handleScroll() {
     if (this) {
-      const codeContainerRef = this?.shadowRoot?.querySelector(
-        `.${prefix}--snippet-container`
-      );
+      const codeContainerRef = this._snippetContainer;
       const codeContentRef = codeContainerRef?.querySelector('pre');
       if (
         this.type === CODE_SNIPPET_TYPE.INLINE ||
@@ -177,9 +180,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore
   private _resizeObserver = new ResizeObserver(() => {
-    const codeContainerRef = this.shadowRoot?.querySelector(
-      `.${prefix}--snippet-container`
-    );
+    const codeContainerRef = this._snippetContainer;
     const codeContentRef = codeContainerRef?.querySelector('code'); // PRE?
     const {
       type,
@@ -325,6 +326,47 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
     } else {
       this.removeAttribute('expanded-code');
     }
+
+    const { _snippetContainer: container } = this;
+    if (!container) {
+      return;
+    }
+
+    if (this.type === CODE_SNIPPET_TYPE.MULTI) {
+      const {
+        maxExpandedNumberOfRows,
+        minExpandedNumberOfRows,
+        maxCollapsedNumberOfRows,
+        minCollapsedNumberOfRows,
+        _expandedCode: expandedCode,
+        _rowHeightInPixels: rowHeightInPixels,
+      } = this;
+
+      let maxHeight = '';
+      let minHeight = '';
+
+      if (expandedCode) {
+        if (maxExpandedNumberOfRows > 0) {
+          maxHeight = `${maxExpandedNumberOfRows * rowHeightInPixels}px`;
+        }
+        if (minExpandedNumberOfRows > 0) {
+          minHeight = `${minExpandedNumberOfRows * rowHeightInPixels}px`;
+        }
+      } else {
+        if (maxCollapsedNumberOfRows > 0) {
+          maxHeight = `${maxCollapsedNumberOfRows * rowHeightInPixels}px`;
+        }
+        if (minCollapsedNumberOfRows > 0) {
+          minHeight = `${minCollapsedNumberOfRows * rowHeightInPixels}px`;
+        }
+      }
+
+      container.style.maxHeight = maxHeight;
+      container.style.minHeight = minHeight;
+    } else {
+      container.style.maxHeight = '';
+      container.style.minHeight = '';
+    }
   }
 
   render() {
@@ -333,10 +375,6 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       feedback,
       feedbackTimeout,
       hideCopyButton,
-      maxExpandedNumberOfRows,
-      minExpandedNumberOfRows,
-      maxCollapsedNumberOfRows,
-      minCollapsedNumberOfRows,
       type,
       wrapText,
       tooltipContent,
@@ -347,7 +385,6 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       _handleScroll: handleScroll,
       _hasRightOverflow: hasRightOverflow,
       _hasLeftOverflow: hasLeftOverflow,
-      _rowHeightInPixels: rowHeightInPixels,
       _shouldShowMoreLessBtn: shouldShowMoreLessBtn,
     } = this;
 
@@ -392,29 +429,6 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       `;
     }
 
-    const styles = {};
-    if (type === 'multi') {
-      if (expandedCode) {
-        if (maxExpandedNumberOfRows > 0) {
-          styles['max-height'] =
-            maxExpandedNumberOfRows * rowHeightInPixels + 'px';
-        }
-        if (minExpandedNumberOfRows > 0) {
-          styles['min-height'] =
-            minExpandedNumberOfRows * rowHeightInPixels + 'px';
-        }
-      } else {
-        if (maxCollapsedNumberOfRows > 0) {
-          styles['max-height'] =
-            maxCollapsedNumberOfRows * rowHeightInPixels + 'px';
-        }
-        if (minCollapsedNumberOfRows > 0) {
-          styles['min-height'] =
-            minCollapsedNumberOfRows * rowHeightInPixels + 'px';
-        }
-      }
-    }
-
     return html`
       <div
         role="${type === CODE_SNIPPET_TYPE.SINGLE ||
@@ -433,8 +447,8 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
           ? true
           : null}"
         aria-multiline="${type === CODE_SNIPPET_TYPE.MULTI ? true : null}"
-        @scroll="${(type === CODE_SNIPPET_TYPE.SINGLE && handleScroll) || null}"
-        style=${styleMap(styles)}>
+        @scroll="${(type === CODE_SNIPPET_TYPE.SINGLE && handleScroll) ||
+        null}">
         <pre
           @scroll="${(type === CODE_SNIPPET_TYPE.MULTI && handleScroll) ||
           null}"><code><slot></slot></code></pre>


### PR DESCRIPTION
Closes #17949

Web Component's `cds-code-snippet` component was throwing CSP errors due to the inline `style` attribute usage.

This PR applies the styles set on expand / collapse of code-snippet via CSSOM instead.

```
container.style.maxHeight = maxHeight;
container.style.minHeight = minHeight;
```

CSP error can be spotted in the console here: https://stackblitz.com/edit/github-jkgy3c-rejzzh?file=index.html

### Changelog

**New**

- added tests for the `maxCollapsedNumberOfRows`, `maxExpandedNumberOfRows`, `minCollapsedNumberOfRows`, `minExpandedNumberOfRows` properties

**Changed**

- extra `d` to the `maxExpandeddNumberOfRows` and `minExpandeddNumberOfRows` storybook controls, controls should now work
- move style logic to the `updated()` lifecycle method instead and apply the styles via CSSOM instead of the inline `style`
- specify type to number for `maxCollapsedNumberOfRows`, `maxExpandedNumberOfRows`, `minCollapsedNumberOfRows`, `minExpandedNumberOfRows` properties

#### Testing / Reviewing

- You can run build this branch locally and run `cd packages/web-components && npm pack`. This will generate a tarball file that can be used.
- Download the linked stackblitz above and drop the generated tarball file into the folder
- in the `package.json` of the stackblitz example, replace `"@carbon/web-components": "latest",` with `"@carbon/web-components": "file:./[name of tarball file here]"`
- Run `yarn install` and `yarn run dev`
- Confirm there is no CSP error in the console.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
