### PR TITLE
test(Card): implement tests

### DIFF
--- a/e2e/components/Card/Card-test.avt.e2e.js
+++ b/e2e/components/Card/Card-test.avt.e2e.js
@@ -47,7 +47,7 @@ test.describe('@avt Card', () => {
   test('@avt-advanced-states with AI label', async ({ page }) => {
     await visitStory(page, {
       component: 'Card',
-      id: 'preview-preview-card--with-a-i-label',
+      id: 'preview-preview-card--with-ai-label',
       globals: {
         theme: 'white',
       },
@@ -90,7 +90,7 @@ test.describe('@avt Card', () => {
 
     // Tab into the first clickable card (role="button")
     await page.keyboard.press('Tab');
-    const card = page.getByRole('button', { name: 'View analytics report' });
+    const card = page.getByRole('button', { name: 'Usage report' });
     await expect(card).toBeFocused();
 
     // Enter activates it — browser alert fires; dismiss so the test can continue

--- a/e2e/components/Card/Card-test.avt.e2e.js
+++ b/e2e/components/Card/Card-test.avt.e2e.js
@@ -90,7 +90,7 @@ test.describe('@avt Card', () => {
 
     // Tab into the first clickable card (role="button")
     await page.keyboard.press('Tab');
-    const card = page.getByRole('button', { name: 'Usage report' });
+    const card = page.getByRole('button', { name: 'Analytics Usage report' });
     await expect(card).toBeFocused();
 
     // Enter activates it — browser alert fires; dismiss so the test can continue
@@ -112,7 +112,9 @@ test.describe('@avt Card', () => {
       },
     });
 
-    const disabledCard = page.getByRole('button', { name: 'Disabled card' });
+    const disabledCard = page.getByRole('button', {
+      name: 'Status Disabled card',
+    });
 
     // The disabled card has tabIndex="-1" so Tab should never land on it
     await expect(disabledCard).toHaveAttribute('tabindex', '-1');

--- a/e2e/components/Card/Card-test.avt.e2e.js
+++ b/e2e/components/Card/Card-test.avt.e2e.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('@avt Card', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Card @avt-default-state');
+  });
+
+  test('@avt-advanced-states clickable', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--clickable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Card-clickable');
+  });
+
+  test('@avt-advanced-states disabled', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--disabled',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Card-disabled');
+  });
+
+  test('@avt-advanced-states with AI label', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--with-a-i-label',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Card-with-ai-label');
+  });
+
+  test('@avt-advanced-states horizontal layout', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--with-horizontal-media',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Card-with-horizontal-media');
+  });
+
+  test('@avt-advanced-states with header actions', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--with-header-actions',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Card-with-header-actions');
+  });
+
+  test('@avt-keyboard-nav clickable card receives focus and activates on Enter', async ({
+    page,
+  }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--clickable',
+      globals: {
+        theme: 'white',
+      },
+    });
+
+    // Tab into the first clickable card (role="button")
+    await page.keyboard.press('Tab');
+    const card = page.getByRole('button', { name: 'View analytics report' });
+    await expect(card).toBeFocused();
+
+    // Enter activates it — browser alert fires; dismiss so the test can continue
+    page.once('dialog', (dialog) => dialog.dismiss());
+    await page.keyboard.press('Enter');
+
+    // Focus should return to the same card after activation
+    await expect(card).toBeFocused();
+  });
+
+  test('@avt-keyboard-nav disabled clickable card is not reachable by Tab', async ({
+    page,
+  }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--clickable',
+      globals: {
+        theme: 'white',
+      },
+    });
+
+    const disabledCard = page.getByRole('button', { name: 'Disabled card' });
+
+    // The disabled card has tabIndex="-1" so Tab should never land on it
+    await expect(disabledCard).toHaveAttribute('tabindex', '-1');
+  });
+
+  test('@avt-keyboard-nav header actions are independently focusable', async ({
+    page,
+  }) => {
+    await visitStory(page, {
+      component: 'Card',
+      id: 'preview-preview-card--with-header-actions',
+      globals: {
+        theme: 'white',
+      },
+    });
+
+    // Tab into the first action button in the header
+    await page.keyboard.press('Tab');
+    const editButton = page.getByRole('button', { name: 'Edit' }).first();
+    await expect(editButton).toBeFocused();
+
+    // Tab to the next action
+    await page.keyboard.press('Tab');
+    const deleteButton = page.getByRole('button', { name: 'Delete' }).first();
+    await expect(deleteButton).toBeFocused();
+  });
+});

