### PR TITLE
fix(styles): use POSIX separators for generated Sass @forward paths

### DIFF
--- a/packages/styles/files.js
+++ b/packages/styles/files.js
@@ -248,8 +248,11 @@ module.exports = {
 
     // If we have an `_index.scss` entrypoint, we can re-export from the
     // directory itself
+    // Sass import specifiers are always `/`-separated, so these are built with
+    // `path.posix` — plain `path.join` emits `\` on Windows and every generated
+    // `@forward` fails to resolve.
     if (basename === '_index.scss') {
-      importPath = path.dirname(filepath);
+      importPath = path.posix.dirname(filepath);
     } else if (filepath !== 'index.scss') {
       // Otherwise, let's drop the leading `_` and trailing `.scss` from the
       // file name to get the import
@@ -257,13 +260,13 @@ module.exports = {
         .basename(filepath)
         .replace(/^_/, '')
         .replace(/\.scss$/, '');
-      importPath = path.join(path.dirname(filepath), basename);
+      importPath = path.posix.join(path.posix.dirname(filepath), basename);
     }
 
     return {
       filepath,
       relativePath: importPath,
-      importPath: path.join('@carbon/styles', importPath),
+      importPath: path.posix.join('@carbon/styles', importPath),
     };
   }),
 };


### PR DESCRIPTION
## Problem

`packages/styles/files.js` builds each generated file's `@forward` import specifier with `path.join`. On Windows that emits `\`-separated paths (e.g. `@carbon\styles\scss\type`).

Sass import specifiers must always be `/`-separated, so on Windows every generated `packages/*/scss/**/*.scss` ends up with an unresolvable `@forward`, and any Sass build fails with `Can't find stylesheet to import`. This makes the repo's Storybook build (and any downstream Sass build) unbuildable on Windows.

## Fix

Use `path.posix.join` / `path.posix.dirname` when composing the import specifiers. The `files` array entries are already POSIX-style string literals, so this produces identical output on macOS/Linux and only changes behavior on Windows.

```diff
-      importPath = path.dirname(filepath);
+      importPath = path.posix.dirname(filepath);
...
-      importPath = path.join(path.dirname(filepath), basename);
+      importPath = path.posix.join(path.posix.dirname(filepath), basename);
...
-      importPath: path.join('@carbon/styles', importPath),
+      importPath: path.posix.join('@carbon/styles', importPath),
```

## Notes

- This PR changes only the generator source. The committed `scss/` outputs should be regenerated with `yarn build` (or per-package `node tasks/build-styles.js`) — I left them out to keep the diff reviewable.
- A changeset may be required by CI; happy to add one.
- Found while building the `packages/react` Storybook on Windows 11 (Node 24, Yarn 4.10.3): the build died with 10 `[sass] Can't find stylesheet to import` errors pointing at `@forward '@carbon\styles\scss\...'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)