### PR TITLE
chore(icon): add Storybook controls args for Icon web component

### DIFF
--- a/packages/web-components/src/components/icon/icon.stories.ts
+++ b/packages/web-components/src/components/icon/icon.stories.ts
@@ -1,49 +1,111 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import Add16 from '@carbon/icons/es/add/16.js';
 import ChevronRight16 from '@carbon/icons/es/chevron--right/16.js';
 import Search16 from '@carbon/icons/es/search/16.js';
 import './icon';
 
+const defaultArgs = {
+  size: 16,
+  class: '',
+  ariaLabel: '',
+};
+
+const controls = {
+  size: {
+    control: 'select',
+    options: [16, 20, 24, 32],
+    description: 'Specify the size of the icon',
+  },
+  class: {
+    control: 'text',
+    description: 'Specify a custom CSS class for the icon',
+  },
+  ariaLabel: {
+    control: 'text',
+    description: 'Specify an aria-label for the icon',
+  },
+};
+
 export const Default = {
+  args: defaultArgs,
+  argTypes: controls,
   decorators: [
     (story) =>
       html`<div style="display: flex; gap: 1rem; align-items: center;">
         ${story()}
       </div>`,
   ],
-  render: () => html`
-    <cds-icon .icon=${Add16}></cds-icon>
-    <cds-icon .icon=${ChevronRight16}></cds-icon>
-    <cds-icon .icon=${Search16}></cds-icon>
+  render: ({ size, class: className, ariaLabel }) => html`
+    <cds-icon
+      .icon=${Add16}
+      .size=${size}
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
+    <cds-icon
+      .icon=${ChevronRight16}
+      .size=${size}
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
+    <cds-icon
+      .icon=${Search16}
+      .size=${size}
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
   `,
 };
 
 export const WithCustomSVG = {
+  args: {
+    ...defaultArgs,
+    ariaLabel: 'Custom shape',
+  },
+  argTypes: {
+    size: {
+      table: {
+        disable: true,
+      },
+    },
+    class: {
+      control: 'text',
+      description: 'Specify a custom CSS class for the icon',
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Specify an aria-label for the icon',
+    },
+  },
   decorators: [
     (story) =>
       html`<div style="display: flex; gap: 1rem; align-items: center;">
         ${story()}
       </div>`,
   ],
-  render: () => html`
-    <cds-icon>
+  render: ({ class: className, ariaLabel }) => html`
+    <cds-icon
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}>
       <svg width="16" height="16" viewBox="0 0 16 16">
         <circle cx="8" cy="8" r="6" fill="currentColor" />
       </svg>
     </cds-icon>
-    <cds-icon>
+    <cds-icon
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}>
       <svg width="16" height="16" viewBox="0 0 16 16">
         <rect x="2" y="2" width="12" height="12" fill="currentColor" />
       </svg>
     </cds-icon>
-    <cds-icon>
+    <cds-icon
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}>
       <svg width="16" height="16" viewBox="0 0 16 16">
         <polygon points="8,2 14,14 2,14" fill="currentColor" />
       </svg>
@@ -52,6 +114,19 @@ export const WithCustomSVG = {
 };
 
 export const WithCustomClasses = {
+  args: {
+    ...defaultArgs,
+  },
+  argTypes: {
+    size: controls.size,
+    // Story purpose is demonstrating distinct color classes; keep class control off.
+    class: {
+      table: {
+        disable: true,
+      },
+    },
+    ariaLabel: controls.ariaLabel,
+  },
   decorators: [
     (story) =>
       html`<style>
@@ -69,24 +144,53 @@ export const WithCustomClasses = {
           ${story()}
         </div>`,
   ],
-  render: () => html`
-    <cds-icon .icon=${Add16} class="blue"></cds-icon>
-    <cds-icon .icon=${ChevronRight16} class="green"></cds-icon>
-    <cds-icon .icon=${Search16} class="red"></cds-icon>
+  render: ({ size, ariaLabel }) => html`
+    <cds-icon
+      .icon=${Add16}
+      .size=${size}
+      class="blue"
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
+    <cds-icon
+      .icon=${ChevronRight16}
+      .size=${size}
+      class="green"
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
+    <cds-icon
+      .icon=${Search16}
+      .size=${size}
+      class="red"
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
   `,
 };
 
 export const WithAriaLabel = {
+  args: {
+    ...defaultArgs,
+    ariaLabel: 'Add item',
+  },
+  argTypes: controls,
   decorators: [
     (story) =>
       html`<div style="display: flex; gap: 1rem; align-items: center;">
         ${story()}
       </div>`,
   ],
-  render: () => html`
-    <cds-icon .icon=${Add16} aria-label="Add item"></cds-icon>
-    <cds-icon .icon=${ChevronRight16} aria-label="Navigate forward"></cds-icon>
-    <cds-icon .icon=${Search16} aria-label="Search"></cds-icon>
+  render: ({ size, class: className, ariaLabel }) => html`
+    <cds-icon
+      .icon=${Add16}
+      .size=${size}
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
+    <cds-icon
+      .icon=${ChevronRight16}
+      .size=${size}
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
+    <cds-icon
+      .icon=${Search16}
+      .size=${size}
+      class=${ifDefined(className || undefined)}
+      aria-label=${ifDefined(ariaLabel || undefined)}></cds-icon>
   `,
 };
 

--- a/packages/web-components/src/components/icon/icon.stories.ts
+++ b/packages/web-components/src/components/icon/icon.stories.ts
@@ -67,19 +67,10 @@ export const WithCustomSVG = {
     ...defaultArgs,
     ariaLabel: 'Custom shape',
   },
-  argTypes: {
-    size: {
-      table: {
-        disable: true,
-      },
-    },
-    class: {
-      control: 'text',
-      description: 'Specify a custom CSS class for the icon',
-    },
-    ariaLabel: {
-      control: 'text',
-      description: 'Specify an aria-label for the icon',
+  argTypes: controls,
+  parameters: {
+    controls: {
+      exclude: ['size'],
     },
   },
   decorators: [
@@ -117,15 +108,12 @@ export const WithCustomClasses = {
   args: {
     ...defaultArgs,
   },
-  argTypes: {
-    size: controls.size,
-    // Story purpose is demonstrating distinct color classes; keep class control off.
-    class: {
-      table: {
-        disable: true,
-      },
+  argTypes: controls,
+  parameters: {
+    controls: {
+      // Story purpose is demonstrating distinct color classes; keep class control off.
+      exclude: ['class'],
     },
-    ariaLabel: controls.ariaLabel,
   },
   decorators: [
     (story) =>


### PR DESCRIPTION
Closes #20969

Adds operable Storybook controls for the Icon web component stories (`size`, `class`, and `aria-label`).

### Changelog

**New**

- Storybook controls and args on Icon web component stories

**Changed**

- Icon stories now pass control values through to `cds-icon` instead of hardcoding only static demos

**Removed**

- N/A

#### Testing / Reviewing

- Open the web components Storybook Elements/Icon stories
- Confirm Default, WithCustomSVG, WithCustomClasses, and WithAriaLabel expose the expected controls
- Toggle `size` / `class` / `aria-label` and verify the icons update where those props apply
- Custom SVG story keeps `size` disabled since slotted SVGs do not use the `size` property

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)