### PR TITLE
fix(renovate): automate code connect updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,19 +1,26 @@
 {
   extends: [
-    "config:js-lib",
-    ":maintainLockFilesWeekly",
-    ":preserveSemverRanges",
-    "security:minimumReleaseAgeNpm",
+    'config:js-lib',
+    ':maintainLockFilesWeekly',
+    ':preserveSemverRanges',
+    'security:minimumReleaseAgeNpm',
   ],
   schedule: [
-    "after 10pm every weekday",
-    "before 5am every weekday",
-    "every weekend",
+    'after 10pm every weekday',
+    'before 5am every weekday',
+    'every weekend',
+  ],
+  packageRules: [
+    {
+      description: 'Bump @figma/code-connect for in-range updates',
+      matchPackageNames: ['@figma/code-connect'],
+      rangeStrategy: 'bump',
+    },
   ],
   vulnerabilityAlerts: {
     enabled: true,
   },
-  rebaseWhen: "never",
+  rebaseWhen: 'never',
   lockFileMaintenance: {
     enabled: false,
   },


### PR DESCRIPTION
Closes #22643

Configures Renovate to open update pull requests for `@figma/code-connect` releases that are already within the existing caret range.

The repository-wide `:preserveSemverRanges` preset uses the `replace` range strategy. Because releases such as `1.4.8` and `1.4.9` already satisfy `^1.4.7`, Renovate detected the dependency but had no manifest change to propose. A package-specific `bump` rule now raises the minimum version while preserving the caret range, allowing Renovate to create update branches and pull requests.

### Changelog

**New**

- None.

**Changed**

- Configured Renovate to bump the minimum `@figma/code-connect` version for in-range updates.
- Formatted the touched Renovate configuration with the repository’s current Prettier rules.

**Removed**

- None.

#### Testing / Reviewing

1. Use the repository Node version:

       nvm use

2. Validate formatting and the Renovate configuration:

       yarn prettier --check .github/renovate.json5
       yarn dlx -p renovate renovate-config-validator .github/renovate.json5

3. Run a focused local Renovate lookup:

       env LOG_LEVEL=debug yarn dlx -p renovate renovate --platform=local --dry-run=lookup --enabled-managers=npm --include-paths=packages/react/package.json

4. Confirm the dry-run output:

   - Lists `@figma/code-connect` among the available updates.
   - Produces the planned branch `renovate/figma-code-connect-1.x`.
   - Completes without configuration validation errors.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)