### PR TITLE
fix(radio-button): associate label with input via matching for/id

### DIFF
--- a/packages/web-components/src/components/radio-button/__tests__/radio-button-test.js
+++ b/packages/web-components/src/components/radio-button/__tests__/radio-button-test.js
@@ -112,4 +112,13 @@ describe('cds-radio-button', () => {
 
     expect(input?.getAttribute('aria-readonly')).to.equal('true');
   });
+
+  it('should associate the label with the input via matching for/id', async () => {
+    const el = await fixture(basicRadioButton);
+    const input = el.shadowRoot.querySelector('input[type="radio"]');
+    const label = el.shadowRoot.querySelector('label');
+
+    expect(input?.id).to.exist;
+    expect(label?.getAttribute('for')).to.equal(input?.id);
+  });
 });

--- a/packages/web-components/src/components/radio-button/radio-button.ts
+++ b/packages/web-components/src/components/radio-button/radio-button.ts
@@ -481,7 +481,7 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
     });
     return html`
       <input
-        id="radio"
+        id="input"
         type="radio"
         class="${prefix}--radio-button"
         .checked=${checked}

--- a/packages/web-components/src/components/radio-button/radio-button.ts
+++ b/packages/web-components/src/components/radio-button/radio-button.ts
@@ -491,7 +491,7 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
         name=${ifDefined(name)}
         value=${ifDefined(value)} />
       <label
-        for="radio"
+        for="input"
         class="${prefix}--radio-button__label ${normalizedProps.invalid
           ? `${prefix}--radio-button__label--invalid`
           : ''} ${normalizedProps.warn

--- a/packages/web-components/src/components/radio-button/radio-button.ts
+++ b/packages/web-components/src/components/radio-button/radio-button.ts
@@ -491,7 +491,7 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
         name=${ifDefined(name)}
         value=${ifDefined(value)} />
       <label
-        for="input"
+        for="radio"
         class="${prefix}--radio-button__label ${normalizedProps.invalid
           ? `${prefix}--radio-button__label--invalid`
           : ''} ${normalizedProps.warn


### PR DESCRIPTION
Closes #22361

Fixes an accessibility defect where the `cds-radio-button` label was not programmatically associated with its input.

### Changelog

**Changed**

- `cds-radio-button`: the internal `<label>` used `for="input"`, but the inner `<input type="radio">` has `id="radio"`. The mismatch meant the label was never associated with the control, so clicking the label text did not focus/activate the radio and assistive technologies did not announce the label as the input's accessible name (WCAG 1.3.1 Info and Relationships, 4.1.2 Name, Role, Value). The label's `for` now points at the input's `id`, mirroring the sibling `cds-checkbox` where `id` and `for` share the same value.

#### Testing / Reviewing

- Added a unit test asserting the label's `for` matches the inner input's `id`, so the association can't silently regress.
- To verify manually: render a `cds-radio-button` with `label-text`, then click the label text — focus should move to the radio input, and a screen reader should announce the label when the radio receives focus.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~ (no API/behavior change; not applicable)
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass
