### PR TITLE
fix(bob-triage): clarify prompt to ensure character limit is respected

### DIFF
--- a/.github/prompts/bob-bug-triage.md
+++ b/.github/prompts/bob-bug-triage.md
@@ -42,5 +42,9 @@ explaining your reasoning.
 
 Return only the exact Markdown comment to post. Use either one paragraph of no
 more than three sentences or a list of two to three single-line bullet items,
-never both. Stay under 100 words and 600 characters. Do not add a heading,
-preamble, signoff, metadata, HTML comment, or code fence.
+never both. Your response MUST BE UNDER 100 WORDS AND 600 CHARACTERS. Count and
+double check your response before you send it - it cannot be over 100 words and
+600 characters. 101 words with 600 characters will fail. 100 words with 601
+characters will fail. You must be both under 100 words and also be under 600
+characters. Do not add a heading, preamble, signoff, metadata, HTML comment, or
+code fence.


### PR DESCRIPTION
Bob triage is failing because Bob's replying with too long of a response, which causes the workflow to bail out and not post a comment.

### Changelog

**Changed**

- update prompt to be more pushy about the limit

#### Testing / Reviewing

- n/a

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
