### PR TITLE
fix(text-input): associate label and describe input with helper text

### DIFF
--- a/packages/web-components/src/components/text-input/__tests__/text-input-test.js
+++ b/packages/web-components/src/components/text-input/__tests__/text-input-test.js
@@ -302,4 +302,48 @@ describe('cds-text-input', () => {
     expect(wrapper.classList.contains('cds--text-input-wrapper--inline')).to.be
       .true;
   });
+
+  it('should associate the label with the input via matching for/id', async () => {
+    const el = await fixture(defaultInput);
+    const label = el.shadowRoot.querySelector('label');
+    const input = el.shadowRoot.querySelector('input');
+
+    expect(input.id).to.exist;
+    expect(label.getAttribute('for')).to.equal(input.id);
+  });
+
+  it('should describe the input with the helper text', async () => {
+    const el = await fixture(html`
+      <cds-text-input
+        label="Text input label"
+        helper-text="Helpful info"></cds-text-input>
+    `);
+    const input = el.shadowRoot.querySelector('input');
+    const helper = el.shadowRoot.querySelector('.cds--form__helper-text');
+
+    expect(input.getAttribute('aria-describedby')).to.equal('helper-text');
+    expect(helper.id).to.equal('helper-text');
+  });
+
+  it('should not set aria-describedby when there is no helper text', async () => {
+    const el = await fixture(defaultInput);
+    const input = el.shadowRoot.querySelector('input');
+
+    expect(input.hasAttribute('aria-describedby')).to.be.false;
+  });
+
+  it('should describe the input with the validation message when invalid', async () => {
+    const el = await fixture(html`
+      <cds-text-input
+        label="Text input label"
+        helper-text="Helpful info"
+        invalid
+        invalid-text="Something is wrong"></cds-text-input>
+    `);
+    const input = el.shadowRoot.querySelector('input');
+    const errorText = el.shadowRoot.querySelector('.cds--form-requirement');
+
+    expect(input.getAttribute('aria-describedby')).to.equal('error-text');
+    expect(errorText.id).to.equal('error-text');
+  });
 });

--- a/packages/web-components/src/components/text-input/text-input.ts
+++ b/packages/web-components/src/components/text-input/text-input.ts
@@ -9,6 +9,7 @@ import { LitElement, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { prefix } from '../../globals/settings';
 import { iconLoader } from '../../globals/internal/icon-loader';
 import ifNonEmpty from '../../globals/directives/if-non-empty';
@@ -475,7 +476,7 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
         : null;
 
     const labelWrapper = html`<div class="${prefix}--text-input__label-wrapper">
-      <label class="${labelClasses}">
+      <label class="${labelClasses}" for="input">
         <slot name="label-text">${label}</slot>
       </label>
       ${counter}
@@ -501,12 +502,22 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
       normalizedProps.invalid || normalizedProps.warn
         ? html`<div
             class="${prefix}--form-requirement"
+            id="error-text"
             ?hidden="${!normalizedProps.invalid && !normalizedProps.warn}">
             <slot name="${normalizedProps['slot-name']}">
               ${normalizedProps['slot-text']}
             </slot>
           </div>`
         : null;
+
+    // Mirrors `cds-select`: the validation message takes precedence over the
+    // helper text, which is hidden while the input is invalid or in warning.
+    let describedBy: string | undefined;
+    if (normalizedProps.invalid || normalizedProps.warn) {
+      describedBy = 'error-text';
+    } else if (hasHelperText) {
+      describedBy = 'helper-text';
+    }
 
     return html`
       <div class="${inputWrapperClasses}">
@@ -523,7 +534,7 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
               class="${inputClasses}"
               ?data-invalid="${invalid}"
               ?disabled="${disabled}"
-              ?aria-describedby="${hasHelperText ? 'helper-text' : undefined}"
+              aria-describedby="${ifDefined(describedBy)}"
               id="input"
               name="${ifNonEmpty(this.name)}"
               pattern="${ifNonEmpty(this.pattern)}"


### PR DESCRIPTION
Closes #22332

### Changelog

**Changed**

- `cds-text-input`: the `<label>` had no `for` attribute while the inner `<input>` has `id="input"`, so the two were never programmatically associated. The label now points at the input, matching `cds-radio-button` and the other form elements that use `id="input"`/`for="input"`.
- `cds-text-input`: `aria-describedby` was written as a **boolean** attribute binding — `?aria-describedby="${hasHelperText ? 'helper-text' : undefined}"`. In Lit the `?` prefix sets the attribute to an *empty string* when the expression is truthy, so the rendered markup was `aria-describedby=""` and the input was described by nothing. It is now a regular attribute binding using `ifDefined`.
- `cds-text-input`: the validation message had no `id`, so it could not be referenced at all. It now has `id="error-text"` and takes precedence over the helper text when the input is invalid or in warning, mirroring `cds-select`.

This is why the automated checks passed while JAWS and VoiceOver announced nothing useful: the attributes were present, they just did not point anywhere. As the issue notes, the input was effectively "labelled" only by its placeholder.

The implementation follows `cds-select`, which already does exactly this (`id="helper-text"` / `id="error-text"`, a computed `describedBy`, and `aria-describedby="${ifDefined(describedBy)}"`), so this brings text-input in line rather than introducing a new pattern.

#### Testing / Reviewing

Four unit tests added to `text-input-test.js`:

- the label's `for` matches the input's `id`
- with `helper-text`, `aria-describedby` resolves to `helper-text` and the helper element carries that id
- with no helper text, `aria-describedby` is absent rather than empty
- when `invalid`, `aria-describedby` resolves to `error-text` and the validation message carries that id

To verify manually: render a `cds-text-input` with `label` and `helper-text`, then inspect the accessibility tree — the input should be named by the label text rather than the placeholder, and described by the helper text. With `invalid` set, the description should switch to the validation message.

**Note for reviewers:** I could not run the web-components suite locally — the build fails resolving `@use './menu-variables'` in `menu.scss` because my Windows user directory contains a space, which breaks the sass path handling. The change is unrelated to that file. Relying on CI for the test run.

Separately, `checkbox-group.ts` has the same `?aria-describedby` boolean-binding bug at line 207. I have left it out to keep this PR scoped to the issue, but it is worth a follow-up.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~ (no API change; not applicable)
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass