### PR TITLE
fix(NumberInput): support en-IN locale grouping in custom validation

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -516,6 +516,8 @@ export const validateNumberSeparators = (
           ? input.includes(groupSeparator)
           : false);
 
+  const isIndianLocale =
+    locale === 'en-IN' || locale.toLowerCase().endsWith('-in');
   const scientificMatch = input?.match(/^([^eE]+)([eE][+-]?.*)?$/);
   const baseNumber = scientificMatch ? scientificMatch[1] : input;
 
@@ -532,20 +534,56 @@ export const validateNumberSeparators = (
   // When grouping is used, we need to handle two cases:
   // 1. Numbers with 1-3 digits (no separator required): 1, 12, 123
   // 2. Numbers with 4+ digits (separator required): 1,234 or 12,345 or 123,456
-  const integerRegex = usesGrouping
-    ? new RegExp(`^${sign}(${digit}{1,3}|${digit}{1,3}(${group}${digit}{3})+)$`)
-    : new RegExp(`^${sign}${digit}+$`);
+  let integerRegex: RegExp;
 
+  if (!usesGrouping) {
+    integerRegex = new RegExp(`^${sign}${digit}+$`);
+  } else if (isIndianLocale) {
+    // Indian grouping:
+    // 1-3 digits
+    // 1,234
+    // 12,345
+    // 1,23,456
+    // 12,34,567
+    // 1,23,45,678
+    integerRegex = new RegExp(
+      `^${sign}(` +
+        `${digit}{1,3}` +
+        `|${digit}{1,3}${group}${digit}{3}` +
+        `|${digit}{1,2}(${group}${digit}{2})+${group}${digit}{3}` +
+        `)$`
+    );
+  } else {
+    integerRegex = new RegExp(
+      `^${sign}(${digit}{1,3}|${digit}{1,3}(${group}${digit}{3})+)$`
+    );
+  }
   if (!integerRegex.test(integerPart)) {
     return false;
   }
 
   // STEP 2: full number validation
-  const fullRegex = new RegExp(
-    `^${sign}${digit}+` +
-      (usesGrouping ? `(${group}${digit}{3})*` : '') +
-      `(${decimal}${digit}+)?${scientific}$`
-  );
+  let fullRegex: RegExp;
+
+  if (!usesGrouping) {
+    fullRegex = new RegExp(
+      `^${sign}${digit}+(${decimal}${digit}+)?${scientific}$`
+    );
+  } else if (isIndianLocale) {
+    fullRegex = new RegExp(
+      `^${sign}(` +
+        `${digit}{1,3}` +
+        `|${digit}{1,3}${group}${digit}{3}` +
+        `|${digit}{1,2}(${group}${digit}{2})+${group}${digit}{3}` +
+        `)` +
+        `(${decimal}${digit}+)?${scientific}$`
+    );
+  } else {
+    fullRegex = new RegExp(
+      `^${sign}${digit}{1,3}(${group}${digit}{3})*` +
+        `(${decimal}${digit}+)?${scientific}$`
+    );
+  }
 
   return fullRegex.test(input);
 };

--- a/packages/react/src/components/NumberInput/__tests__/NumberInput-test.js
+++ b/packages/react/src/components/NumberInput/__tests__/NumberInput-test.js
@@ -2728,4 +2728,26 @@ describe('NumberInput', () => {
       numberFormatSpy.mockRestore();
     });
   });
+
+  describe('validateNumberSeparators - Indian locale', () => {
+    it('should accept valid Indian digit grouping for en-IN', () => {
+      expect(validateNumberSeparators('5,00,000', 'en-IN')).toBe(true);
+      expect(validateNumberSeparators('1,23,45,678', 'en-IN')).toBe(true);
+    });
+
+    it('should reject invalid Indian digit grouping for en-IN', () => {
+      expect(validateNumberSeparators('5,000,00', 'en-IN')).toBe(false);
+      expect(validateNumberSeparators('5,0000', 'en-IN')).toBe(false);
+    });
+  });
+
+  describe('validateNumberSeparators - locale specific grouping', () => {
+    it('accepts Indian grouping for en-IN', () => {
+      expect(validateNumberSeparators('5,00,000', 'en-IN')).toBe(true);
+    });
+
+    it('continues to reject Indian grouping for en-US', () => {
+      expect(validateNumberSeparators('5,00,000', 'en-US')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Closes #22757

This PR fixes custom validation for NumberInput with type="text" when using the en-IN locale.

Previously, custom validation only supported Western-style digit grouping (e.g., 500,000) and incorrectly rejected valid Indian-formatted numbers such as 5,00,000 and 1,23,45,678.

Changes
Updated validateNumberSeparators() to support locale-specific Indian digit grouping for en-IN.
Preserved the existing validation behavior for all other locales.
Added unit tests to verify:
Valid Indian-formatted numbers are accepted for en-IN.
Invalid Indian-formatted numbers continue to be rejected.

### Changelog

**New**

Added support for validating Indian digit grouping (en-IN) in NumberInput custom validation.
Added unit tests covering valid and invalid en-IN number grouping.

**Changed**

Updated validateNumberSeparators() to support locale-specific digit grouping for the en-IN locale when NumberInput is used with type="text" and custom validation.
Existing validation behavior for all other locales remains unchanged.
**Removed**

None

#### Testing / Reviewing

Verify that 5,00,000 is accepted as valid for locale="en-IN" with type="text" and custom validation enabled.

Verify that 1,23,45,678 is accepted as valid for locale="en-IN".

Verify that invalid values such as 5,0000 and 5,000,00 are rejected.

Verify that en-US validation behavior remains unchanged (e.g., 500,000 is valid and 5,00,000 is invalid).

Run the NumberInput unit tests and ensure all existing tests continue to pass.
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
