### PR TITLE
chore: update cname files for v12 storybooks

### DIFF
--- a/.github/workflows/deploy-v12-storybooks.yml
+++ b/.github/workflows/deploy-v12-storybooks.yml
@@ -20,11 +20,11 @@ jobs:
           - package: react
             name: React
             destination: v12-react-storybook
-            cname: v2-react.carbondesignsystem.com
+            cname: v12-react.carbondesignsystem.com
           - package: web-components
             name: Web Components
             destination: v12-web-components-storybook
-            cname: v3-web-components.carbondesignsystem.com
+            cname: v12-web-components.carbondesignsystem.com
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
  We are updating our v12 storybook paths to use `https://v12-react.carbondesignsystem.com` and `v12-web-components.carbondesignsystem.com`. The CNAME file gets set in the v12 storybook deploy workflow, so this PR modifies the file.

### Changelog

**Changed**

- updated path

#### Testing / Reviewing

will have to test after we merge this PR in. I did manually change the cname file in each repo yesterday and it worked.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
