### PR TITLE
chore(renovate): add `yarnDedupeHighest` option to Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,7 @@
     enabled: true,
   },
   rebaseWhen: 'never',
+  postUpdateOptions: ['yarnDedupeHighest'],
   lockFileMaintenance: {
     enabled: false,
   },


### PR DESCRIPTION
The `ci/dedupe` CI check frequently fails, with Renovate PRs accounting for the bulk of them. The current fix is manual - dedupe, commit, push. Turns out Renovate has a [post-update](https://docs.renovatebot.com/configuration-options/#yarndedupehighest) option that can do this. Hopefully this will automatically resolve any lockfile discrepancies introduced by Renovate PRs.

### Changelog

**Changed**

- add `yarnDedupeHighest` option to Renovate config

#### Testing / Reviewing

Future PRs opened by Renovate should no longer require a manual `dedupe` to resolve lockfile discrepancies. This config change doesn't apply retroactively to current Renovate PRs.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
