### PR TITLE
fix(NumberInput): add Storybook controls

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.stories.js
+++ b/packages/react/src/components/NumberInput/NumberInput.stories.js
@@ -34,6 +34,8 @@ export default {
 };
 
 const sharedArgTypes = {
+  allowEmpty: { control: { type: 'boolean' } },
+  disableWheel: { control: { type: 'boolean' } },
   min: { control: { type: 'number' } },
   max: { control: { type: 'number' } },
   step: { control: { type: 'number' } },
@@ -48,12 +50,71 @@ const sharedArgTypes = {
   },
   label: { control: { type: 'text' } },
   helperText: { control: { type: 'text' } },
+  hideLabel: { control: { type: 'boolean' } },
+  hideSteppers: { control: { type: 'boolean' } },
+  inputMode: {
+    options: [
+      'none',
+      'text',
+      'tel',
+      'url',
+      'email',
+      'numeric',
+      'decimal',
+      'search',
+    ],
+    control: { type: 'select' },
+  },
+  readOnly: { control: { type: 'boolean' } },
+  type: {
+    options: ['number', 'text'],
+    control: { type: 'select' },
+  },
 };
 
 const reusableProps = {
   min: -100000000,
   max: 100000000,
 };
+
+const sharedArgs = {
+  allowEmpty: false,
+  disableWheel: false,
+  disabled: false,
+  helperText: 'Optional helper text.',
+  invalid: false,
+  invalidText: 'Number is not valid.',
+  label: 'NumberInput label',
+  hideLabel: false,
+  hideSteppers: false,
+  inputMode: 'decimal',
+  readOnly: false,
+  size: 'md',
+  step: 1,
+  type: 'number',
+  warn: false,
+  warnText:
+    'Warning message that is really long can wrap to more lines but should not be excessively long.',
+};
+
+const textArgs = {
+  ...sharedArgs,
+  formatOptions: {},
+  inputMode: 'decimal',
+  locale: 'en-US',
+  max: reusableProps.max,
+  min: reusableProps.min,
+  stepStartValue: 0,
+  type: 'text',
+};
+
+const sharedControls = Object.keys(sharedArgTypes);
+const textControls = [
+  ...sharedControls,
+  'formatOptions',
+  'locale',
+  'stepStartValue',
+];
 
 // TODO: Potential opportunity to differentiate between controlled and uncontrolled stories
 export const Default = (args) => {
@@ -66,11 +127,7 @@ export const Default = (args) => {
   return (
     <NumberInput
       id="default-number-input"
-      min={-100}
-      max={100}
       value={value}
-      label="NumberInput label"
-      helperText="Optional helper text."
       onChange={handleChange}
       {...args}
     />
@@ -78,18 +135,19 @@ export const Default = (args) => {
 };
 
 Default.args = {
-  step: 1,
-  disabled: false,
-  invalid: false,
+  ...sharedArgs,
+  max: 100,
+  min: -100,
   invalidText: `Number is not valid. Must be between -100 and 100`,
-  helperText: 'Optional helper text.',
-  warn: false,
-  warnText:
-    'Warning message that is really long can wrap to more lines but should not be excessively long.',
-  size: 'md',
 };
 
 Default.argTypes = { ...sharedArgTypes };
+
+Default.parameters = {
+  controls: {
+    include: sharedControls,
+  },
+};
 
 export const withAILabel = (args) => {
   const aiLabel = (
@@ -125,50 +183,42 @@ export const withAILabel = (args) => {
 
   return (
     <div style={{ width: 400 }}>
-      <NumberInput
-        min={reusableProps.min}
-        max={reusableProps.max}
-        defaultValue={50}
-        label="NumberInput label"
-        helperText="Optional helper text."
-        invalidText="Number is not valid"
-        decorator={aiLabel}
-        {...args}
-      />
+      <NumberInput defaultValue={50} decorator={aiLabel} {...args} />
     </div>
   );
 };
 
 withAILabel.argTypes = { ...sharedArgTypes };
 
+withAILabel.args = {
+  ...sharedArgs,
+  invalidText: 'Number is not valid',
+  max: reusableProps.max,
+  min: reusableProps.min,
+};
+
+withAILabel.parameters = {
+  controls: {
+    include: sharedControls,
+  },
+};
+
 export const WithTypeOfText = (args) => {
   const locale = useDocumentLang();
+  const { locale: localeArg, ...inputArgs } = args;
 
   return (
     <NumberInput
       id="default-number-input"
-      min={reusableProps.min}
-      max={reusableProps.max}
-      inputMode="decimal"
       defaultValue={50}
-      label="NumberInput label"
-      helperText="Optional helper text."
-      {...args}
-      locale={locale}
+      {...inputArgs}
+      locale={localeArg || locale}
     />
   );
 };
 WithTypeOfText.args = {
-  step: 1,
-  disabled: false,
-  invalid: false,
+  ...textArgs,
   invalidText: `Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}`,
-  helperText: 'Optional helper text.',
-  warn: false,
-  warnText:
-    'Warning message that is really long can wrap to more lines but should not be excessively long.',
-  size: 'md',
-  type: 'text',
 };
 WithTypeOfText.argTypes = {
   locale: { control: { type: 'text' } },
@@ -176,23 +226,23 @@ WithTypeOfText.argTypes = {
   formatOptions: { control: { type: 'object' } },
   ...sharedArgTypes,
 };
+WithTypeOfText.parameters = {
+  controls: {
+    include: textControls,
+  },
+};
 
 export const WithTypeOfTextControlled = (args) => {
   const locale = useDocumentLang();
   const [value, setValue] = useState(NaN);
+  const { locale: localeArg, ...inputArgs } = args;
 
   return (
     <>
       <NumberInput
         id="default-number-input"
-        min={reusableProps.min}
-        max={reusableProps.max}
-        type="text"
-        inputMode="decimal"
-        label="NumberInput label"
-        helperText="Optional helper text."
-        {...args}
-        locale={locale}
+        {...inputArgs}
+        locale={localeArg || locale}
         value={value}
         onChange={(event, state) => {
           setValue(state.value);
@@ -210,40 +260,33 @@ export const WithTypeOfTextControlled = (args) => {
   );
 };
 WithTypeOfTextControlled.args = {
-  step: 1,
-  disabled: false,
-  invalid: false,
+  ...textArgs,
   invalidText: `Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}`,
-  helperText: 'Optional helper text.',
-  warn: false,
-  warnText:
-    'Warning message that is really long can wrap to more lines but should not be excessively long.',
-  size: 'md',
-  type: 'text',
 };
 WithTypeOfTextControlled.argTypes = {
   locale: { control: { type: 'text' } },
   formatOptions: { control: { type: 'object' } },
   ...sharedArgTypes,
 };
+WithTypeOfTextControlled.parameters = {
+  controls: {
+    include: textControls,
+  },
+};
 
 export const WithTypeOfCustomValidation = (args) => {
   const locale = useDocumentLang();
   const [value, setValue] = useState(NaN);
+  const { locale: localeArg, ...inputArgs } = args;
 
   return (
     <>
       <NumberInput
         id="default-number-input"
-        type="text"
-        inputMode="decimal"
-        label="NumberInput label"
-        helperText="Optional helper text."
         validate={validateNumberSeparators}
-        {...args}
-        locale={locale}
+        {...inputArgs}
+        locale={localeArg || locale}
         value={value}
-        allowEmpty
         onChange={(event, state) => {
           setValue(state.value);
         }}
@@ -259,21 +302,19 @@ export const WithTypeOfCustomValidation = (args) => {
   );
 };
 WithTypeOfCustomValidation.args = {
-  step: 1,
-  disabled: false,
-  invalid: false,
+  ...textArgs,
+  allowEmpty: true,
   invalidText: `Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}`,
-  helperText: 'Optional helper text.',
-  warn: false,
-  warnText:
-    'Warning message that is really long can wrap to more lines but should not be excessively long.',
-  size: 'md',
-  type: 'text',
 };
 WithTypeOfCustomValidation.argTypes = {
   locale: { control: { type: 'text' } },
   formatOptions: { control: { type: 'object' } },
   ...sharedArgTypes,
+};
+WithTypeOfCustomValidation.parameters = {
+  controls: {
+    include: textControls,
+  },
 };
 
 export const Skeleton = (args) => {

--- a/packages/web-components/src/components/number-input/number-input.stories.ts
+++ b/packages/web-components/src/components/number-input/number-input.stories.ts
@@ -208,76 +208,79 @@ const argTypes = {
   },
 };
 
+const storyParameters = {
+  controls: {
+    exclude: ['onInput'],
+  },
+};
+
+const renderNumberInput = (args, { children = '', id, validate } = {}) => {
+  const {
+    allowEmpty,
+    decrementButtonDescription,
+    incrementButtonDescription,
+    disabled,
+    helperText,
+    hideLabel,
+    hideSteppers,
+    invalid,
+    invalidText,
+    label,
+    readOnly,
+    warn,
+    warnText,
+    value,
+    min,
+    max,
+    size,
+    step,
+    type,
+    locale,
+    inputMode,
+    stepStartValue,
+    disableWheel,
+    onInput,
+  } = args ?? {};
+
+  return html`
+    <cds-number-input
+      id="${ifDefined(id)}"
+      ?allow-empty="${allowEmpty}"
+      decrement-button-assistive-text="${ifDefined(decrementButtonDescription)}"
+      increment-button-assistive-text="${ifDefined(incrementButtonDescription)}"
+      helper-text="${ifDefined(helperText)}"
+      ?hide-steppers="${hideSteppers}"
+      ?hide-label="${hideLabel}"
+      ?invalid="${invalid}"
+      invalid-text="${ifDefined(invalidText)}"
+      label="${ifDefined(label)}"
+      ?readonly="${readOnly}"
+      value="${ifDefined(value)}"
+      ?warn="${warn}"
+      warn-text="${ifDefined(warnText)}"
+      ?disabled="${disabled}"
+      min="${ifDefined(min)}"
+      max="${ifDefined(max)}"
+      size="${ifDefined(size)}"
+      step="${ifDefined(step)}"
+      type="${ifDefined(type)}"
+      locale="${ifDefined(locale)}"
+      input-mode="${ifDefined(inputMode)}"
+      step-start-value="${ifDefined(stepStartValue)}"
+      ?disable-wheel="${disableWheel}"
+      .validate="${validate}"
+      @cds-number-input="${onInput}">
+      ${children}
+    </cds-number-input>
+  `;
+};
+
 export const Default = {
   args,
   argTypes,
-  parameters: {
-    controls: {
-      exclude: ['onInput'],
-    },
-  },
-  render: (args) => {
-    const {
-      allowEmpty,
-      decrementButtonDescription,
-      incrementButtonDescription,
-      disabled,
-      helperText,
-      hideLabel,
-      hideSteppers,
-      invalid,
-      invalidText,
-      label,
-      readOnly,
-      warn,
-      warnText,
-      value,
-      min,
-      max,
-      size,
-      step,
-      type,
-      locale,
-      inputMode,
-      stepStartValue,
-      disableWheel,
-      onInput,
-    } = args ?? {};
-    return html`
-      <cds-form-item>
-        <cds-number-input
-          ?allow-empty="${allowEmpty}"
-          decrement-button-assistive-text="${ifDefined(
-            decrementButtonDescription
-          )}"
-          increment-button-assistive-text="${ifDefined(
-            incrementButtonDescription
-          )}"
-          helper-text="${ifDefined(helperText)}"
-          ?hide-steppers="${hideSteppers}"
-          ?hide-label="${hideLabel}"
-          ?invalid="${invalid}"
-          invalid-text="${ifDefined(invalidText)}"
-          label="${ifDefined(label)}"
-          ?readonly="${readOnly}"
-          value="${ifDefined(value)}"
-          ?warn="${warn}"
-          warn-text="${ifDefined(warnText)}"
-          ?disabled="${disabled}"
-          min="${ifDefined(min)}"
-          max="${ifDefined(max)}"
-          size="${ifDefined(size)}"
-          step="${ifDefined(step)}"
-          type="${ifDefined(type)}"
-          locale="${ifDefined(locale)}"
-          input-mode="${ifDefined(inputMode)}"
-          step-start-value="${ifDefined(stepStartValue)}"
-          ?disable-wheel="${disableWheel}"
-          @cds-number-input="${onInput}">
-        </cds-number-input>
-      </cds-form-item>
-    `;
-  },
+  parameters: storyParameters,
+  render: (args) =>
+    html`<cds-form-item>${renderNumberInput(args)}</cds-form-item>`,
 };
 
 export const Skeleton = {
@@ -318,33 +321,42 @@ export const Skeleton = {
 };
 
 export const WithAILabel = {
+  args: {
+    ...args,
+    helperText: 'Optional helper text.',
+    invalidText: 'Number is not valid',
+    max: reusableProps.max,
+    min: reusableProps.min,
+  },
   argTypes,
-  render: (args) => {
-    const { onInput } = args ?? {};
-    return html`
-      <div style="width: 400px">
-        <cds-number-input
-          value="50"
-          min="${reusableProps.min}"
-          max="${reusableProps.max}"
-          step="1"
-          label="NumberInput label"
-          helper-text="Optional helper text."
-          invalid-text="Number is not valid"
-          @cds-number-input="${onInput}">
+  parameters: storyParameters,
+  render: (args) => html`
+    <div style="width: 400px">
+      ${renderNumberInput(args, {
+        children: html`
           <cds-ai-label alignment="bottom-left">
             ${content}${actions}
           </cds-ai-label>
-        </cds-number-input>
-      </div>
-    `;
-  },
+        `,
+      })}
+    </div>
+  `,
 };
 
 export const WithTypeOfCustomValidation = {
+  args: {
+    ...args,
+    allowEmpty: true,
+    helperText: 'Optional helper text. Uses en-US formatting.',
+    invalidText: `Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}`,
+    max: reusableProps.max,
+    min: reusableProps.min,
+    type: 'text',
+    value: '',
+  },
   argTypes,
-  render: (args, { globals: { locale } }) => {
-    const { onInput } = args ?? {};
+  parameters: storyParameters,
+  render: (args) => {
     // Custom user-passed validator
     const validateNumberSeparators = (
       input: string,
@@ -454,21 +466,10 @@ export const WithTypeOfCustomValidation = {
 
     return html`
       <cds-form-item>
-        <cds-number-input
-          id="custom-validation-number-input"
-          type="text"
-          input-mode="decimal"
-          allow-empty
-          min="${reusableProps.min}"
-          invalid-text="Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}"
-          max="${reusableProps.max}"
-          step="1"
-          locale="${locale}"
-          label="NumberInput label"
-          helper-text="Optional helper text. Uses ${locale} formatting."
-          .validate="${validateNumberSeparators}"
-          @cds-number-input="${onInput}">
-        </cds-number-input>
+        ${renderNumberInput(args, {
+          id: 'custom-validation-number-input',
+          validate: validateNumberSeparators,
+        })}
       </cds-form-item>
       <button
         @click="${() => {
@@ -486,49 +487,37 @@ export const WithTypeOfCustomValidation = {
 };
 
 export const WithTypeOfText = {
-  argTypes,
-  render: (args, { globals: { locale } }) => {
-    const { onInput } = args ?? {};
-    return html`
-      <cds-form-item>
-        <cds-number-input
-          type="text"
-          input-mode="decimal"
-          allow-empty
-          default-value="50"
-          min="${reusableProps.min}"
-          max="${reusableProps.max}"
-          step="1"
-          locale="${locale}"
-          label="NumberInput label"
-          invalid-text="Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}"
-          helper-text="Optional helper text. Uses ${locale} formatting."
-          @cds-number-input="${onInput}">
-        </cds-number-input>
-      </cds-form-item>
-    `;
+  args: {
+    ...args,
+    allowEmpty: true,
+    helperText: 'Optional helper text. Uses en-US formatting.',
+    invalidText: `Number is not valid. Must be between ${reusableProps.min} and ${reusableProps.max}`,
+    max: reusableProps.max,
+    min: reusableProps.min,
+    type: 'text',
   },
+  argTypes,
+  parameters: storyParameters,
+  render: (args) =>
+    html`<cds-form-item>${renderNumberInput(args)}</cds-form-item>`,
 };
 
 export const WithTypeOfTextControlled = {
+  args: {
+    ...args,
+    allowEmpty: true,
+    helperText: 'Optional helper text. Uses en-US formatting.',
+    max: reusableProps.max,
+    min: 0,
+    type: 'text',
+    value: '',
+  },
   argTypes,
-  render: (args, { globals: { locale } }) => {
-    const { onInput } = args ?? {};
+  parameters: storyParameters,
+  render: (args) => {
     return html`
       <cds-form-item>
-        <cds-number-input
-          id="controlled-number-input"
-          type="text"
-          input-mode="decimal"
-          allow-empty
-          min="0"
-          max="100000000"
-          step="1"
-          locale="${locale}"
-          label="NumberInput label"
-          helper-text="Optional helper text. Uses ${locale} formatting."
-          @cds-number-input="${onInput}">
-        </cds-number-input>
+        ${renderNumberInput(args, { id: 'controlled-number-input' })}
       </cds-form-item>
       <button
         @click="${() => {


### PR DESCRIPTION
Closes #20939

Adds operable Storybook controls to every visible NumberInput story across React and Web Components. Shared args now drive the default, AI-label, text-format, controlled-text, and custom-validation examples while hidden regression fixtures remain deterministic.

### Changelog

**New**

- Added complete shared args and correctly typed controls for React NumberInput stories.
- Added focused control sets for NumberInput text-format variants.
- Added a reusable args-driven NumberInput renderer for Web Component stories.

**Changed**

- Updated React default, AI-label, text, controlled-text, and custom-validation stories to source configurable props from args.
- Made React locale controls operative with a document-language fallback.
- Updated Web Component default, AI-label, text, controlled-text, and custom-validation stories to render configurable attributes from args.
- Scoped action-only handlers out of the visible Controls panel while retaining Storybook action logging.

**Removed**

- None.

#### Testing / Reviewing

1. Use the repository Node version and start React Storybook:

       nvm use
       yarn workspace @carbon/react storybook

2. Open `Components/NumberInput`.

3. Verify Default and With AI Label respond to number, state, label, helper text, size, stepper, and input-mode controls.

4. Verify With Type Of Text, With Type Of Text Controlled, and With Type Of Custom Validation respond to locale, formatting, range, state, and text-input controls without exposing controlled-value internals.

5. Start Web Components Storybook:

       yarn workspace @carbon/web-components storybook

6. Open `Components/Number Input`.

7. Verify Default, With AI Label, With Type Of Text, With Type Of Text Controlled, and With Type Of Custom Validation respond to their controls.

8. Confirm the custom validator and set-value buttons still work.

9. Verify the Skeleton stories respond to size and hide-label controls.

10. Run the focused checks:

       yarn jest packages/react/src/components/NumberInput/__tests__/NumberInput-test.js packages/react/src/components/NumberInput/__tests__/NumberInputSkeleton-test.js --runInBand
       yarn workspace @carbon/web-components exec web-test-runner "src/components/number-input/__tests__/*-test.js" --node-resolve --concurrency=1
       yarn eslint --no-warn-ignored packages/react/src/components/NumberInput/NumberInput.stories.js packages/web-components/src/components/number-input/number-input.stories.ts
       yarn prettier --check packages/react/src/components/NumberInput/NumberInput.stories.js packages/web-components/src/components/number-input/number-input.stories.ts
       yarn workspace @carbon/react storybook:build
       yarn workspace @carbon/web-components storybook:build
       CI=1 yarn playwright test e2e/components/NumberInput/NumberInput-test.avt.e2e.js --project chromium

**Test Screenshots**
<img width="1282" height="247" alt="Screenshot 2026-08-02 at 11 45 27 a m" src="https://github.com/user-attachments/assets/c1928d83-949a-43da-b483-ef9dbe82a376" />


## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and Storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md).