### PR TITLE
fix(Pagination): add Storybook controls

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -11,43 +11,97 @@ import { action } from 'storybook/actions';
 import mdx from './Pagination.mdx';
 import userEvent from '@testing-library/user-event';
 
-const props = () => ({
-  disabled: false,
-  page: 1,
-  totalItems: 103,
-  pagesUnknown: false,
-  pageInputDisabled: undefined,
-  pageSizeInputDisabled: undefined,
+const args = {
   backwardText: 'Previous',
+  backwardTextTooltipPosition: 'top',
+  disabled: false,
   forwardText: 'Next',
-  pageSize: 10,
-  pageSizes: [10, 20, 30, 40, 50],
+  forwardTextTooltipPosition: 'top',
+  isLastPage: false,
   itemsPerPageText: 'Items per page:',
+  page: 1,
+  pageInputDisabled: false,
+  pageNumberText: 'Page Number',
+  pageSize: 10,
+  pageSizeInputDisabled: false,
+  pageSizes: [10, 20, 30, 40, 50],
+  pagesUnknown: false,
+  size: 'md',
+  totalItems: 103,
   onChange: action('onChange'),
-});
+};
+
+const argTypes = {
+  className: {
+    control: false,
+  },
+  id: {
+    control: false,
+  },
+  itemText: {
+    control: false,
+  },
+  backwardText: {
+    control: { type: 'text' },
+  },
+  backwardTextTooltipPosition: {
+    options: ['top', 'right', 'bottom', 'left'],
+    control: { type: 'select' },
+  },
+  forwardText: {
+    control: { type: 'text' },
+  },
+  forwardTextTooltipPosition: {
+    options: ['top', 'right', 'bottom', 'left'],
+    control: { type: 'select' },
+  },
+  disabled: {
+    control: { type: 'boolean' },
+  },
+  isLastPage: {
+    control: { type: 'boolean' },
+  },
+  itemsPerPageText: {
+    control: { type: 'text' },
+  },
+  onChange: {
+    action: 'onChange',
+  },
+  page: {
+    control: { type: 'number' },
+  },
+  pageInputDisabled: {
+    control: { type: 'boolean' },
+  },
+  pageSize: {
+    control: { type: 'number' },
+  },
+  pageSizes: {
+    control: { type: 'array' },
+  },
+  pageNumberText: {
+    control: { type: 'text' },
+  },
+  pagesUnknown: {
+    control: { type: 'boolean' },
+  },
+  pageSizeInputDisabled: {
+    control: { type: 'boolean' },
+  },
+  size: {
+    options: ['xs', 'sm', 'md', 'lg'],
+    control: { type: 'select' },
+  },
+  totalItems: {
+    control: { type: 'number' },
+  },
+};
 
 export default {
   title: 'Components/Pagination',
   component: Pagination,
-  argTypes: {
-    size: {
-      options: ['xs', 'sm', 'md', 'lg'],
-      control: { type: 'select' },
-    },
-    backwardTextTooltipPosition: {
-      options: ['top', 'right', 'bottom', 'left'],
-      control: { type: 'select' },
-    },
-    forwardTextTooltipPosition: {
-      options: ['top', 'right', 'bottom', 'left'],
-      control: { type: 'select' },
-    },
-  },
-  args: {
-    size: 'md',
-    backwardTextTooltipPosition: 'top',
-    forwardTextTooltipPosition: 'top',
-  },
+  argTypes,
+  args,
   decorators: [
     (story) => (
       <div style={{ maxWidth: '800px', marginTop: '15px' }}>{story()}</div>
@@ -61,118 +115,10 @@ export default {
 };
 
 export const Default = (args) => {
-  return <Pagination pageSizes={[10, 20, 30, 40, 50]} {...args} />;
-};
-
-Default.args = {
-  backwardText: 'Previous',
-  backwardTextTooltipPosition: 'top',
-  forwardText: 'Next',
-  forwardTextTooltipPosition: 'top',
-  disabled: false,
-  isLastPage: false,
-  itemsPerPageText: 'Items per page:',
-  page: 1,
-  pageInputDisabled: false,
-  pageSize: 10,
-  pageSizes: [10, 20, 30, 40, 50],
-  pageNumberText: 'Page Number',
-  pagesUnknown: false,
-  pageSizeInputDisabled: false,
-  totalItems: 103,
-};
-
-Default.argTypes = {
-  className: {
-    control: false,
-  },
-  id: {
-    control: false,
-  },
-  itemText: {
-    control: false,
-  },
-  backwardText: {
-    control: {
-      type: 'text',
-    },
-  },
-  backwardTextTooltipPosition: {
-    options: ['top', 'right', 'bottom', 'left'],
-    control: { type: 'select' },
-  },
-  forwardText: {
-    control: {
-      type: 'text',
-    },
-  },
-  forwardTextTooltipPosition: {
-    options: ['top', 'right', 'bottom', 'left'],
-    control: { type: 'select' },
-  },
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  isLastPage: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  itemsPerPageText: {
-    control: {
-      type: 'text',
-    },
-  },
-  page: {
-    control: {
-      type: 'number',
-    },
-  },
-  pageInputDisabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  pageSize: {
-    control: {
-      type: 'number',
-    },
-  },
-  pageSizes: {
-    control: {
-      type: 'array',
-    },
-  },
-  pageNumberText: {
-    control: {
-      type: 'text',
-    },
-  },
-  pagesUnknown: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  pageSizeInputDisabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  size: {
-    options: ['xs', 'sm', 'md', 'lg'],
-    control: { type: 'select' },
-  },
-  totalItems: {
-    control: {
-      type: 'number',
-    },
-  },
+  return <Pagination {...args} />;
 };
 
 export const TooltipHover = {
-  ...Default,
   tags: ['!autodocs', '!dev'],
   parameters: {
     chromatic: { delay: 100 },
@@ -188,8 +134,8 @@ export const TooltipHover = {
 export const MultiplePaginationComponents = (args) => {
   return (
     <div>
-      <Pagination {...props()} {...args} />
-      <Pagination {...props()} {...args} />
+      <Pagination {...args} />
+      <Pagination {...args} />
     </div>
   );
 };
@@ -200,7 +146,7 @@ export const PaginationWithCustomPageSizesLabel = (args) => {
   return (
     <div>
       <Pagination
-        {...props()}
+        {...args}
         pageSizes={[
           { text: 'Ten', value: 10 },
           { text: 'Twenty', value: 20 },
@@ -208,7 +154,6 @@ export const PaginationWithCustomPageSizesLabel = (args) => {
           { text: 'Forty', value: 40 },
           { text: 'Fifty', value: 50 },
         ]}
-        {...args}
       />
     </div>
   );
@@ -216,19 +161,18 @@ export const PaginationWithCustomPageSizesLabel = (args) => {
 
 PaginationWithCustomPageSizesLabel.storyName =
   'Pagination with custom page sizes label';
+PaginationWithCustomPageSizesLabel.parameters = {
+  controls: {
+    exclude: ['pageSizes'],
+  },
+};
 
 export const PaginationUnknownPages = (args) => {
   const { pageInputDisabled, pagesUnknown, totalItems, ...rest } = args ?? {};
 
   return (
     <div>
-      <Pagination
-        {...props()}
-        page={1}
-        {...rest}
-        pagesUnknown
-        totalItems={undefined}
-      />
+      <Pagination {...rest} pagesUnknown totalItems={undefined} />
     </div>
   );
 };


### PR DESCRIPTION
Closes #20942

Adds operable Storybook controls to every React Pagination story and verifies the existing Web Component stories already meet the same acceptance criteria. Shared metadata now drives all general-purpose controls, while fixed variant props remain intentionally scoped out.

### Changelog

**New**

- None.

**Changed**

- Consolidated React Pagination args and argTypes at story metadata level.
- Updated Default, Tooltip Hover, Multiple Pagination Components, custom page-size labels, and unknown-pages stories to consume shared args.
- Scoped the fixed `pageSizes` control out of the custom-label story.
- Scoped fixed unknown-page props out of the unknown-pages story.
- Removed duplicate per-story Pagination prop factories.

**Removed**

- None.

#### Testing / Reviewing

1. Use the repository Node version and start both Storybooks:

       nvm use
       yarn workspace @carbon/react storybook
       yarn workspace @carbon/web-components storybook

2. Open `Components/Pagination` in React Storybook.

3. Verify Default and Multiple Pagination Components respond to text, tooltip position, disabled state, page, page size, size, and total-item controls.

4. Open Pagination with custom page sizes label. Confirm general controls remain operable and `pageSizes` is omitted because the story intentionally fixes its text/value pairs.

5. Open Unknown pages and items. Confirm general controls remain operable and `pageInputDisabled`, `pagesUnknown`, and `totalItems` are omitted because that variant fixes them.

6. Open `Components/Pagination` in Web Components Storybook and confirm Default, Multiple, custom page-size labels, and unknown-pages stories continue responding to their existing controls.

7. Run the focused checks:

       yarn jest packages/react/src/components/Pagination/__tests__/Pagination-test.js packages/react/src/components/Pagination/__tests__/PaginationSkeleton-test.js --runInBand
       yarn workspace @carbon/react storybook:build
       yarn workspace @carbon/web-components storybook:build
       CI=1 yarn playwright test e2e/components/Pagination/Pagination-test.avt.e2e.js --project chromium

**Test Screenshot**
<img width="999" height="247" alt="Screenshot 2026-08-03 at 3 46 18 p m" src="https://github.com/user-attachments/assets/56426d7d-6cac-45d7-8cff-6ae81498f612" />

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)