### PR TITLE
fix(OrderedList): add Storybook controls

### DIFF
--- a/packages/react/src/components/OrderedList/OrderedList.stories.js
+++ b/packages/react/src/components/OrderedList/OrderedList.stories.js
@@ -93,6 +93,12 @@ Nested.args = {
   nested: true,
 };
 
+Nested.argTypes = {
+  nested: {
+    control: false,
+  },
+};
+
 export const NativeListStyles = ({ nested, ...listArgs }) => {
   return (
     <OrderedList {...listArgs}>
@@ -123,4 +129,13 @@ export const NativeListStyles = ({ nested, ...listArgs }) => {
 NativeListStyles.args = {
   native: true,
   nested: true,
+};
+
+NativeListStyles.argTypes = {
+  native: {
+    control: false,
+  },
+  nested: {
+    control: false,
+  },
 };

--- a/packages/react/src/components/OrderedList/OrderedList.stories.js
+++ b/packages/react/src/components/OrderedList/OrderedList.stories.js
@@ -10,6 +10,30 @@ import OrderedList from '../OrderedList';
 import ListItem from '../ListItem';
 import mdx from './OrderedList.mdx';
 
+const args = {
+  isExpressive: false,
+  native: false,
+  nested: false,
+};
+
+const argTypes = {
+  isExpressive: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  native: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  nested: {
+    control: {
+      type: 'boolean',
+    },
+  },
+};
+
 export default {
   title: 'Components/OrderedList',
   component: OrderedList,
@@ -21,6 +45,8 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
 
 export const Default = (args) => (
@@ -41,40 +67,16 @@ export const Default = (args) => (
   </OrderedList>
 );
 
-Default.args = {
-  isExpressive: false,
-  native: false,
-  nested: false,
-};
-
-Default.argTypes = {
-  isExpressive: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  native: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  nested: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
-
-export const Nested = () => {
+export const Nested = ({ nested, ...listArgs }) => {
   return (
-    <OrderedList>
+    <OrderedList {...listArgs}>
       <ListItem>
         Ordered List level 1
-        <OrderedList nested>
+        <OrderedList {...listArgs} nested={nested}>
           <ListItem>Ordered List level 2</ListItem>
           <ListItem>
             Ordered List level 2
-            <OrderedList nested>
+            <OrderedList {...listArgs} nested={nested}>
               <ListItem>Ordered List level 3</ListItem>
               <ListItem>Ordered List level 3</ListItem>
             </OrderedList>
@@ -87,15 +89,19 @@ export const Nested = () => {
   );
 };
 
-export const NativeListStyles = () => {
+Nested.args = {
+  nested: true,
+};
+
+export const NativeListStyles = ({ nested, ...listArgs }) => {
   return (
-    <OrderedList native>
+    <OrderedList {...listArgs}>
       <ListItem>Ordered List level 1</ListItem>
       <ListItem>Ordered List level 1</ListItem>
       <ListItem>Ordered List level 1</ListItem>
       <ListItem>
         Ordered List level 1
-        <OrderedList nested>
+        <OrderedList {...listArgs} nested={nested}>
           <ListItem>Ordered List level 2</ListItem>
           <ListItem>Ordered List level 2</ListItem>
           <ListItem>Ordered List level 2</ListItem>
@@ -112,4 +118,9 @@ export const NativeListStyles = () => {
       <ListItem>Ordered List level 1</ListItem>
     </OrderedList>
   );
+};
+
+NativeListStyles.args = {
+  native: true,
+  nested: true,
 };

--- a/packages/web-components/src/components/list/ordered-list.stories.ts
+++ b/packages/web-components/src/components/list/ordered-list.stories.ts
@@ -12,6 +12,7 @@ import './index';
 const defaultArgs = {
   isExpressive: false,
   native: false,
+  nested: false,
 };
 
 const controls = {
@@ -24,13 +25,18 @@ const controls = {
     description:
       'Specify whether this ordered list should use native list styles instead of custom counter.',
   },
+  nested: {
+    control: 'boolean',
+    description: 'Specify whether to use nested styling for child lists.',
+  },
 };
 
 export const Default = {
-  args: defaultArgs,
-  argTypes: controls,
-  render: ({ isExpressive, native }) =>
-    html`<cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
+  render: ({ isExpressive, native, nested }) =>
+    html`<cds-ordered-list
+      ?is-expressive="${isExpressive}"
+      ?native="${native}"
+      ?nested="${nested}">
       <cds-list-item>Ordered List level 1</cds-list-item>
       <cds-list-item>Ordered List level 1</cds-list-item>
       <cds-list-item>Ordered List level 1</cds-list-item>
@@ -48,16 +54,18 @@ export const Default = {
 };
 
 export const NativeListStyles = {
-  args: { ...defaultArgs, native: true },
-  argTypes: controls,
-  render: ({ isExpressive, native }) =>
+  args: { native: true, nested: true },
+  render: ({ isExpressive, native, nested }) =>
     html`<cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
       <cds-list-item>Ordered List level 1</cds-list-item>
       <cds-list-item>Ordered List level 1</cds-list-item>
       <cds-list-item>Ordered List level 1</cds-list-item>
       <cds-list-item>
         Ordered List level 1
-        <cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
+        <cds-ordered-list
+          ?is-expressive="${isExpressive}"
+          ?native="${native}"
+          ?nested="${nested}">
           <cds-list-item>Ordered List level 2</cds-list-item>
           <cds-list-item>Ordered List level 2</cds-list-item>
           <cds-list-item>Ordered List level 2</cds-list-item>
@@ -76,19 +84,22 @@ export const NativeListStyles = {
 };
 
 export const Nested = {
-  args: defaultArgs,
-  argTypes: controls,
-  render: ({ isExpressive, native }) =>
+  args: { nested: true },
+  render: ({ isExpressive, native, nested }) =>
     html`<cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
       <cds-list-item>
         Ordered List level 1
-        <cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
+        <cds-ordered-list
+          ?is-expressive="${isExpressive}"
+          ?native="${native}"
+          ?nested="${nested}">
           <cds-list-item>Ordered List level 2</cds-list-item>
           <cds-list-item>
             Ordered List level 2
             <cds-ordered-list
               ?is-expressive="${isExpressive}"
-              ?native="${native}">
+              ?native="${native}"
+              ?nested="${nested}">
               <cds-list-item>Ordered List level 3</cds-list-item>
               <cds-list-item>Ordered List level 3</cds-list-item>
             </cds-ordered-list>
@@ -102,6 +113,8 @@ export const Nested = {
 
 const meta = {
   title: 'Components/Ordered list',
+  args: defaultArgs,
+  argTypes: controls,
   parameters: {
     docs: {
       page: storyDocs,

--- a/packages/web-components/src/components/list/ordered-list.stories.ts
+++ b/packages/web-components/src/components/list/ordered-list.stories.ts
@@ -55,6 +55,16 @@ export const Default = {
 
 export const NativeListStyles = {
   args: { native: true, nested: true },
+  argTypes: {
+    native: {
+      ...controls.native,
+      control: false,
+    },
+    nested: {
+      ...controls.nested,
+      control: false,
+    },
+  },
   render: ({ isExpressive, native, nested }) =>
     html`<cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
       <cds-list-item>Ordered List level 1</cds-list-item>
@@ -85,6 +95,12 @@ export const NativeListStyles = {
 
 export const Nested = {
   args: { nested: true },
+  argTypes: {
+    nested: {
+      ...controls.nested,
+      control: false,
+    },
+  },
   render: ({ isExpressive, native, nested }) =>
     html`<cds-ordered-list ?is-expressive="${isExpressive}" ?native="${native}">
       <cds-list-item>


### PR DESCRIPTION
Closes #20940

Adds operable Storybook controls to every OrderedList story across React and Web Components. The Default, Nested, and Native List Styles examples now share component args and apply nested styling controls to the intended list level.

### Changelog

**New**

- Added the inherited `nested` control to Web Component OrderedList stories.
- Added args to the React Nested and Native List Styles stories.

**Changed**

- Shared OrderedList args and argTypes across all stories in both packages.
- Updated React Nested and Native List Styles stories to render from args.
- Updated Web Component nested child lists to respond to expressive, native, and nested controls.

**Removed**

- None.

#### Testing / Reviewing

1. Use the repository Node version and start both Storybooks:

       nvm use
       yarn workspace @carbon/react storybook
       yarn workspace @carbon/web-components storybook

2. Open `Components/OrderedList` in React Storybook and `Components/Ordered list` in Web Components Storybook.

3. In Default, toggle `isExpressive`, `native`, and `nested`, and verify the root list styling updates.

4. In Nested, toggle `isExpressive` and `native`, and verify those styles apply across list levels. Toggle `nested` and verify nested styling changes only on child lists.

5. In Native List Styles, verify `native` defaults to enabled and `nested` defaults to enabled for the child list. Toggle each control and confirm the corresponding list styles update.

6. Run the focused checks:

       yarn jest packages/react/src/components/OrderedList/OrderedList-test.js --runInBand
       yarn workspace @carbon/web-components exec web-test-runner "src/components/list/__tests__/ordered-list-test.js" --node-resolve --concurrency=1
       yarn workspace @carbon/react storybook:build
       yarn workspace @carbon/web-components storybook:build
       CI=1 yarn playwright test e2e/components/OrderedList/OrderedList-test.avt.e2e.js --project chromium

**Test Screenshot**
<img width="658" height="224" alt="Screenshot 2026-08-03 at 3 27 47 p m" src="https://github.com/user-attachments/assets/173c09b9-db26-4e4f-9efd-2a045e0ebff7" />

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)