### PR TITLE
feat: rounded buttons with css custom properties and story controls

### DIFF
--- a/packages/react/src/components/Button/Button.stories.js
+++ b/packages/react/src/components/Button/Button.stories.js
@@ -9,14 +9,12 @@ import React from 'react';
 import { action } from 'storybook/actions';
 import { Add, Notification, Filter } from '@carbon/icons-react';
 import { default as Button, ButtonSkeleton } from '../Button';
-import { Stack } from '../Stack';
 import mdx from './Button.mdx';
 import './button-story.scss';
 import {
   radiusArgTypes,
   radiusArgs,
   radiusNames,
-  radiusSource,
   withRadiusVars,
   withoutRadiusArgs,
 } from './story-radius-controls';
@@ -148,7 +146,6 @@ export default {
   parameters: {
     docs: {
       page: mdx,
-      source: radiusSource,
     },
   },
 };
@@ -452,3 +449,146 @@ Skeleton.parameters = {
     include: skeletonControls,
   },
 };
+
+const Example = ({ label, note, children }) => (
+  <div className="button-story-example">
+    <code>{label}</code>
+    <span className="button-story-example__note">{note}</span>
+    {/* Keeps the content in block flow, so only `fluid` stretches. */}
+    <div>{children}</div>
+  </div>
+);
+
+const IconButtons = (props) => (
+  <>
+    <Button {...props} renderIcon={Add} hasIconOnly iconDescription="Add" />
+    <Button
+      {...props}
+      renderIcon={Filter}
+      hasIconOnly
+      iconDescription="Filter"
+    />
+    <Button
+      {...props}
+      renderIcon={Notification}
+      hasIconOnly
+      iconDescription="Notification"
+    />
+  </>
+);
+
+// Everything here follows the border-radius controls; each example only
+// overrides the corners it needs to, so the whole grid reacts to the sliders.
+export const ButtonsInContext = (args) => {
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
+  const icon =
+    renderIcon !== 'None' ? getIconFromString(renderIcon) : undefined;
+
+  return (
+    <div className="button-story-grid">
+      <Example label="single" note="follows the base property">
+        <Button {...rest}>Button</Button>
+      </Example>
+
+      <Example label="form actions" note="the common pairing">
+        <div className="button-story-row">
+          <Button kind="secondary" {...rest}>
+            Cancel
+          </Button>
+          <Button kind="primary" {...rest} renderIcon={icon ?? Add}>
+            Create
+          </Button>
+        </div>
+      </Example>
+
+      <Example label="joined" note="inner corners squared">
+        <div className="button-story-joined">
+          <Button kind="secondary" {...rest}>
+            Day
+          </Button>
+          <Button kind="secondary" {...rest}>
+            Week
+          </Button>
+          <Button kind="secondary" {...rest}>
+            Month
+          </Button>
+        </div>
+      </Example>
+
+      <Example label="joined icons" note="tooltip wrappers, same result">
+        <div className="button-story-joined">
+          <IconButtons kind="secondary" {...rest} />
+        </div>
+      </Example>
+
+      <Example
+        label="toolbar on a layer"
+        note="container = buttons + padding, so the gap is even">
+        <div className="button-story-toolbar">
+          <IconButtons kind="secondary" {...rest} />
+        </div>
+      </Example>
+
+      <Example
+        label="joined icons on a layer"
+        note="container follows the group's outer corners">
+        <div className="button-story-toolbar">
+          <div className="button-story-joined">
+            <IconButtons kind="secondary" {...rest} />
+          </div>
+        </div>
+      </Example>
+
+      <Example label="nested radius" note="outer = inner + padding">
+        <div className="button-story-nested">
+          <Button kind="primary" {...rest}>
+            Inset
+          </Button>
+        </div>
+      </Example>
+
+      <Example label="badge" note="sits where the corner pulls in">
+        <Button
+          {...rest}
+          kind="ghost"
+          size="lg"
+          hasIconOnly
+          renderIcon={Notification}
+          iconDescription="Notifications"
+          badgeCount={4}
+        />
+      </Example>
+
+      <Example label="flush with a field" note="leading corners squared">
+        <div className="button-story-flush">
+          <span className="button-story-flush__field">Search</span>
+          <Button kind="primary" {...rest}>
+            Go
+          </Button>
+        </div>
+      </Example>
+
+      <Example label="asymmetric" note="one corner opted out">
+        <div className="button-story-asymmetric">
+          <Button kind="primary" {...rest}>
+            Notched
+          </Button>
+        </div>
+      </Example>
+
+      <Example label="fluid" note="stretched, corners unchanged">
+        <div className="button-story-fluid">
+          <Button kind="primary" {...rest}>
+            Full width
+          </Button>
+        </div>
+      </Example>
+
+      <Example label="skeleton" note="clipped by overflow: hidden">
+        <ButtonSkeleton size={rest.size} />
+      </Example>
+    </div>
+  );
+};
+
+ButtonsInContext.storyName = 'Buttons in Context';

--- a/packages/react/src/components/Button/Button.stories.js
+++ b/packages/react/src/components/Button/Button.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,6 +12,14 @@ import { default as Button, ButtonSkeleton } from '../Button';
 import { Stack } from '../Stack';
 import mdx from './Button.mdx';
 import './button-story.scss';
