### PR TITLE
fix: close passive modals on first Escape

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -153,6 +153,23 @@ describe.each([
       expect(onClose).toHaveBeenCalled();
     });
 
+    it('should close a passive modal on a single Escape key press', async () => {
+      const onClose = jest.fn();
+
+      render(
+        <Component open onClose={onClose}>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>Modal body</ModalBody>
+        </Component>
+      );
+
+      expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('should not close when onClose returns false', async () => {
       const onClose = () => false;
       render(
@@ -1075,10 +1092,6 @@ describe('state with presence context', () => {
     expect(screen.queryByTestId('sibling-modal')).toBeInTheDocument();
     expect(screen.queryByTestId('child-modal')).toBeInTheDocument();
 
-    // First ESC closes the tooltip in the child modal
-    await userEvent.keyboard('{Escape}');
-
-    // Second ESC closes the child modal
     await userEvent.keyboard('{Escape}');
 
     // Wait for child modal to be removed

--- a/packages/react/src/components/ComposedModal/ModalHeader.tsx
+++ b/packages/react/src/components/ComposedModal/ModalHeader.tsx
@@ -16,8 +16,8 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Close } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
-import { IconButton } from '../IconButton';
 import { useId } from '../../internal/useId';
+import { ModalCloseButton } from '../Modal/ModalCloseButton';
 import { ComposedModalContext } from './ComposedModalContext';
 
 export type DivProps = Omit<HTMLAttributes<HTMLDivElement>, 'title'>;
@@ -160,19 +160,18 @@ export const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
         {children}
 
         <div className={`${prefix}--modal-close-button`}>
-          <IconButton
+          <ModalCloseButton
             className={closeClass}
             label={iconDescription}
             onClick={handleCloseButtonClick}
-            aria-label={iconDescription}
-            align="left">
+            aria-label={iconDescription}>
             <Close
               size={20}
               aria-hidden="true"
               tabIndex="-1"
               className={closeIconClass}
             />
-          </IconButton>
+          </ModalCloseButton>
         </div>
       </div>
     );

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -155,6 +155,26 @@ describe.each([
     );
   });
 
+  it('should close a passive modal on a single Escape key press', async () => {
+    const onRequestClose = jest.fn();
+
+    render(
+      <Component
+        open
+        modalHeading="A test heading"
+        onRequestClose={onRequestClose}
+        passiveModal>
+        <p>Test content</p>
+      </Component>
+    );
+
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+
   it('should set id if one is passed via props', () => {
     render(
       <Component id="custom-modal-id" data-testid="modal-4">

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -54,6 +54,7 @@ import {
   ModalPresenceContext,
   useExclusiveModalPresenceContext,
 } from './ModalPresence';
+import { ModalCloseButton } from './ModalCloseButton';
 import { isTopmostVisibleModal } from './isTopmostVisibleModal';
 
 export const ModalSizes = ['xs', 'sm', 'md', 'lg'] as const;
@@ -711,12 +712,11 @@ const ModalDialog = React.forwardRef(function ModalDialog(
 
   const modalButton = (
     <div className={`${prefix}--modal-close-button`}>
-      <IconButton
+      <ModalCloseButton
         className={modalCloseButtonClass}
         label={closeButtonLabel}
         onClick={onRequestClose}
         aria-label={closeButtonLabel}
-        align="left"
         ref={button}>
         <Close
           size={20}
@@ -724,7 +724,7 @@ const ModalDialog = React.forwardRef(function ModalDialog(
           tabIndex="-1"
           className={`${modalCloseButtonClass}__icon`}
         />
-      </IconButton>
+      </ModalCloseButton>
     </div>
   );
 

--- a/packages/react/src/components/Modal/ModalCloseButton.tsx
+++ b/packages/react/src/components/Modal/ModalCloseButton.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from 'react';
+import cx from 'classnames';
+
+import { keys, match } from '../../internal/keyboard';
+import { useDelayedState } from '../../internal/useDelayedState';
+import { useId } from '../../internal/useId';
+import { usePrefix } from '../../internal/usePrefix';
+import ButtonBase from '../Button/ButtonBase';
+import { Popover, PopoverContent } from '../Popover';
+
+interface ModalCloseButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  label: string;
+}
+
+// eslint-disable-next-line react/display-name
+export const ModalCloseButton = forwardRef<
+  HTMLButtonElement,
+  ModalCloseButtonProps
+>((props, ref) => {
+  const {
+    children,
+    className,
+    label,
+    onBlur,
+    onClick,
+    onFocus,
+    onMouseDown,
+    ...rest
+  } = props;
+  const prefix = usePrefix();
+  const id = useId('tooltip');
+  const [open, setOpen] = useDelayedState(false);
+  const [focusByMouse, setFocusByMouse] = useState(false);
+  const suppressInitialFocus = useRef(true);
+  const tooltipRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (match(event, keys.Escape)) {
+        event.stopPropagation();
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, setOpen]);
+
+  return (
+    <Popover
+      align="left"
+      className={cx(`${prefix}--tooltip`, `${prefix}--icon-tooltip`)}
+      highContrast
+      onMouseLeave={() => setOpen(false, 100)}
+      open={open}>
+      <div className={`${prefix}--tooltip-trigger__wrapper`}>
+        <ButtonBase
+          {...rest}
+          ref={ref}
+          hasIconOnly
+          className={className}
+          aria-label={rest['aria-label'] ?? label}
+          onBlur={(event) => {
+            setOpen(false);
+            setFocusByMouse(false);
+            suppressInitialFocus.current = false;
+            onBlur?.(event);
+          }}
+          onClick={onClick}
+          onFocus={(event) => {
+            if (suppressInitialFocus.current) {
+              suppressInitialFocus.current = false;
+            } else if (!focusByMouse) {
+              setOpen(true, 100);
+            }
+            onFocus?.(event);
+          }}
+          onMouseDown={(event) => {
+            setFocusByMouse(true);
+            suppressInitialFocus.current = false;
+            onMouseDown?.(event);
+          }}
+          onMouseEnter={() => setOpen(true, 100)}>
+          {children}
+        </ButtonBase>
+      </div>
+      <PopoverContent
+        aria-hidden={open ? 'false' : 'true'}
+        className={`${prefix}--tooltip-content`}
+        id={id}
+        onMouseEnter={() => setOpen(true, 100)}
+        ref={tooltipRef}
+        role="tooltip">
+        {label}
+      </PopoverContent>
+    </Popover>
+  );
+});


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/22306

Fixed passive modal `Escape` handling by preventing the close button tooltip from opening on initial autofocus. This change should preserve the behavior where nested floating UI components (e.g., `OverflowMenu` and `AILabel`) consume the first `Escape` key press before the modal closes.

### Changelog

**New**

- Added an internal `ModalCloseButton` component to prevent passive modal 'Close' button tooltips from opening on initial autofocus.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/Modal/Modal-test.js
yarn test packages/react/src/components/ComposedModal/ComposedModal-test.js
```

In a passive modal, the initial close button focus should not require two `Escape` key presses to dismiss the modal.

In a modal with an open `OverflowMenu` or `AILabel`, the first `Escape` key press should close the nested floating UI and the second should close the modal.

Relevant docs:

https://github.com/carbon-design-system/carbon-website/blob/c91c4a70b6c692f637fdd706dd12cdf59b3f226d/src/pages/components/modal/usage.mdx?plain=1#L397-L405

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
