### PR TITLE
fix(textarea): support flex grow

### DIFF
--- a/packages/web-components/src/components/textarea/__tests__/textarea-test.js
+++ b/packages/web-components/src/components/textarea/__tests__/textarea-test.js
@@ -99,6 +99,23 @@ describe('cds-textarea', () => {
     expect(textarea.getAttribute('rows')).to.equal('10');
   });
 
+  it('should stretch the inner textarea when the host grows in a flex column layout', async () => {
+    const container = await fixture(html`
+      <div style="display: flex; flex-direction: column; height: 240px;">
+        <div style="flex: 0 0 20px;"></div>
+        <cds-textarea hide-label style="flex: 1 1 auto;"></cds-textarea>
+        <div style="flex: 0 0 20px;"></div>
+      </div>
+    `);
+
+    const el = container.querySelector('cds-textarea');
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const textarea = el.shadowRoot.querySelector('textarea');
+    expect(textarea.getBoundingClientRect().height).to.be.greaterThan(150);
+  });
+
   it('should accept pattern and required attributes', async () => {
     const el = await fixture(html`
       <cds-textarea pattern="[A-Za-z]+" required></cds-textarea>

--- a/packages/web-components/src/components/textarea/textarea.scss
+++ b/packages/web-components/src/components/textarea/textarea.scss
@@ -15,6 +15,8 @@ $css--plex: true !default;
 :host(#{$prefix}-textarea) {
   @include emit-layout-tokens();
 
+  display: flex;
+  flex-direction: column;
   outline: none;
   ::slotted(#{$prefix}-ai-label),
   ::slotted(#{$prefix}-slug) {
@@ -59,6 +61,10 @@ $css--plex: true !default;
 :host(#{$prefix}-textarea[ai-label])
   .#{$prefix}--text-area__wrapper--decorator {
   @include ai-gradient;
+}
+
+.#{$prefix}--text-area__wrapper {
+  flex: 1 1 auto;
 }
 
 .#{$prefix}--text-area__wrapper--cols {

--- a/packages/web-components/src/components/textarea/textarea.stories.ts
+++ b/packages/web-components/src/components/textarea/textarea.stories.ts
@@ -301,6 +301,33 @@ export const WithLayer = {
   `,
 };
 
+// TODO: Remove this test story before merging.
+export const TestFlexGrow = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; block-size: 24rem; inline-size: 24rem;">
+      <div
+        style="flex: 0 0 auto; padding: 0.5rem 0; border-block-end: 1px solid var(--cds-border-subtle);">
+        Top
+      </div>
+      <cds-textarea
+        hide-label
+        label="Notes"
+        helper-text="The native textarea should fill the remaining vertical space."
+        style="flex: 1 1 auto;"></cds-textarea>
+      <div
+        style="flex: 0 0 auto; padding: 0.5rem 0; border-block-start: 1px solid var(--cds-border-subtle);">
+        Bottom
+      </div>
+    </div>
+  `,
+};
+
 export default {
   title: 'Components/Text Area',
 };

--- a/packages/web-components/src/components/textarea/textarea.stories.ts
+++ b/packages/web-components/src/components/textarea/textarea.stories.ts
@@ -301,33 +301,6 @@ export const WithLayer = {
   `,
 };
 
-// TODO: Remove this test story before merging.
-export const TestFlexGrow = {
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
-  render: () => html`
-    <div
-      style="display: flex; flex-direction: column; block-size: 24rem; inline-size: 24rem;">
-      <div
-        style="flex: 0 0 auto; padding: 0.5rem 0; border-block-end: 1px solid var(--cds-border-subtle);">
-        Top
-      </div>
-      <cds-textarea
-        hide-label
-        label="Notes"
-        helper-text="The native textarea should fill the remaining vertical space."
-        style="flex: 1 1 auto;"></cds-textarea>
-      <div
-        style="flex: 0 0 auto; padding: 0.5rem 0; border-block-start: 1px solid var(--cds-border-subtle);">
-        Bottom
-      </div>
-    </div>
-  `,
-};
-
 export default {
   title: 'Components/Text Area',
 };


### PR DESCRIPTION
Closes #22446

Fixes `cds-textarea` so the inner textarea grows when the component is used inside a flex column layout.

> [!WARNING]  
> I need to remove this test story before merging.

### Changelog

**New**

- ~None.~

**Changed**

- Updated `cds-textarea` styles so the inner textarea fills the available height.
- Added a test

**Removed**

- ~None.~

#### Testing / Reviewing

1. Got to WC Deploy Preview > `Text Area `> `TestFlexGrow` story in Storybook.
2. Check that the textarea fills the space between the “Top” and “Bottom” text.

Note: This fix is based on #[22469](https://github.com/carbon-design-system/carbon/pull/22469), which was closed because of DCO. The code is good, just added the storybook test.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- [X] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)