### PR TITLE
fix(pr-template): broken link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ As the author of this PR, before marking ready for review, confirm you:
 - [ ] Reviewed every line of the diff
 - [ ] Updated documentation and storybook examples
 - [ ] Followed the
-      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
+      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
       for any code change that affects v12, or struck through this item because
       the PR does not affect v12
 - [ ] Wrote passing tests that cover this change


### PR DESCRIPTION
No issue

Fixes a broken link in the PR template

### Changelog


**Changed**

- Changed `../docs/working-with-v12.md#required-v12-migration-documentation` to https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation

#### Testing / Reviewing

- New link should work

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~~[ ] Updated documentation and storybook examples~~
- ~~[ ] Followed the
      [required v12 migration documentation](../docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~~
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- ~~[ ] Tested for cross-browser consistency~~
- ~~[ ] Validated that this code is ready for review and status checks should pass~~

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
