### PR TITLE
fix(search): ExpandableSearch: collapsed-state tooltip label is hardcoded "Search" with no way to override it

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3400,9 +3400,7 @@ Map {
       "className": {
         "type": "string",
       },
-      "closeButtonLabelText": {
-        "type": "string",
-      },
+      "closeButtonLabelText": [Function],
       "defaultValue": {
         "args": [
           [
@@ -3469,6 +3467,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "translateWithId": {
+        "type": "func",
       },
       "type": {
         "type": "string",
@@ -5005,9 +5006,7 @@ Map {
       "className": {
         "type": "string",
       },
-      "closeButtonLabelText": {
-        "type": "string",
-      },
+      "closeButtonLabelText": [Function],
       "defaultValue": {
         "args": [
           [
@@ -5045,6 +5044,9 @@ Map {
       },
       "role": {
         "type": "string",
+      },
+      "translateWithId": {
+        "type": "func",
       },
       "type": {
         "type": "string",
@@ -8662,9 +8664,7 @@ Map {
       "className": {
         "type": "string",
       },
-      "closeButtonLabelText": {
-        "type": "string",
-      },
+      "closeButtonLabelText": [Function],
       "defaultValue": {
         "args": [
           [
@@ -8731,6 +8731,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "translateWithId": {
+        "type": "func",
       },
       "type": {
         "type": "string",
@@ -13211,9 +13214,7 @@ Map {
       "className": {
         "type": "string",
       },
-      "closeButtonLabelText": {
-        "type": "string",
-      },
+      "closeButtonLabelText": [Function],
       "defaultValue": {
         "args": [
           [
@@ -13251,6 +13252,9 @@ Map {
       },
       "role": {
         "type": "string",
+      },
+      "translateWithId": {
+        "type": "func",
       },
       "type": {
         "type": "string",
@@ -15253,9 +15257,7 @@ Map {
       "className": {
         "type": "string",
       },
-      "closeButtonLabelText": {
-        "type": "string",
-      },
+      "closeButtonLabelText": [Function],
       "defaultValue": {
         "args": [
           [
@@ -15293,6 +15295,9 @@ Map {
       },
       "role": {
         "type": "string",
+      },
+      "translateWithId": {
+        "type": "func",
       },
       "type": {
         "type": "string",

--- a/packages/react/src/components/DataTable/TableToolbarSearch.tsx
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.tsx
@@ -47,7 +47,8 @@ type ExcludedInheritedProps =
   | 'onChange'
   | 'onExpand'
   | 'onFocus'
-  | 'tabIndex';
+  | 'tabIndex'
+  | 'translateWithId';
 
 export type TableToolbarSearchHandleExpand = (
   event: FocusEvent<HTMLInputElement>,

--- a/packages/react/src/components/ExpandableSearch/ExpandableSearch-test.js
+++ b/packages/react/src/components/ExpandableSearch/ExpandableSearch-test.js
@@ -206,4 +206,29 @@ describe('ExpandableSearch', () => {
       );
     });
   });
+
+  describe('translateWithId', () => {
+    it('should support translating the expand button tooltip', () => {
+      const translateWithId = jest.fn((id) => {
+        if (id === 'carbon.search.expand') {
+          return 'test-expand';
+        }
+        if (id === 'carbon.search.clear') {
+          return 'test-clear';
+        }
+        throw new Error(`Unsupported id: ${id}`);
+      });
+
+      const { container } = render(
+        <ExpandableSearch
+          labelText="test-search"
+          translateWithId={translateWithId}
+        />
+      );
+
+      expect(
+        container.querySelector('.cds--tooltip-content')
+      ).toHaveTextContent('test-expand');
+    });
+  });
 });

--- a/packages/react/src/components/FluidSearch/FluidSearch.stories.js
+++ b/packages/react/src/components/FluidSearch/FluidSearch.stories.js
@@ -14,7 +14,6 @@ export default {
   component: FluidSearch,
   args: {
     autoComplete: 'off',
-    closeButtonLabelText: 'Clear search input',
     defaultWidth: 400,
     disabled: false,
     labelText: 'Search',
@@ -27,7 +26,9 @@ export default {
       control: { type: 'text' },
     },
     closeButtonLabelText: {
-      control: { type: 'text' },
+      table: {
+        disable: true,
+      },
     },
     defaultValue: {
       control: { type: 'text' },

--- a/packages/react/src/components/FluidSearch/FluidSearch.tsx
+++ b/packages/react/src/components/FluidSearch/FluidSearch.tsx
@@ -11,8 +11,10 @@ import classnames from 'classnames';
 import Search from '../Search';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm/FormContext';
+import { deprecate } from '../../prop-types/deprecate';
+import type { TranslateWithId } from '../../types/common';
 
-export interface FluidSearchProps {
+export interface FluidSearchProps extends TranslateWithId {
   /**
    * Specify an optional value for the `autocomplete` property on the underlying
    * `<input>`, defaults to "off"
@@ -23,6 +25,7 @@ export interface FluidSearchProps {
    */
   className?: string;
   /**
+   * @deprecated Use `translateWithId` with the `carbon.search.clear` id instead.
    * Specify a label to be read by screen readers on the "close" button
    */
   closeButtonLabelText?: string;
@@ -100,9 +103,13 @@ FluidSearch.propTypes = {
   className: PropTypes.string,
 
   /**
+   * @deprecated Use `translateWithId` with the `carbon.search.clear` id instead.
    * Specify a label to be read by screen readers on the "close" button
    */
-  closeButtonLabelText: PropTypes.string,
+  closeButtonLabelText: deprecate(
+    PropTypes.string,
+    'The `closeButtonLabelText` prop has been deprecated. Use `translateWithId` with the `carbon.search.clear` id instead.'
+  ),
 
   /**
    * Optionally provide the default value of the `<input>`
@@ -155,6 +162,11 @@ FluidSearch.propTypes = {
    * Optional prop to specify the type of the `<input>`
    */
   type: PropTypes.string,
+
+  /**
+   * Translates component strings using your i18n tool.
+   */
+  translateWithId: PropTypes.func,
 
   /**
    * Specify the value of the `<input>`

--- a/packages/react/src/components/Search/Search-test.js
+++ b/packages/react/src/components/Search/Search-test.js
@@ -77,6 +77,49 @@ describe('Search', () => {
       expect(screen.getByLabelText('clear')).toBeInTheDocument();
     });
 
+    it('should support translating the clear button label via translateWithId', () => {
+      const translateWithId = jest.fn((id) => {
+        if (id === 'carbon.search.clear') {
+          return 'test-clear';
+        }
+        if (id === 'carbon.search.expand') {
+          return 'test-expand';
+        }
+        throw new Error(`Unsupported id: ${id}`);
+      });
+
+      render(
+        <Search labelText="test-search" translateWithId={translateWithId} />
+      );
+
+      expect(screen.getByLabelText('test-clear')).toBeInTheDocument();
+    });
+
+    it('should support translating the expand button tooltip via translateWithId', () => {
+      const translateWithId = jest.fn((id) => {
+        if (id === 'carbon.search.clear') {
+          return 'test-clear';
+        }
+        if (id === 'carbon.search.expand') {
+          return 'test-expand';
+        }
+        throw new Error(`Unsupported id: ${id}`);
+      });
+
+      const { container } = render(
+        <Search
+          labelText="test-search"
+          onExpand={() => {}}
+          isExpanded={false}
+          translateWithId={translateWithId}
+        />
+      );
+
+      expect(
+        container.querySelector('.cds--tooltip-content')
+      ).toHaveTextContent('test-expand');
+    });
+
     it('should respect defaultValue prop', () => {
       render(<Search labelText="test-search" defaultValue="test-value" />);
 

--- a/packages/react/src/components/Search/Search.stories.js
+++ b/packages/react/src/components/Search/Search.stories.js
@@ -18,7 +18,6 @@ export default {
   title: 'Components/Search',
   component: Search,
   args: {
-    closeButtonLabelText: 'Clear search input',
     disabled: false,
     defaultWidth: 800,
     labelText: 'Site search',
@@ -32,13 +31,13 @@ export default {
         disable: true,
       },
     },
+    closeButtonLabelText: {
+      table: {
+        disable: true,
+      },
+    },
     defaultWidth: {
       control: { type: 'range', min: 300, max: 800, step: 50 },
-    },
-    closeButtonLabelText: {
-      control: {
-        type: 'text',
-      },
     },
     disabled: {
       control: {
@@ -81,7 +80,7 @@ export default {
       page: mdx,
     },
     controls: {
-      exclude: ['id'],
+      exclude: ['id', 'translateWithId'],
     },
   },
 };

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -31,9 +31,28 @@ import { noopFn } from '../../internal/noopFn';
 import { Tooltip } from '../Tooltip';
 import { isSearchValuePresent } from './utils';
 import { useNoInteractiveChildren } from '../../internal/useNoInteractiveChildren';
+import type { TFunc, TranslateWithId } from '../../types/common';
+
+const translationIds = {
+  'carbon.search.clear': 'carbon.search.clear',
+  'carbon.search.expand': 'carbon.search.expand',
+} as const;
+
+type TranslationKey = keyof typeof translationIds;
+
+const defaultTranslations: Record<TranslationKey, string> = {
+  [translationIds['carbon.search.clear']]: 'Clear search input',
+  [translationIds['carbon.search.expand']]: 'Search',
+};
+
+const defaultTranslateWithId: TFunc<TranslationKey> = (messageId) => {
+  return defaultTranslations[messageId];
+};
 
 type InputPropsBase = Omit<HTMLAttributes<HTMLInputElement>, 'onChange'>;
-export interface SearchProps extends InputPropsBase {
+export interface SearchProps
+  extends InputPropsBase,
+    TranslateWithId<TranslationKey> {
   /**
    * Specify an optional value for the `autocomplete` property on the underlying
    * `<input>`, defaults to "off"
@@ -46,6 +65,7 @@ export interface SearchProps extends InputPropsBase {
   className?: string;
 
   /**
+   * @deprecated Use `translateWithId` with the `carbon.search.clear` id instead.
    * Specify a label to be read by screen readers on the "close" button
    */
   closeButtonLabelText?: string;
@@ -132,7 +152,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
     {
       autoComplete = 'off',
       className,
-      closeButtonLabelText = 'Clear search input',
+      closeButtonLabelText,
       defaultValue,
       disabled,
       isExpanded = true,
@@ -150,6 +170,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       role,
       size,
       tabIndex,
+      translateWithId,
       type = 'search',
       value,
       ...rest
@@ -278,13 +299,17 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       </div>
     );
 
+    const t = translateWithId ?? defaultTranslateWithId;
+    const clearLabel =
+      closeButtonLabelText ?? t(translationIds['carbon.search.clear']);
+
     // Wrap magnifierButton in a tooltip if it's expandable
     const magnifierWithTooltip =
       onExpand && !isExpanded && !disabled ? (
         <Tooltip
           className={`${prefix}--search-tooltip ${prefix}--search-magnifier-tooltip ${prefix}--icon-tooltip`}
           align="top"
-          label="Search">
+          label={t(translationIds['carbon.search.expand'])}>
           {magnifierButton}
         </Tooltip>
       ) : (
@@ -326,11 +351,11 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
           tabIndex={isExpandableCollapsed ? -1 : tabIndex}
         />
         <button
-          aria-label={closeButtonLabelText}
+          aria-label={clearLabel}
           className={clearClasses}
           disabled={disabled}
           onClick={clearInput}
-          title={closeButtonLabelText}
+          title={clearLabel}
           type="button">
           <Close />
         </button>
@@ -353,9 +378,18 @@ Search.propTypes = {
   className: PropTypes.string,
 
   /**
+   * @deprecated Use `translateWithId` with the `carbon.search.clear` id instead.
    * Specify a label to be read by screen readers on the "close" button
    */
-  closeButtonLabelText: PropTypes.string,
+  closeButtonLabelText: deprecate(
+    PropTypes.string,
+    'The `closeButtonLabelText` prop has been deprecated. Use `translateWithId` with the `carbon.search.clear` id instead.'
+  ),
+
+  /**
+   * Translates component strings using your i18n tool.
+   */
+  translateWithId: PropTypes.func,
 
   /**
    * Optionally provide the default value of the `<input>`


### PR DESCRIPTION

Closes https://github.com/carbon-design-system/carbon/issues/23076

`Search` / `ExpandableSearch` now supports `translateWithId` for localising internal strings. The tooltip shown over the magnifier button when collapsed was previously hardcoded to "Search" with no way to override it. `closeButtonLabelText` has been deprecated in favour of `translateWithId` for consistency with other Carbon components.


### Changelog

**New**

- `Search` / `ExpandableSearch`/ `FluidSearch`: add `translateWithId` prop to localise internal strings. Available IDs: `carbon.search.clear`, `carbon.search.expand`

**Changed**

- `Search` / `ExpandableSearch`/ `FluidSearch`: `closeButtonLabelText` is deprecated - use `translateWithId` with `carbon.search.clear `instead (existing usage continues to work)

#### Testing / Reviewing

1. Render `<ExpandableSearch
  labelText="Szukaj"
  translateWithId={(id) => {
    if (id === 'carbon.search.expand') return 'Szukaj';
    if (id === 'carbon.search.clear') return 'Wyczyść wyszukiwanie';
  }}
/>` - hover the magnifier button while collapsed and confirm the tooltip reads "Szukaj"
2. Type something and confirm the close button title reads "Wyczyść wyszukiwanie"
3. Render without the prop - confirm defaults are "Search" and "Clear search input"
4. Run `yarn test --testPathPatterns="Search-test|ExpandableSearch-test|TableToolbarSearch-test"` - all tests pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~~Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
