### PR TITLE
chore: fix permissions for pull-request-closed workflow

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -1,13 +1,20 @@
 # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+#
+# Uses pull_request_target so the GITHUB_TOKEN retains write access when a PR
+# from a fork is closed/merged. pull_request always receives a read-only token
+# for forks, which causes intermittent 403s on createComment. This workflow does
+# not check out or execute PR code, so pull_request_target is safe here.
 name: Pull request closed
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cleanup up branch cache
         run: |
@@ -31,6 +38,8 @@ jobs:
   if_merged:
     if: github.event.pull_request.merged == true
     permissions:
+      # createComment uses the Issues API; both scopes are required
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -1,9 +1,4 @@
 # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
-#
-# Uses pull_request_target so the GITHUB_TOKEN retains write access when a PR
-# from a fork is closed/merged. pull_request always receives a read-only token
-# for forks, which causes intermittent 403s on createComment. This workflow does
-# not check out or execute PR code, so pull_request_target is safe here.
 name: Pull request closed
 on:
   pull_request_target:
@@ -38,7 +33,6 @@ jobs:
   if_merged:
     if: github.event.pull_request.merged == true
     permissions:
-      # createComment uses the Issues API; both scopes are required
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #19204

This PR attempts to fix the intermittent fails for the `pull-request-closed` action. 

The previous PR [#22730](https://github.com/carbon-design-system/carbon/pull/22730) partially fixed the issue so that currently it passes for dependabot or renovate PRs (same repo PRs). However it fails for forked PRs due to permissions issue.

With trigger on `pull_request`, GitHub always gives a read-only `GITHUB_TOKEN` for forks, so `createComment` fails. This PR changes the trigger to `pull_request_target` so that the token keeps write access for forked PRs. This is safe here as by default for `pull_request_target`, GitHub runs the workflow from the `main` branch and not from the fork. We also don't checkout the PR code in this workflow.

Also added `issues: write` as required by the Issues comments API (`createComment`) and `actions: write` on cleanup  so cache deletion also works for fork PRs.

### Changelog

**Changed**

- change workflow trigger to `pull_request_target`
- add `issues: write` and `actions: write` permissions

#### Testing / Reviewing

Will have to merge into `main` to see if this works.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
