### PR TITLE
feat(styles): expose $button-min-inline-size as a configurable public variable

### DIFF
--- a/packages/styles/scss/components/__tests__/button-test.js
+++ b/packages/styles/scss/components/__tests__/button-test.js
@@ -39,6 +39,7 @@ describe('scss/components/button', () => {
   "button-padding-ghost-sm",
   "button-border-width",
   "button-outline-width",
+  "button-min-inline-size",
   "button-separator",
   "button-primary",
   "button-secondary",

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -58,9 +58,9 @@
   // NOTE: Container queries are based on this value which is based on IBM Products implementation
   // Side panel has up to 3 buttons unstacked from size lg (640px). Min 160.33px/button
   // Narrow Tearsheet 540px has 4 buttons unstacked buttons. Min 135px/button
-  // May need to be configurable as 3 * 135px is less than 640px.
-  // Current value 176px only supports up to 3 buttons at 540px.
-  $min-inline-button-size: convert.to-rem(176px);
+  // Override via `@use '@carbon/styles/scss/components/button' with
+  //   ($button-min-inline-size: <value>)` for contexts that need a different threshold.
+  $min-inline-button-size: $button-min-inline-size;
 
   .#{$prefix}--btn-set__fluid-inner .#{$prefix}--btn {
     // default non-column layout

--- a/packages/styles/scss/components/button/_vars.scss
+++ b/packages/styles/scss/components/button/_vars.scss
@@ -6,6 +6,7 @@
 //
 
 @use '../../spacing' as *;
+@use '../../utilities/convert';
 
 /// @type Number
 /// @access public
@@ -77,3 +78,12 @@ $button-border-width: 2px !default;
 /// @access public
 /// @group button
 $button-outline-width: 1px !default;
+
+/// Minimum inline size of a fluid button. Used as the container-query threshold
+/// for stacking fluid button sets. Contexts with more buttons or narrower
+/// containers (e.g. Tearsheet at 540px with 4 buttons) should lower this value
+/// via `@use … with ($button-min-inline-size: <value>)`.
+/// @type Number
+/// @access public
+/// @group button
+$button-min-inline-size: convert.to-rem(176px) !default;


### PR DESCRIPTION
Closes #22888

Moves the mixin-local `$min-inline-button-size` in `button-set-fluid-layout()` to a public, module-level `!default` variable (`$button-min-inline-size`) in `_vars.scss`, following the same convention used by all other configurable button properties.

This is a **non-breaking change** — the default value remains `convert.to-rem(176px)` (`11rem`), so all existing consumers are unaffected. It unblocks IBM Products (and any other consumer) from configuring the fluid button stacking threshold at Sass compile time via:

```scss
@use '@carbon/styles/scss/components/button' with (
  $button-min-inline-size: convert.to-rem(120px)
);
```

> **Note:** A `var()` approach is not viable here because `@container` query conditions require a resolved `<length>` at parse time — CSS custom properties are not resolved at that stage per the current spec.

### Changelog

**New**

- Added `$button-min-inline-size` as a public, configurable `!default` variable in `@carbon/styles` button component, controlling the container-query threshold for fluid button set stacking.

**Changed**

- `$min-inline-button-size` inside `button-set-fluid-layout()` now references the new public variable instead of a hardcoded `convert.to-rem(176px)`.

**Removed**

- N/A

#### Testing / Reviewing

1. Verify the default visual output is unchanged — fluid button sets should stack at the same breakpoints as before.
2. Override the variable in a consuming stylesheet:
   ```scss
   @use '@carbon/styles/scss/components/button' with (
     $button-min-inline-size: convert.to-rem(120px)
   );
   ```
   Confirm that fluid buttons in a narrow container (≤540px, 4 buttons) remain inline at the new threshold.
3. Confirm no regressions in existing button Storybook stories.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