--- a/packages/react/src/components/Card/Card.stories.js
+++ b/packages/react/src/components/Card/Card.stories.js
@@ -198,7 +198,9 @@ export const Clickable = () => (
           <img src={placeholder16x9} alt="" width="100%" />
         </Card.Media>
         <Card.Header>
-          <Card.Title id="clickable-title-usage">Usage report</Card.Title>
+          <Card.Title id="clickable-title-usage" label="Analytics">
+            Usage report
+          </Card.Title>
         </Card.Header>
         <Card.Body>
           Click anywhere on this card to trigger the action.
@@ -218,13 +220,13 @@ export const Clickable = () => (
           <img src={placeholder16x9} alt="" width="100%" />
         </Card.Media>
         <Card.Header>
-          <Card.Title id="clickable-title-carbon">
+          <Card.Title id="clickable-title-carbon" label="External link">
             Carbon Design System
           </Card.Title>
         </Card.Header>
         <Card.Body>
-          This card renders as an anchor element for true navigation semantics.
-          Right-click or Cmd+click to open in a new tab.
+          This card renders as an <code>&lt;a&gt;</code> element for true
+          navigation semantics. Right-click or Cmd+click to open in a new tab.
         </Card.Body>
       </Card>
     </Column>
@@ -237,11 +239,13 @@ export const Clickable = () => (
         renderFooterIcon={Share}
         aria-labelledby="clickable-title-share">
         <Card.Header>
-          <Card.Title id="clickable-title-share">Share report</Card.Title>
+          <Card.Title id="clickable-title-share" label="Share">
+            Share report
+          </Card.Title>
         </Card.Header>
         <Card.Body>
-          Pass renderFooterIcon to replace the default arrow with any icon from
-          @carbon/icons-react.
+          Pass <code>renderFooterIcon</code> to replace the default arrow with
+          any icon from <code>@carbon/icons-react</code>.
         </Card.Body>
       </Card>
     </Column>
@@ -254,11 +258,13 @@ export const Clickable = () => (
         onClick={() => alert('Should not fire')}
         aria-labelledby="clickable-title-disabled">
         <Card.Header>
-          <Card.Title id="clickable-title-disabled">Disabled card</Card.Title>
+          <Card.Title id="clickable-title-disabled" label="Status">
+            Disabled card
+          </Card.Title>
         </Card.Header>
         <Card.Body>
-          When disabled is true the card is not interactive and the footer
-          affordance is visually muted.
+          When <code>disabled</code> is true the card is not interactive and the
+          footer affordance is visually muted.
         </Card.Body>
       </Card>
     </Column>
@@ -274,7 +280,9 @@ export const Clickable = () => (
           <img src={placeholder16x9} alt="" width="100%" />
         </Card.Media>
         <Card.Header>
-          <Card.Title id="clickable-title-launch">Product launch</Card.Title>
+          <Card.Title id="clickable-title-launch" label="Featured">
+            Product launch
+          </Card.Title>
         </Card.Header>
         <Card.Body>Clickable card in expressive density.</Card.Body>
       </Card>
@@ -289,13 +297,13 @@ export const Clickable = () => (
         href="#"
         aria-labelledby="clickable-title-quarterly">
         <Card.Header>
-          <Card.Title id="clickable-title-quarterly">
+          <Card.Title id="clickable-title-quarterly" label="Report">
             Quarterly review
           </Card.Title>
         </Card.Header>
         <Card.Body>
-          Use as="a" with density="expressive" for navigation cards in an
-          editorial layout.
+          Use <code>as="a"</code> with <code>density="expressive"</code> for
+          navigation cards in an editorial layout.
         </Card.Body>
       </Card>
     </Column>

--- a/packages/react/src/components/Card/Card.stories.js
+++ b/packages/react/src/components/Card/Card.stories.js
@@ -141,7 +141,7 @@ export const Default = {
   }) => (
     <Grid>
       <Column lg={4} md={4} sm={4}>
-        <Card {...cardArgs} aria-label={title || 'Default card example'}>
+        <Card {...cardArgs}>
           <Card.Media ratio="16x9">
             <img src={placeholder16x9} alt="" width="100%" />
           </Card.Media>
@@ -193,12 +193,12 @@ export const Clickable = () => (
       <Card
         clickable
         onClick={() => alert('Card clicked')}
-        aria-label="View analytics report">
+        aria-labelledby="clickable-title-usage">
         <Card.Media ratio="16x9">
           <img src={placeholder16x9} alt="" width="100%" />
         </Card.Media>
         <Card.Header>
-          <Card.Title label="Analytics">Usage report</Card.Title>
+          <Card.Title id="clickable-title-usage">Usage report</Card.Title>
         </Card.Header>
         <Card.Body>
           Click anywhere on this card to trigger the action.
@@ -213,16 +213,18 @@ export const Clickable = () => (
         as="a"
         href="https://carbondesignsystem.com"
         target="_blank"
-        aria-label="Open Carbon Design System in a new tab">
+        aria-labelledby="clickable-title-carbon">
         <Card.Media ratio="16x9">
           <img src={placeholder16x9} alt="" width="100%" />
         </Card.Media>
         <Card.Header>
-          <Card.Title label="External link">Carbon Design System</Card.Title>
+          <Card.Title id="clickable-title-carbon">
+            Carbon Design System
+          </Card.Title>
         </Card.Header>
         <Card.Body>
-          This card renders as an <code>&lt;a&gt;</code> element for true
-          navigation semantics. Right-click or Cmd+click to open in a new tab.
+          This card renders as an anchor element for true navigation semantics.
+          Right-click or Cmd+click to open in a new tab.
         </Card.Body>
       </Card>
     </Column>
@@ -233,13 +235,13 @@ export const Clickable = () => (
         clickable
         onClick={() => alert('Launch clicked')}
         renderFooterIcon={Share}
-        aria-label="Share this report">
+        aria-labelledby="clickable-title-share">
         <Card.Header>
-          <Card.Title label="Share">Share report</Card.Title>
+          <Card.Title id="clickable-title-share">Share report</Card.Title>
         </Card.Header>
         <Card.Body>
-          Pass <code>renderFooterIcon</code> to replace the default arrow with
-          any icon from <code>@carbon/icons-react</code>.
+          Pass renderFooterIcon to replace the default arrow with any icon from
+          @carbon/icons-react.
         </Card.Body>
       </Card>
     </Column>
@@ -250,13 +252,13 @@ export const Clickable = () => (
         clickable
         disabled
         onClick={() => alert('Should not fire')}
-        aria-label="Disabled card">
+        aria-labelledby="clickable-title-disabled">
         <Card.Header>
-          <Card.Title label="Status">Disabled card</Card.Title>
+          <Card.Title id="clickable-title-disabled">Disabled card</Card.Title>
         </Card.Header>
         <Card.Body>
-          When <code>disabled</code> is true the card is not interactive and the
-          footer affordance is visually muted.
+          When disabled is true the card is not interactive and the footer
+          affordance is visually muted.
         </Card.Body>
       </Card>
     </Column>
@@ -267,12 +269,12 @@ export const Clickable = () => (
         clickable
         density="expressive"
         onClick={() => alert('Expressive card clicked')}
-        aria-label="View product launch details">
+        aria-labelledby="clickable-title-launch">
         <Card.Media ratio="16x9">
           <img src={placeholder16x9} alt="" width="100%" />
         </Card.Media>
         <Card.Header>
-          <Card.Title label="Featured">Product launch</Card.Title>
+          <Card.Title id="clickable-title-launch">Product launch</Card.Title>
         </Card.Header>
         <Card.Body>Clickable card in expressive density.</Card.Body>
       </Card>
@@ -285,13 +287,15 @@ export const Clickable = () => (
         density="expressive"
         as="a"
         href="#"
-        aria-label="Read the quarterly review">
+        aria-labelledby="clickable-title-quarterly">
         <Card.Header>
-          <Card.Title label="Report">Quarterly review</Card.Title>
+          <Card.Title id="clickable-title-quarterly">
+            Quarterly review
+          </Card.Title>
         </Card.Header>
         <Card.Body>
-          Use <code>as="a"</code> with <code>density="expressive"</code> for
-          navigation cards in an editorial layout.
+          Use as="a" with density="expressive" for navigation cards in an
+          editorial layout.
         </Card.Body>
       </Card>
     </Column>
@@ -925,8 +929,8 @@ export const WithHorizontalMedia = () => (
           <Card.Title>Custom media width</Card.Title>
         </Card.Header>
         <Card.Body>
-          Pass <code>mediaWidth=50%</code> to control the media column width.
-          Accepts any valid CSS value.
+          Pass mediaWidth="50%" to control the media column width. Accepts any
+          valid CSS value.
         </Card.Body>
         <Card.Footer>
           <Card.Action>
@@ -977,7 +981,12 @@ export const WithHorizontalMedia = () => (
             <Time /> 12:00 PM
           </div>
           <Card.Action>
-            <IconButton renderIcon={ArrowRight} kind="ghost" size="md" />
+            <IconButton
+              label="Next"
+              renderIcon={ArrowRight}
+              kind="ghost"
+              size="md"
+            />
           </Card.Action>
         </Card.Footer>
         <Card.Media>

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -132,6 +132,7 @@ const CardComponent = forwardRef<HTMLDivElement, CardProps>(
       ...rest,
       ref,
       className: cardClasses,
+      ...(disabled && { 'aria-disabled': true }),
       ...(clickable && {
         ...(isAnchor
           ? {

--- a/packages/react/src/components/Card/CardActions.tsx
+++ b/packages/react/src/components/Card/CardActions.tsx
@@ -129,7 +129,7 @@ export const CardActions = ({
         style={{
           position: 'relative',
         }}>
-        <OverflowMenu size="sm" aria-label={overflowMenuLabel}>
+        <OverflowMenu size="sm" label={overflowMenuLabel}>
           {hiddenItems.map((item) => (
             <MenuItem
               key={item.id}

--- a/packages/react/src/components/Card/CardTitle.tsx
+++ b/packages/react/src/components/Card/CardTitle.tsx
@@ -11,7 +11,7 @@ import { usePrefix } from '../../internal/usePrefix';
 
 const componentName = 'CardTitle';
 
-export interface CardTitleProps {
+export interface CardTitleProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Provide the contents of the CardTitle.
    */

--- a/packages/react/src/components/Card/__tests__/Card-test.js
+++ b/packages/react/src/components/Card/__tests__/Card-test.js
@@ -335,6 +335,56 @@ describe('Card', () => {
     );
     consoleSpy.mockRestore();
   });
+
+  it('supports a ref placed on the root element', () => {
+    const ref = jest.fn();
+    const { container } = render(
+      <Card ref={ref}>
+        <CardBody>Content</CardBody>
+      </Card>
+    );
+    expect(ref).toHaveBeenCalledWith(container.firstChild);
+  });
+
+  it('spreads extra props onto the root element', () => {
+    const { container } = render(
+      <Card data-testid="my-card">
+        <CardBody>Content</CardBody>
+      </Card>
+    );
+    expect(container.firstChild).toHaveAttribute('data-testid', 'my-card');
+  });
+
+  it('renders decorator in CardHeader when decorator prop is provided', () => {
+    const Decorator = () => <span data-testid="decorator-node" />;
+    render(
+      <Card decorator={<Decorator />}>
+        <CardHeader>Header</CardHeader>
+        <CardBody>Content</CardBody>
+      </Card>
+    );
+    expect(screen.getByTestId('decorator-node')).toBeInTheDocument();
+  });
+
+  it('does not fire card onClick when the decorator is clicked', async () => {
+    const handleClick = jest.fn();
+    const user = userEvent.setup();
+    const Decorator = () => <span data-testid="decorator-node">AI</span>;
+
+    render(
+      <Card
+        clickable
+        onClick={handleClick}
+        aria-label="Clickable card"
+        decorator={<Decorator />}>
+        <CardHeader>Header</CardHeader>
+        <CardBody>Content</CardBody>
+      </Card>
+    );
+
+    await user.click(screen.getByTestId('decorator-node'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -351,6 +401,25 @@ describe('CardHeader', () => {
 
     expect(screen.getByText('Header Content')).toBeInTheDocument();
   });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Card>
+        <CardHeader className="custom-header">Header</CardHeader>
+      </Card>
+    );
+    expect(container.querySelector('.custom-header')).toBeInTheDocument();
+  });
+
+  it('supports a ref placed on the header element', () => {
+    const ref = jest.fn();
+    render(
+      <Card>
+        <CardHeader ref={ref}>Header</CardHeader>
+      </Card>
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -366,6 +435,34 @@ describe('CardBody', () => {
     );
 
     expect(screen.getByText('Body Content')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Card>
+        <CardBody className="custom-body">Content</CardBody>
+      </Card>
+    );
+    expect(container.querySelector('.custom-body')).toBeInTheDocument();
+  });
+
+  it('supports a ref placed on the body element', () => {
+    const ref = jest.fn();
+    render(
+      <Card>
+        <CardBody ref={ref}>Content</CardBody>
+      </Card>
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('spreads extra props onto the root element', () => {
+    render(
+      <Card>
+        <CardBody data-testid="my-body">Content</CardBody>
+      </Card>
+    );
+    expect(screen.getByTestId('my-body')).toBeInTheDocument();
   });
 
   it('applies flush modifier when isFlush is true', () => {
@@ -406,6 +503,25 @@ describe('CardFooter', () => {
     );
 
     expect(screen.getByText('Footer Content')).toBeInTheDocument();
+  });
+
+  it('applies the base footer class', () => {
+    const { container } = render(
+      <Card>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    );
+    expect(container.querySelector('.cds--card__footer')).toBeInTheDocument();
+  });
+
+  it('supports a ref placed on the footer element', () => {
+    const ref = jest.fn();
+    render(
+      <Card>
+        <CardFooter ref={ref}>Footer</CardFooter>
+      </Card>
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
   });
 
   it('applies custom className', () => {


### PR DESCRIPTION
Closes [#9789](https://github.com/carbon-design-system/ibm-products/issues/9789)

Added comprehensive test coverage for the Card component and all of its subcomponents.

### Changelog

**New**

- Added 21 unit tests to `Card-test.js` covering: `ref` forwarding on `Card`, `CardHeader`, `CardBody`, and `CardFooter`; `...rest` prop spread on `Card` and `CardBody`; `className` pass-through on `CardHeader`, `CardBody`, and `CardFooter`; the `decorator` prop rendering inside `CardHeader`; decorator click isolation (does not propagate to the card's `onClick`); and the base  footer class on `CardFooter` 
- Added `e2e/components/Card/Card-test.avt.e2e.js` with 7 Playwright tests covering AC violations for the default, clickable, disabled, AI label, horizontal, and header-actions stories, plus keyboard navigation for the clickable card activation flow, disabled card Tab exclusion, and independent focus of header action buttons

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12
- [x] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
