### PR TITLE
chore(workflow): change pull request closed workflow permission

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -31,7 +31,7 @@ jobs:
   if_merged:
     if: github.event.pull_request.merged == true
     permissions:
-      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Comment the schedule release


### PR DESCRIPTION
Closes #19204

The [pull-request-closed](https://github.com/carbon-design-system/carbon/actions/workflows/pull-request-closed.yml) workflow, which adds a comment to merged PRs announcing the changes will be part of the upcoming release, has been failing for a while now. This PR changes the token permissions to `pull-requests: write` instead to allow for mutating a PR.

### Changelog

**Changed**

- change token permission from `issues` to `pull-requests` instead as we are adding a comment to a PR.

#### Testing / Reviewing

Tested this with my own fork, you can see the workflow passes: https://github.com/annawen1/carbon/actions/workflows/pull-request-closed.yml

You can see the expected comment is made to the merged PR here: https://github.com/annawen1/carbon/pull/2

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
