### PR TITLE
test(file-uploader): add delete interaction regression coverage

### DIFF
--- a/packages/react/src/components/FileUploader/__tests__/FileUploader-test.js
+++ b/packages/react/src/components/FileUploader/__tests__/FileUploader-test.js
@@ -121,6 +121,52 @@ describe('FileUploader', () => {
 
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
+
+  it('should remove an uploaded file when clicking the delete button', async () => {
+    const { container } = render(
+      <FileUploader {...requiredProps} filenameStatus="edit" />
+    );
+
+    const input = container.querySelector('input');
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+    await userEvent.upload(input, file);
+
+    expect(screen.getByText('test.png')).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'test description - test.png' })
+    );
+
+    expect(screen.queryByText('test.png')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])(
+    'should remove an uploaded file with the %s key from the delete button',
+    async (_, key) => {
+      const { container } = render(
+        <FileUploader {...requiredProps} filenameStatus="edit" />
+      );
+
+      const input = container.querySelector('input');
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+      await userEvent.upload(input, file);
+
+      const removeFileButton = screen.getByRole('button', {
+        name: 'test description - test.png',
+      });
+      removeFileButton.focus();
+
+      await userEvent.keyboard(key);
+
+      expect(screen.queryByText('test.png')).not.toBeInTheDocument();
+    }
+  );
+
   it('should trigger `onChange` when files are selected', async () => {
     const onChange = jest.fn();
     const { container } = render(


### PR DESCRIPTION
Closes #16301

I could not reproduce this issue in `@carbon/react@1.114.0`. FileUploader files can be deleted with a mouse click, Enter, and Space. So, I added a regression tests for those interactions so the behavior stays covered.

### Changelog

**New**

- Added regression tests for deleting FileUploader files with mouse and keyboard interactions.

**Changed**

- ~None~

**Removed**

- ~None~

#### Testing / Reviewing

Just run `yarn test packages/react/src/components/FileUploader/__tests__/FileUploader-test.js`

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- [X] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)