+import {
+  radiusArgTypes,
+  radiusArgs,
+  radiusNames,
+  radiusSource,
+  withRadiusVars,
+  withoutRadiusArgs,
+} from './story-radius-controls';
 
 // Note: we explicitly define the defaultValue here, as the Button component takes `props` and forwards them
 // to the underlying `button` or `a` element, as a result storybook cannot infer the default values from the component.
@@ -109,6 +117,7 @@ const sharedArgTypes = {
     control: { type: 'select' },
     options: ['Add', 'None'],
   },
+  ...radiusArgTypes,
 };
 
 const textButtonControls = [
@@ -124,24 +133,28 @@ const textButtonControls = [
   'tabIndex',
   'target',
   'type',
+  ...radiusNames,
 ];
 
-const skeletonControls = ['href', 'size'];
+const skeletonControls = ['href', 'size', ...radiusNames];
 
 export default {
   title: 'Components/Button',
   component: Button,
   subcomponents: { ButtonSkeleton },
   argTypes: sharedArgTypes,
+  args: radiusArgs,
+  decorators: [withRadiusVars],
   parameters: {
     docs: {
       page: mdx,
+      source: radiusSource,
     },
   },
 };
 
 export const Default = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -163,7 +176,7 @@ Default.parameters = {
 };
 
 export const Secondary = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -194,7 +207,7 @@ Secondary.parameters = {
 };
 
 export const Tertiary = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -225,7 +238,7 @@ Tertiary.parameters = {
 };
 
 export const Ghost = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -256,7 +269,7 @@ Ghost.parameters = {
 };
 
 export const Danger = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -287,7 +300,7 @@ Danger.parameters = {
 };
 
 export const DangerTertiary = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -318,7 +331,7 @@ DangerTertiary.parameters = {
 };
 
 export const DangerGhost = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -349,7 +362,7 @@ DangerGhost.parameters = {
 };
 
 export const IconButton = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -381,7 +394,7 @@ IconButton.args = {
 };
 
 export const IconButtonWithBadge = (args) => {
-  const { renderIcon, ...rest } = args;
+  const { renderIcon, ...rest } = withoutRadiusArgs(args);
   return (
     <Button
       {...rest}
@@ -430,7 +443,9 @@ IconButtonWithBadge.args = {
   size: 'lg',
 };
 
-export const Skeleton = (args) => <ButtonSkeleton {...args} />;
+export const Skeleton = (args) => (
+  <ButtonSkeleton {...withoutRadiusArgs(args)} />
+);
 
 Skeleton.parameters = {
   controls: {

--- a/packages/react/src/components/Button/story-radius-controls.js
+++ b/packages/react/src/components/Button/story-radius-controls.js
@@ -6,21 +6,20 @@
  */
 
 import React from 'react';
+import './story-radius-controls.scss';
 
-// Slider positions; the arg holds the index into this list.
-export const radiusSteps = [
-  '0px',
-  '2px',
-  '4px',
-  '8px',
-  '16px',
-  '24px',
-  '999999px',
-];
+// Slider positions, named after the `$border-radius-*` variables that declare
+// them. Keep in sync with `$radius-steps` in `story-radius-controls.scss`; the
+// arg holds the index into this list.
+const stepNames = ['0', '02', '04', '08', '16', '24', 'max'];
+
+const stepLabels = stepNames
+  .map((step) => (step === '0' ? '0' : `$border-radius-${step}`))
+  .join(', ');
 
 const argType = (description) => ({
-  description: `${description} Steps: ${radiusSteps.join(', ')}.`,
-  control: { type: 'range', min: 0, max: radiusSteps.length - 1, step: 1 },
+  description: `${description} Steps: ${stepLabels}.`,
+  control: { type: 'range', min: 0, max: stepNames.length - 1, step: 1 },
   table: { category: 'border-radius' },
 });
 
@@ -38,47 +37,30 @@ export const radiusArgTypes = {
 
 export const radiusNames = Object.keys(radiusArgTypes);
 
-export const radiusArgs = { '--cds-border-radius': radiusSteps.length - 1 };
+export const radiusArgs = { '--cds-border-radius': stepNames.length - 1 };
 
-const radiusStyle = (args) =>
-  Object.fromEntries(
-    radiusNames
-      .filter((name) => args[name] != null)
-      .map((name) => [name, radiusSteps[args[name]]])
-  );
+// `--cds-border-radius-ss` is declared by `.button-story-radius-ss--04`, and so
+// on for each property and step.
+const radiusClasses = (args) =>
+  radiusNames
+    .filter((name) => args[name] != null)
+    .map(
+      (name) =>
+        `button-story-${name.replace('--cds-border-', '')}--${
+          stepNames[args[name]]
+        }`
+    )
+    .join(' ');
 
 // The decorator below applies these args, so stories drop them before
 // forwarding the rest to the DOM.
 export const withoutRadiusArgs = (args) =>
   Object.fromEntries(
-    Object.entries(args).filter(([key]) => !radiusNames.includes(key))
+    Object.entries(args).filter(([name]) => !radiusNames.includes(name))
   );
 
 export const withRadiusVars = (Story, context) => (
-  <div style={radiusStyle(context.args)}>
+  <div className={radiusClasses(context.args)}>
     <Story />
   </div>
 );
-
-// Shows the custom properties that are set in the docs code snippet.
-export const radiusSource = {
-  type: 'dynamic',
-  transform: (code, context) => {
-    const style = Object.entries(radiusStyle(context.args));
-
-    if (style.length === 0) {
-      return code;
-    }
-
-    const declarations = style
-      .map(([name, value]) => `    '${name}': '${value}',`)
-      .join('\n');
-    const story = code
-      .trimEnd()
-      .split('\n')
-      .map((line) => `  ${line}`)
-      .join('\n');
-
-    return `// set this in your scss with the border-tokens\n<div\n  style={{\n${declarations}\n  }}>\n${story}\n</div>`;
-  },
-};

--- a/packages/react/src/components/Button/story-radius-controls.js
+++ b/packages/react/src/components/Button/story-radius-controls.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+// Slider positions; the arg holds the index into this list.
+export const radiusSteps = [
+  '0px',
+  '2px',
+  '4px',
+  '8px',
+  '16px',
+  '24px',
+  '999999px',
+];
+
+const argType = (description) => ({
+  description: `${description} Steps: ${radiusSteps.join(', ')}.`,
+  control: { type: 'range', min: 0, max: radiusSteps.length - 1, step: 1 },
+  table: { category: 'border-radius' },
+});
+
+// Args are keyed by the custom property they set, so they double as the names
+// to list in `controls.include`.
+export const radiusArgTypes = {
+  '--cds-border-radius': argType(
+    'Base radius for all four corners. The per-corner properties take priority.'
+  ),
+  '--cds-border-radius-ss': argType('Start-start corner.'),
+  '--cds-border-radius-se': argType('Start-end corner.'),
+  '--cds-border-radius-es': argType('End-start corner.'),
+  '--cds-border-radius-ee': argType('End-end corner.'),
+};
+
+export const radiusNames = Object.keys(radiusArgTypes);
+
+export const radiusArgs = { '--cds-border-radius': radiusSteps.length - 1 };
+
+const radiusStyle = (args) =>
+  Object.fromEntries(
+    radiusNames
+      .filter((name) => args[name] != null)
+      .map((name) => [name, radiusSteps[args[name]]])
+  );
+
+// The decorator below applies these args, so stories drop them before
+// forwarding the rest to the DOM.
+export const withoutRadiusArgs = (args) =>
+  Object.fromEntries(
+    Object.entries(args).filter(([key]) => !radiusNames.includes(key))
+  );
+
+export const withRadiusVars = (Story, context) => (
+  <div style={radiusStyle(context.args)}>
+    <Story />
+  </div>
+);
+
+// Shows the custom properties that are set in the docs code snippet.
+export const radiusSource = {
+  type: 'dynamic',
+  transform: (code, context) => {
+    const style = Object.entries(radiusStyle(context.args));
+
+    if (style.length === 0) {
+      return code;
+    }
+
+    const declarations = style
+      .map(([name, value]) => `    '${name}': '${value}',`)
+      .join('\n');
+    const story = code
+      .trimEnd()
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n');
+
+    return `// set this in your scss with the border-tokens\n<div\n  style={{\n${declarations}\n  }}>\n${story}\n</div>`;
+  },
+};

--- a/packages/react/src/components/Button/story-radius-controls.scss
+++ b/packages/react/src/components/Button/story-radius-controls.scss
@@ -1,0 +1,34 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/components/button/vars' as *;
+@use '@carbon/styles/scss/utilities/custom-property';
+
+// The steps the border-radius controls offer. Keep in sync with `stepNames` in
+// `story-radius-controls.js`, which turns a slider index into a class name.
+$radius-steps: (
+  '0': 0rem,
+  '02': $border-radius-02,
+  '04': $border-radius-04,
+  '08': $border-radius-08,
+  '16': $border-radius-16,
+  '24': $border-radius-24,
+  'max': $border-radius-max,
+);
+
+$radius-parts: 'radius', 'radius-ss', 'radius-se', 'radius-es', 'radius-ee';
+
+// One class per property and step, so the decorator can declare the custom
+// properties by toggling classes rather than writing an inline style. Setting
+// them here is also how a consumer would do it.
+@each $part in $radius-parts {
+  @each $step, $value in $radius-steps {
+    .button-story-#{$part}--#{$step} {
+      @include custom-property.declaration('border-#{$part}', $value);
+    }
+  }
+}

--- a/packages/react/src/components/ButtonSet/ButtonSet.stories.js
+++ b/packages/react/src/components/ButtonSet/ButtonSet.stories.js
@@ -14,19 +14,29 @@ import {
   fluidButtonOptions,
 } from '../Button/__story__/fluid-button-set-args';
 import { action } from 'storybook/actions';
+import {
+  radiusArgTypes,
+  radiusArgs,
+  radiusSource,
+  withRadiusVars,
+} from '../Button/story-radius-controls';
 
 export default {
   title: 'Components/Button/Set Of Buttons',
   component: ButtonSet,
   subcomponents: { Button },
+  decorators: [withRadiusVars],
+  parameters: { docs: { source: radiusSource } },
 
   args: {
     Buttons: 4,
     'Container width': 600,
     'Container visible': false,
+    ...radiusArgs,
   },
 
   argTypes: {
+    ...radiusArgTypes,
     Buttons: {
       control: {
         type: 'select',

--- a/packages/react/src/components/ButtonSet/ButtonSet.stories.js
+++ b/packages/react/src/components/ButtonSet/ButtonSet.stories.js
@@ -17,7 +17,6 @@ import { action } from 'storybook/actions';
 import {
   radiusArgTypes,
   radiusArgs,
-  radiusSource,
   withRadiusVars,
 } from '../Button/story-radius-controls';
 
@@ -26,7 +25,6 @@ export default {
   component: ButtonSet,
   subcomponents: { Button },
   decorators: [withRadiusVars],
-  parameters: { docs: { source: radiusSource } },
 
   args: {
     Buttons: 4,

--- a/packages/react/src/components/IconButton/IconButton.stories.js
+++ b/packages/react/src/components/IconButton/IconButton.stories.js
@@ -9,6 +9,13 @@ import { Edit, Notification } from '@carbon/icons-react';
 import React from 'react';
 import { IconButton } from '../IconButton';
 import mdx from './IconButton.mdx';
+import {
+  radiusArgTypes,
+  radiusArgs,
+  radiusSource,
+  withRadiusVars,
+  withoutRadiusArgs,
+} from '../Button/story-radius-controls';
 
 const alignOptions = [
   'top',
@@ -39,6 +46,9 @@ const deprecatedAlignOptions = [
 export default {
   title: 'Components/IconButton',
   component: IconButton,
+  argTypes: radiusArgTypes,
+  args: radiusArgs,
+  decorators: [withRadiusVars],
   parameters: {
     controls: {
       hideNoControlsWarning: true,
@@ -46,13 +56,14 @@ export default {
     },
     docs: {
       page: mdx,
+      source: radiusSource,
     },
     layout: 'centered',
   },
 };
 
 export const Default = (args) => {
-  const { align, alignDeprecated, ...rest } = args;
+  const { align, alignDeprecated, ...rest } = withoutRadiusArgs(args);
   const resolvedAlign = alignDeprecated || align;
   return (
     <div style={{ margin: '3rem' }}>
@@ -114,7 +125,7 @@ export const withBadgeIndicator = (args) => {
         kind="ghost"
         size="lg"
         autoAlign
-        {...args}>
+        {...withoutRadiusArgs(args)}>
         <Notification />
       </IconButton>
     </div>

--- a/packages/react/src/components/IconButton/IconButton.stories.js
+++ b/packages/react/src/components/IconButton/IconButton.stories.js
@@ -12,7 +12,6 @@ import mdx from './IconButton.mdx';
 import {
   radiusArgTypes,
   radiusArgs,
-  radiusSource,
   withRadiusVars,
   withoutRadiusArgs,
 } from '../Button/story-radius-controls';
@@ -56,7 +55,6 @@ export default {
     },
     docs: {
       page: mdx,
-      source: radiusSource,
     },
     layout: 'centered',
   },

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2024
+// Copyright IBM Corp. 2016, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -457,6 +457,7 @@
   .#{$prefix}--btn.#{$prefix}--skeleton {
     @include skeleton;
 
+    overflow: hidden;
     inline-size: convert.to-rem(150px);
   }
 

--- a/packages/styles/scss/components/button/_mixins.scss
+++ b/packages/styles/scss/components/button/_mixins.scss
@@ -19,6 +19,12 @@
 @use '../../utilities/layout';
 @use 'tokens' as *;
 
+// get this from https://github.com/carbon-design-system/carbon/pull/22814
+$button-radius-max: custom-property.get-var(
+  'border-radius',
+  convert.to-rem(999999px)
+);
+
 $button-focus-color: custom-property.get-var('button-focus-color', $focus);
 
 @mixin button-base {
@@ -48,9 +54,24 @@ $button-focus-color: custom-property.get-var('button-focus-color', $focus);
   display: inline-flex;
   flex-shrink: 0;
   justify-content: space-between;
-  border-radius: $button-border-radius;
   // Fix to remove added margins on buttons in safari (see #5155)
   margin: 0;
+  border-end-end-radius: custom-property.get-var(
+    'border-radius-ee',
+    $button-radius-max
+  );
+  border-end-start-radius: custom-property.get-var(
+    'border-radius-es',
+    $button-radius-max
+  );
+  border-start-end-radius: custom-property.get-var(
+    'border-radius-se',
+    $button-radius-max
+  );
+  border-start-start-radius: custom-property.get-var(
+    'border-radius-ss',
+    $button-radius-max
+  );
   cursor: pointer;
   inline-size: max-content;
   max-inline-size: convert.to-rem(320px);

--- a/packages/styles/scss/components/button/_mixins.scss
+++ b/packages/styles/scss/components/button/_mixins.scss
@@ -19,12 +19,6 @@
 @use '../../utilities/layout';
 @use 'tokens' as *;
 
-// get this from https://github.com/carbon-design-system/carbon/pull/22814
-$button-radius-max: custom-property.get-var(
-  'border-radius',
-  convert.to-rem(999999px)
-);
-
 $button-focus-color: custom-property.get-var('button-focus-color', $focus);
 
 @mixin button-base {
@@ -58,19 +52,19 @@ $button-focus-color: custom-property.get-var('button-focus-color', $focus);
   margin: 0;
   border-end-end-radius: custom-property.get-var(
     'border-radius-ee',
-    $button-radius-max
+    custom-property.get-var('border-radius', $border-radius-max)
   );
   border-end-start-radius: custom-property.get-var(
     'border-radius-es',
-    $button-radius-max
+    custom-property.get-var('border-radius', $border-radius-max)
   );
   border-start-end-radius: custom-property.get-var(
     'border-radius-se',
-    $button-radius-max
+    custom-property.get-var('border-radius', $border-radius-max)
   );
   border-start-start-radius: custom-property.get-var(
     'border-radius-ss',
-    $button-radius-max
+    custom-property.get-var('border-radius', $border-radius-max)
   );
   cursor: pointer;
   inline-size: max-content;

--- a/packages/styles/scss/components/button/_vars.scss
+++ b/packages/styles/scss/components/button/_vars.scss
@@ -22,6 +22,37 @@ $button-font-size: 0.875rem !default;
 /// @group button
 $button-border-radius: 0 !default;
 
+/// get these from https://github.com/carbon-design-system/carbon/pull/22814
+/// @type Number
+/// @access public
+/// @group button
+$border-radius-02: 0.125rem !default;
+
+/// @type Number
+/// @access public
+/// @group button
+$border-radius-04: 0.25rem !default;
+
+/// @type Number
+/// @access public
+/// @group button
+$border-radius-08: 0.5rem !default;
+
+/// @type Number
+/// @access public
+/// @group button
+$border-radius-16: 1rem !default;
+
+/// @type Number
+/// @access public
+/// @group button
+$border-radius-24: 1.5rem !default;
+
+/// @type Number
+/// @access public
+/// @group button
+$border-radius-max: 999999px !default;
+
 /// @type Number
 /// @access public
 /// @group button

--- a/packages/web-components/src/components/button/button-story.scss
+++ b/packages/web-components/src/components/button/button-story.scss
@@ -5,10 +5,10 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/styles/scss/theme' as *;
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/components/button/vars' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/type' as *;
 
 // Falls back to the same value the button mixin uses, for the cases where a
 // container has to match a radius it does not set itself.
@@ -39,17 +39,18 @@ $corners: (
 // columns and still drops to two or one when there is no room.
 .button-story-grid {
   display: grid;
+  align-items: start;
   gap: $spacing-07;
   grid-template-columns: repeat(
     auto-fill,
     minmax(max(16rem, calc((100% - #{$spacing-07} * 2) / 3)), 1fr)
   );
-  align-items: start;
 }
 
 .button-story-example {
   display: flex;
   flex-direction: column;
+  color: $text-primary;
   gap: $spacing-03;
 }
 
@@ -68,9 +69,7 @@ $corners: (
 }
 
 // A joined set keeps the radius on the outer corners of the set only, which is
-// what the per-corner properties are for. The properties are set on the direct
-// children, so they land on the button whether it is the child itself or is
-// wrapped in a tooltip, as icon-only buttons are.
+// what the per-corner properties are for.
 .button-story-joined {
   display: inline-flex;
 
@@ -83,6 +82,17 @@ $corners: (
     --cds-border-radius-se: 0;
     --cds-border-radius-ee: 0;
   }
+}
+
+// A toolbar on a layer. The buttons take all four corner properties as they
+// are set, and the container derives its own from the same properties.
+.button-story-toolbar {
+  @include concentric-corners($spacing-03);
+
+  display: inline-flex;
+  padding: $spacing-03;
+  background: $layer;
+  gap: $spacing-03;
 }
 
 // Concentric corners: the container has to add its padding to the radius its
@@ -109,11 +119,11 @@ $corners: (
 .button-story-flush__field {
   display: flex;
   align-items: center;
-  padding-inline: $spacing-05;
-  border-start-start-radius: $radius;
-  border-end-start-radius: $radius;
   background: $field;
+  border-end-start-radius: $radius;
+  border-start-start-radius: $radius;
   color: $text-secondary;
+  padding-inline: $spacing-05;
 }
 
 // Opting a single corner out of the shared radius.
@@ -121,18 +131,12 @@ $corners: (
   --cds-border-radius-ee: 0;
 }
 
-.button-story-fluid .cds--btn {
+// The host has to stretch as well, or the part fills a shrink-wrapped box.
+.button-story-fluid > * {
   inline-size: 100%;
-  max-inline-size: none;
 }
 
-// A toolbar on a layer. The buttons take all four corner properties as they
-// are set, and the container derives its own from the same properties.
-.button-story-toolbar {
-  @include concentric-corners($spacing-03);
-
-  display: inline-flex;
-  gap: $spacing-03;
-  padding: $spacing-03;
-  background: $layer;
+.button-story-fluid > *::part(button) {
+  inline-size: 100%;
+  max-inline-size: none;
 }

--- a/packages/web-components/src/components/button/button.stories.ts
+++ b/packages/web-components/src/components/button/button.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,6 +21,13 @@ import Add16 from '@carbon/icons/es/add/16.js';
 import Notification16 from '@carbon/icons/es/notification/16.js';
 import Filter16 from '@carbon/icons/es/filter/16.js';
 import { iconLoader } from '../../globals/internal/icon-loader';
+import {
+  radiusArgTypes,
+  radiusArgs,
+  radiusNames,
+  radiusSource,
+  withRadiusVars,
+} from './story-radius-controls';
 
 /**
  * Prop parity
@@ -44,6 +51,7 @@ const textButtonControls = [
   'tabindex',
   'target',
   'type',
+  ...radiusNames,
 ];
 
 const iconButtonControls = [
@@ -226,6 +234,7 @@ const sharedArgTypes = {
       None: undefined,
     },
   },
+  ...radiusArgTypes,
 };
 
 const baseButtonTemplate = (args) => html`
@@ -276,9 +285,12 @@ const iconButtonTemplate = (args) => html`
 const meta = {
   title: 'Components/Button',
   argTypes: sharedArgTypes,
+  args: radiusArgs,
+  decorators: [withRadiusVars],
   parameters: {
     actions: { argTypesRegex: '^on.*' },
     controls: { include: textButtonControls },
+    docs: { source: radiusSource },
   },
   render: baseButtonTemplate,
 };
@@ -430,7 +442,7 @@ export const SetOfButtons = {
   },
   parameters: {
     controls: {
-      include: ['stacked'],
+      include: ['stacked', ...radiusNames],
     },
   },
   render: (args) => html`
@@ -448,7 +460,7 @@ export const Skeleton = {
   },
   parameters: {
     controls: {
-      include: ['size', 'href'],
+      include: ['size', 'href', ...radiusNames],
     },
   },
   render: (args) =>

--- a/packages/web-components/src/components/button/button.stories.ts
+++ b/packages/web-components/src/components/button/button.stories.ts
@@ -21,11 +21,11 @@ import Add16 from '@carbon/icons/es/add/16.js';
 import Notification16 from '@carbon/icons/es/notification/16.js';
 import Filter16 from '@carbon/icons/es/filter/16.js';
 import { iconLoader } from '../../globals/internal/icon-loader';
+import styles from './button-story.scss?lit';
 import {
   radiusArgTypes,
   radiusArgs,
   radiusNames,
-  radiusSource,
   withRadiusVars,
 } from './story-radius-controls';
 
@@ -290,7 +290,6 @@ const meta = {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
     controls: { include: textButtonControls },
-    docs: { source: radiusSource },
   },
   render: baseButtonTemplate,
 };
@@ -468,4 +467,125 @@ export const Skeleton = {
       size=${ifDefined(args.size)}
       href=${ifDefined(args.href)}>
     </cds-button-skeleton>`,
+};
+
+const example = (label, note, content) => html`
+  <div class="button-story-example">
+    <code>${label}</code>
+    <span class="button-story-example__note">${note}</span>
+    <div>${content}</div>
+  </div>
+`;
+
+const iconButtons = (args) => html`
+  <cds-button kind="secondary" size=${ifDefined(args.size)}
+    >${iconLoader(Add16, { slot: 'icon' })}</cds-button
+  >
+  <cds-button kind="secondary" size=${ifDefined(args.size)}
+    >${iconLoader(Filter16, { slot: 'icon' })}</cds-button
+  >
+  <cds-button kind="secondary" size=${ifDefined(args.size)}
+    >${iconLoader(Notification16, { slot: 'icon' })}</cds-button
+  >
+`;
+
+export const ButtonsInContext = {
+  name: 'Buttons in Context',
+  render: (args) => html`
+    <div class="button-story-grid">
+      ${example(
+        'single',
+        'follows the base property',
+        html`<cds-button size=${ifDefined(args.size)}>Button</cds-button>`
+      )}
+      ${example(
+        'form actions',
+        'the common pairing',
+        html`<div class="button-story-row">
+          <cds-button kind="secondary" size=${ifDefined(args.size)}
+            >Cancel</cds-button
+          >
+          <cds-button size=${ifDefined(args.size)}>Create</cds-button>
+        </div>`
+      )}
+      ${example(
+        'joined',
+        'inner corners squared',
+        html`<div class="button-story-joined">
+          <cds-button kind="secondary" size=${ifDefined(args.size)}
+            >Day</cds-button
+          >
+          <cds-button kind="secondary" size=${ifDefined(args.size)}
+            >Week</cds-button
+          >
+          <cds-button kind="secondary" size=${ifDefined(args.size)}
+            >Month</cds-button
+          >
+        </div>`
+      )}
+      ${example(
+        'joined icons',
+        'same result with icon buttons',
+        html`<div class="button-story-joined">${iconButtons(args)}</div>`
+      )}
+      ${example(
+        'toolbar on a layer',
+        'container = buttons + padding, so the gap is even',
+        html`<div class="button-story-toolbar">${iconButtons(args)}</div>`
+      )}
+      ${example(
+        'joined icons on a layer',
+        "container follows the group's outer corners",
+        html`<div class="button-story-toolbar">
+          <div class="button-story-joined">${iconButtons(args)}</div>
+        </div>`
+      )}
+      ${example(
+        'nested radius',
+        'outer = inner + padding',
+        html`<div class="button-story-nested">
+          <cds-button size=${ifDefined(args.size)}>Inset</cds-button>
+        </div>`
+      )}
+      ${example(
+        'badge',
+        'sits where the corner pulls in',
+        html`<cds-button kind="ghost" size="lg">
+          ${iconLoader(Notification16, { slot: 'icon' })}
+          <cds-badge-indicator count="4"></cds-badge-indicator>
+        </cds-button>`
+      )}
+      ${example(
+        'flush with a field',
+        'leading corners squared',
+        html`<div class="button-story-flush">
+          <span class="button-story-flush__field">Search</span>
+          <cds-button size=${ifDefined(args.size)}>Go</cds-button>
+        </div>`
+      )}
+      ${example(
+        'asymmetric',
+        'one corner opted out',
+        html`<div class="button-story-asymmetric">
+          <cds-button size=${ifDefined(args.size)}>Notched</cds-button>
+        </div>`
+      )}
+      ${example(
+        'fluid',
+        'stretched, corners unchanged',
+        html`<div class="button-story-fluid">
+          <cds-button size=${ifDefined(args.size)}>Full width</cds-button>
+        </div>`
+      )}
+      ${example(
+        'skeleton',
+        'clipped by overflow: hidden',
+        html`<cds-button-skeleton
+          size=${ifDefined(args.size)}></cds-button-skeleton>`
+      )}
+    </div>
+    <style>
+      ${styles}
+    </style>
+  `,
 };

--- a/packages/web-components/src/components/button/story-radius-controls.scss
+++ b/packages/web-components/src/components/button/story-radius-controls.scss
@@ -1,0 +1,34 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/components/button/vars' as *;
+@use '@carbon/styles/scss/utilities/custom-property';
+
+// The steps the border-radius controls offer. Keep in sync with `stepNames` in
+// `story-radius-controls.ts`, which turns a slider index into a class name.
+$radius-steps: (
+  '0': 0rem,
+  '02': $border-radius-02,
+  '04': $border-radius-04,
+  '08': $border-radius-08,
+  '16': $border-radius-16,
+  '24': $border-radius-24,
+  'max': $border-radius-max,
+);
+
+$radius-parts: 'radius', 'radius-ss', 'radius-se', 'radius-es', 'radius-ee';
+
+// One class per property and step, so the decorator can declare the custom
+// properties by toggling classes rather than writing an inline style. Setting
+// them here is also how a consumer would do it.
+@each $part in $radius-parts {
+  @each $step, $value in $radius-steps {
+    .button-story-#{$part}--#{$step} {
+      @include custom-property.declaration('border-#{$part}', $value);
+    }
+  }
+}

--- a/packages/web-components/src/components/button/story-radius-controls.ts
+++ b/packages/web-components/src/components/button/story-radius-controls.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit';
+
+// Slider positions; the arg holds the index into this list.
+export const radiusSteps = [
+  '0px',
+  '2px',
+  '4px',
+  '8px',
+  '16px',
+  '24px',
+  '999999px',
+];
+
+const argType = (description: string) => ({
+  description: `${description} Steps: ${radiusSteps.join(', ')}.`,
+  control: { type: 'range', min: 0, max: radiusSteps.length - 1, step: 1 },
+  table: { category: 'border-radius' },
+});
+
+// Args are keyed by the custom property they set, so they double as the names
+// to list in `controls.include`.
+export const radiusArgTypes = {
+  '--cds-border-radius': argType(
+    'Base radius for all four corners. The per-corner properties take priority.'
+  ),
+  '--cds-border-radius-ss': argType('Start-start corner.'),
+  '--cds-border-radius-se': argType('Start-end corner.'),
+  '--cds-border-radius-es': argType('End-start corner.'),
+  '--cds-border-radius-ee': argType('End-end corner.'),
+};
+
+export const radiusNames = Object.keys(radiusArgTypes);
+
+export const radiusArgs = { '--cds-border-radius': radiusSteps.length - 1 };
+
+const radiusStyle = (args) =>
+  radiusNames
+    .filter((name) => args?.[name] != null)
+    .map((name) => `${name}: ${radiusSteps[args[name]]};`)
+    .join(' ');
+
+// Sets the custom properties on a wrapper. They inherit through the shadow
+// boundary into the button.
+export const withRadiusVars = (story, { args }) =>
+  html`<div style="${radiusStyle(args)}">${story()}</div>`;
+
+// Shows the custom properties that are set in the docs code snippet.
+export const radiusSource = {
+  transform: (code: string, { args }) => {
+    const style = radiusStyle(args);
+
+    if (!style) {
+      return code;
+    }
+
+    const story = code
+      .trimEnd()
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n');
+
+    return `<!-- set this in your scss with the border-tokens -->\n<div style="${style}">\n${story}\n</div>`;
+  },
+};

--- a/packages/web-components/src/components/button/story-radius-controls.ts
+++ b/packages/web-components/src/components/button/story-radius-controls.ts
@@ -6,21 +6,20 @@
  */
 
 import { html } from 'lit';
+import styles from './story-radius-controls.scss?lit';
 
-// Slider positions; the arg holds the index into this list.
-export const radiusSteps = [
-  '0px',
-  '2px',
-  '4px',
-  '8px',
-  '16px',
-  '24px',
-  '999999px',
-];
+// Slider positions, named after the `$border-radius-*` variables that declare
+// them. Keep in sync with `$radius-steps` in `story-radius-controls.scss`; the
+// arg holds the index into this list.
+const stepNames = ['0', '02', '04', '08', '16', '24', 'max'];
+
+const stepLabels = stepNames
+  .map((step) => (step === '0' ? '0' : `$border-radius-${step}`))
+  .join(', ');
 
 const argType = (description: string) => ({
-  description: `${description} Steps: ${radiusSteps.join(', ')}.`,
-  control: { type: 'range', min: 0, max: radiusSteps.length - 1, step: 1 },
+  description: `${description} Steps: ${stepLabels}.`,
+  control: { type: 'range', min: 0, max: stepNames.length - 1, step: 1 },
   table: { category: 'border-radius' },
 });
 
@@ -38,34 +37,26 @@ export const radiusArgTypes = {
 
 export const radiusNames = Object.keys(radiusArgTypes);
 
-export const radiusArgs = { '--cds-border-radius': radiusSteps.length - 1 };
+export const radiusArgs = { '--cds-border-radius': stepNames.length - 1 };
 
-const radiusStyle = (args) =>
+// `--cds-border-radius-ss` is declared by `.button-story-radius-ss--04`, and so
+// on for each property and step.
+const radiusClasses = (args) =>
   radiusNames
     .filter((name) => args?.[name] != null)
-    .map((name) => `${name}: ${radiusSteps[args[name]]};`)
+    .map(
+      (name) =>
+        `button-story-${name.replace('--cds-border-', '')}--${
+          stepNames[args[name]]
+        }`
+    )
     .join(' ');
 
-// Sets the custom properties on a wrapper. They inherit through the shadow
+// The classes declare the custom properties, which inherit through the shadow
 // boundary into the button.
-export const withRadiusVars = (story, { args }) =>
-  html`<div style="${radiusStyle(args)}">${story()}</div>`;
-
-// Shows the custom properties that are set in the docs code snippet.
-export const radiusSource = {
-  transform: (code: string, { args }) => {
-    const style = radiusStyle(args);
-
-    if (!style) {
-      return code;
-    }
-
-    const story = code
-      .trimEnd()
-      .split('\n')
-      .map((line) => `  ${line}`)
-      .join('\n');
-
-    return `<!-- set this in your scss with the border-tokens -->\n<div style="${style}">\n${story}\n</div>`;
-  },
-};
+export const withRadiusVars = (story, { args }) => html`
+  <div class="${radiusClasses(args)}">${story()}</div>
+  <style>
+    ${styles}
+  </style>
+`;

--- a/packages/web-components/src/components/icon-button/icon-button.stories.ts
+++ b/packages/web-components/src/components/icon-button/icon-button.stories.ts
@@ -18,7 +18,6 @@ import { iconLoader } from '../../globals/internal/icon-loader';
 import {
   radiusArgTypes,
   radiusArgs,
-  radiusSource,
   withRadiusVars,
 } from '../button/story-radius-controls';
 
@@ -179,7 +178,6 @@ const meta = {
     withRadiusVars,
   ],
   title: 'Components/Icon Button',
-  parameters: { docs: { source: radiusSource } },
 };
 
 export default meta;

--- a/packages/web-components/src/components/icon-button/icon-button.stories.ts
+++ b/packages/web-components/src/components/icon-button/icon-button.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,12 @@ import Edit16 from '@carbon/icons/es/edit/16.js';
 import Notification16 from '@carbon/icons/es/notification/16.js';
 import { BUTTON_KIND } from '../button/defs';
 import { iconLoader } from '../../globals/internal/icon-loader';
+import {
+  radiusArgTypes,
+  radiusArgs,
+  radiusSource,
+  withRadiusVars,
+} from '../button/story-radius-controls';
 
 const kinds = {
   [`Primary button (${BUTTON_KIND.PRIMARY})`]: BUTTON_KIND.PRIMARY,
@@ -47,6 +53,7 @@ const args = {
   kind: BUTTON_KIND.PRIMARY,
   label: 'Custom label',
   size: ICON_BUTTON_SIZE.MEDIUM,
+  ...radiusArgs,
 };
 
 const argTypes = {
@@ -99,6 +106,7 @@ const argTypes = {
     description: 'Specify the size of the Button. Defaults to <code>md</code>.',
     options: ICON_BUTTON_SIZE,
   },
+  ...radiusArgTypes,
 };
 
 export const Default = {
@@ -166,8 +174,12 @@ export const withBadgeIndicator = {
 };
 
 const meta = {
-  decorators: [(story) => html`<div style="padding: 3rem">${story()}</div>`],
+  decorators: [
+    (story) => html`<div style="padding: 3rem">${story()}</div>`,
+    withRadiusVars,
+  ],
   title: 'Components/Icon Button',
+  parameters: { docs: { source: radiusSource } },
 };
 
 export default meta;


### PR DESCRIPTION
### 4-corner border radius through CSS custom properties

As discussed in yesterday’s refinement for #22895 (6-Aug-2026).

This PR is **not a complete implementation**, but rather an idea for allowing more control over button border radius based on context. 
e.g: modals, cards, data tables, ... etc.

The default is a fully rounded button using `border-radius-max`, while still allowing the radius to be customized per DOM node by setting CSS custom properties at any level. This allows us to modify the appearance of buttons based on their context.

This approach is **framework-agnostic** and works everywhere for buttons

demos (check for controls and `button in context` story)
[react](https://deploy-preview-22962--v12-carbon-react.netlify.app/?path=/story/components-button--default) [wc](https://deploy-preview-22962--v12-carbon-web-components.netlify.app/?path=/story/components-button--default)