### PR TITLE
fix: defer Tabs overflow updates on resize

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -475,6 +475,7 @@ function TabList({
   const ref = useRef<HTMLDivElement>(null);
   const previousButton = useRef<HTMLButtonElement>(null);
   const nextButton = useRef<HTMLButtonElement>(null);
+  const resizeAnimationFrame = useRef<number>(null);
   const [isScrollable, setIsScrollable] = useState(false);
   const [scrollLeft, setScrollLeft] = useState<number>(0);
 
@@ -697,10 +698,27 @@ function TabList({
 
     updateOverflowState();
 
-    const resizeObserver = new ResizeObserver(updateOverflowState);
+    const resizeObserver = new ResizeObserver(() => {
+      if (resizeAnimationFrame.current !== null) {
+        cancelAnimationFrame(resizeAnimationFrame.current);
+      }
+
+      resizeAnimationFrame.current = requestAnimationFrame(() => {
+        resizeAnimationFrame.current = null;
+
+        updateOverflowState();
+      });
+    });
+
     resizeObserver.observe(element);
 
     return () => {
+      if (resizeAnimationFrame.current !== null) {
+        cancelAnimationFrame(resizeAnimationFrame.current);
+
+        resizeAnimationFrame.current = null;
+      }
+
       resizeObserver.disconnect();
     };
   }, [updateOverflowState]);

--- a/packages/react/src/components/Tabs/__tests__/Tabs-test.js
+++ b/packages/react/src/components/Tabs/__tests__/Tabs-test.js
@@ -712,6 +712,88 @@ describe('Tab', () => {
     }
   });
 
+  it('should defer overflow layout changes until after ResizeObserver delivery', () => {
+    let resizeCallback;
+    let queuedResizeUpdate;
+    let containerWidth = 300;
+    const originalResizeObserver = window.ResizeObserver;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const clientWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockImplementation(function () {
+        if (this.classList.contains(`${prefix}--tabs`)) return containerWidth;
+
+        return this.getAttribute('role') === 'tablist' ? containerWidth : 0;
+      });
+    const scrollWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+      .mockImplementation(function () {
+        return this.getAttribute('role') === 'tablist' ? 190 : 0;
+      });
+
+    window.ResizeObserver = jest.fn((callback) => {
+      resizeCallback = callback;
+
+      return {
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+      };
+    });
+    window.requestAnimationFrame = jest.fn((callback) => {
+      queuedResizeUpdate = callback;
+
+      return 1;
+    });
+    window.cancelAnimationFrame = jest.fn();
+
+    try {
+      render(
+        <Tabs>
+          <TabList aria-label="List of tabs">
+            <Tab>Tab Label 1</Tab>
+            <Tab>Tab Label 2</Tab>
+          </TabList>
+        </Tabs>
+      );
+
+      const nextButton = screen.getByLabelText('Scroll right');
+
+      expect(nextButton).toHaveClass(
+        `${prefix}--tab--overflow-nav-button--hidden`
+      );
+
+      // Shrinking the container turns overflow on. The resize callback should
+      // not update the overflow button layout during the same `ResizeObserver`
+      // delivery, and should instead wait until the queued animation frame.
+      containerWidth = 180;
+      const classNameBeforeResize = nextButton.className;
+
+      act(() => {
+        resizeCallback();
+      });
+
+      expect(nextButton.className).toBe(classNameBeforeResize);
+      expect(nextButton).toHaveClass(
+        `${prefix}--tab--overflow-nav-button--hidden`
+      );
+
+      act(() => {
+        queuedResizeUpdate();
+      });
+
+      expect(nextButton).not.toHaveClass(
+        `${prefix}--tab--overflow-nav-button--hidden`
+      );
+    } finally {
+      window.ResizeObserver = originalResizeObserver;
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+      clientWidthSpy.mockRestore();
+      scrollWidthSpy.mockRestore();
+    }
+  });
+
   it('should hide next overflow button when only 1px remains in the overflow threshold', () => {
     jest.useFakeTimers();
     const clientWidthSpy = jest

--- a/packages/react/src/components/Tabs/__tests__/Tabs-test.js
+++ b/packages/react/src/components/Tabs/__tests__/Tabs-test.js
@@ -794,6 +794,66 @@ describe('Tab', () => {
     }
   });
 
+  it('should cancel a pending resize animation frame on unmount', () => {
+    let resizeCallback;
+    let containerWidth = 300;
+    const originalResizeObserver = window.ResizeObserver;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const clientWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockImplementation(function () {
+        if (this.classList.contains(`${prefix}--tabs`)) return containerWidth;
+
+        return this.getAttribute('role') === 'tablist' ? containerWidth : 0;
+      });
+    const scrollWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+      .mockImplementation(function () {
+        return this.getAttribute('role') === 'tablist' ? 190 : 0;
+      });
+
+    window.ResizeObserver = jest.fn((callback) => {
+      resizeCallback = callback;
+
+      return {
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+      };
+    });
+    window.requestAnimationFrame = jest.fn(() => 1);
+    window.cancelAnimationFrame = jest.fn();
+
+    try {
+      const { unmount } = render(
+        <Tabs>
+          <TabList aria-label="List of tabs">
+            <Tab>Tab Label 1</Tab>
+            <Tab>Tab Label 2</Tab>
+          </TabList>
+        </Tabs>
+      );
+
+      containerWidth = 180;
+
+      act(() => {
+        resizeCallback();
+      });
+
+      expect(window.cancelAnimationFrame).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
+    } finally {
+      window.ResizeObserver = originalResizeObserver;
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+      clientWidthSpy.mockRestore();
+      scrollWidthSpy.mockRestore();
+    }
+  });
+
   it('should hide next overflow button when only 1px remains in the overflow threshold', () => {
     jest.useFakeTimers();
     const clientWidthSpy = jest


### PR DESCRIPTION
No issue.

Deferred `Tabs` overflow updates until after `ResizeObserver` delivery to avoid resize feedback loops that emit `ResizeObserver loop completed with undelivered notifications` exceptions.

### Changelog

**Changed**

- Updated horizontal `TabList` resize handling to schedule overflow recalculation in `requestAnimationFrame` instead of mutating layout directly inside the `ResizeObserver` callback.

#### Testing / Reviewing

One of the projects I work on began crashing after updating `@carbon/react` to `1.113.0` with `ResizeObserver loop completed with undelivered notifications` errors. I think https://github.com/carbon-design-system/carbon/pull/22719 may be responsible.

```sh
yarn test packages/react/src/components/Tabs/__tests__/Tabs-test.js
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
