### PR TITLE
fix(DatePicker): move position-try rules to top level

### DIFF
--- a/docs/migration/v12.md
+++ b/docs/migration/v12.md
@@ -94,14 +94,6 @@ snapshots or application overrides that depend on the previous spacing.
 
 ## `@carbon/styles`
 
-### Sass DatePicker position fallbacks
-
-DatePicker position fallback rules are emitted as top-level `@position-try`
-rules instead of being nested under the DatePicker selector.
-
-This fixes production build failures in tooling such as Vite 8 with Lightning
-CSS when consuming `@carbon/styles`. No DatePicker API changes are required.
-
 ### Sass tile radio icons
 
 Radio-tile selection icons are always visible instead of appearing only for the

--- a/docs/migration/v12.md
+++ b/docs/migration/v12.md
@@ -94,6 +94,14 @@ snapshots or application overrides that depend on the previous spacing.
 
 ## `@carbon/styles`
 
+### Sass DatePicker position fallbacks
+
+DatePicker position fallback rules are emitted as top-level `@position-try`
+rules instead of being nested under the DatePicker selector.
+
+This fixes production build failures in tooling such as Vite 8 with Lightning
+CSS when consuming `@carbon/styles`. No DatePicker API changes are required.
+
 ### Sass tile radio icons
 
 Radio-tile selection icons are always visible instead of appearing only for the

--- a/packages/styles/__tests__/styles-test.js
+++ b/packages/styles/__tests__/styles-test.js
@@ -80,4 +80,23 @@ describe('@carbon/styles', () => {
       ).resolves.not.toThrow();
     });
   });
+
+  it('should emit DatePicker position-try rules at the top level', async () => {
+    const { result } = await render(`
+    @use '../scss/components/date-picker/date-picker-next' as date-picker;
+
+    @include date-picker.date-picker-next();
+  `);
+
+    const output = result.css.toString();
+
+    expect(output).toContain('@position-try --bottom-left {');
+    expect(output).toContain(
+      'position-try-options: --bottom-left, --top-left, --bottom-right, --top-right'
+    );
+
+    expect(output).not.toMatch(
+      /@position-try --bottom-left\s*{\s*\.cds--date-picker/
+    );
+  });
 });

--- a/packages/styles/scss/components/date-picker/_date-picker-next.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker-next.scss
@@ -27,6 +27,26 @@
 /// @access public
 /// @group date-picker
 
+@position-try --bottom-left {
+  inset-area: block-end span-inline-start;
+  margin-block-start: $spacing-02;
+}
+
+@position-try --top-left {
+  inset-area: block-start span-inline-start;
+  margin-block-end: $spacing-02;
+}
+
+@position-try --bottom-right {
+  inset-area: block-end span-inline-end;
+  margin-block-start: $spacing-02;
+}
+
+@position-try --top-right {
+  inset-area: block-start span-inline-end;
+  margin-block-end: $spacing-02;
+}
+
 @mixin date-picker-next-rules {
   // Input wrapper needs relative positioning for icon placement
   .#{$prefix}--date-picker-input__wrapper {
@@ -97,26 +117,6 @@
 
     // Handle viewport overflow
     position-try-options: --bottom-left, --top-left, --bottom-right, --top-right;
-
-    @position-try --bottom-left {
-      inset-area: block-end span-inline-start;
-      margin-block-start: $spacing-02;
-    }
-
-    @position-try --top-left {
-      inset-area: block-start span-inline-start;
-      margin-block-end: $spacing-02;
-    }
-
-    @position-try --bottom-right {
-      inset-area: block-end span-inline-end;
-      margin-block-start: $spacing-02;
-    }
-
-    @position-try --top-right {
-      inset-area: block-start span-inline-end;
-      margin-block-end: $spacing-02;
-    }
   }
 
   .#{$prefix}--date-picker__calendar.open {


### PR DESCRIPTION
Closes #23022

Fixes the Vite 8 / Lightning CSS build failure caused by nested selectors being emitted inside the DatePicker `@position-try` rules.

### Root cause

The DatePicker `@position-try` rules were nested inside `.cds--date-picker__calendar-popover`. Sass hoists these at-rules while preserving the surrounding selector, producing CSS like:

```css
@position-try --bottom-left {
  .cds--date-picker--next .cds--date-picker__calendar-popover {
    inset-area: block-end span-inline-start;
    margin-block-start: 0.25rem;
  }
}
```

Lightning CSS rejects the nested selector while parsing `@position-try`, causing Vite 8 production builds to fail.

This change moves the named `@position-try` definitions to the top level while keeping `position-try-options` on the DatePicker calendar popover.

The resulting CSS is:

```css
@position-try --bottom-left {
  inset-area: block-end span-inline-start;
  margin-block-start: 0.25rem;
}

.cds--date-picker--next .cds--date-picker__calendar-popover {
  position-try-options: --bottom-left, --top-left, --bottom-right, --top-right;
}
```

### Changelog

**New**

- None

**Changed**

- Moved DatePicker `@position-try` fallback definitions to the top level to prevent nested selectors from being emitted inside `@position-try`.
- Added regression coverage for the generated DatePicker `@position-try` output.
- Documented the DatePicker position fallback change in the v12 migration guide.

**Removed**

- None

#### Testing / Reviewing

- Built `@carbon/styles` successfully with:

  ```sh
  yarn workspace @carbon/styles build
  ```

- Verified the generated `packages/styles/css/styles.css` contains top-level `@position-try` rules without nested DatePicker selectors.

- Verified that `.cds--date-picker--next .cds--date-picker__calendar-popover` still references the named fallback rules through `position-try-options`.

- Verified the complete generated `@carbon/styles/css/styles.css` can be parsed and minified successfully by Lightning CSS 1.33.0.

- Verified a Vite 8.2.1 production build that previously reproduced the issue succeeds when using the locally fixed `@carbon/styles` package.

- Added and ran regression coverage with:

  ```sh
  yarn jest packages/styles/__tests__/styles-test.js
  ```

  All 214 tests passed.

- Ran `yarn lint:styles` successfully.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass