### PR TITLE
fix(OverflowMenu): export v12 prop types and extend div props

### DIFF
--- a/packages/react/src/components/OverflowMenu/index.tsx
+++ b/packages/react/src/components/OverflowMenu/index.tsx
@@ -7,7 +7,10 @@
 
 import React, { forwardRef, type Ref } from 'react';
 import { useFeatureFlag } from '../FeatureFlags';
-import { OverflowMenu as OverflowMenuV12 } from './next';
+import {
+  OverflowMenu as OverflowMenuV12,
+  type OverflowMenuProps as OverflowMenuV12Props,
+} from './next';
 import {
   OverflowMenu as OverflowMenuV11,
   type OverflowMenuProps,
@@ -18,7 +21,14 @@ const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
     const enableV12OverflowMenu = useFeatureFlag('enable-v12-overflowmenu');
 
     return enableV12OverflowMenu ? (
-      <OverflowMenuV12 {...props} ref={ref} />
+      // The two implementations have different prop shapes and different host
+      // elements (v12 renders a div, v11 a button), so neither branch is
+      // assignable from the shared v11-typed props. The v11 branch already
+      // casts its ref for the same reason.
+      <OverflowMenuV12
+        {...(props as unknown as OverflowMenuV12Props)}
+        ref={ref}
+      />
     ) : (
       <OverflowMenuV11 {...props} ref={ref as Ref<HTMLButtonElement>} />
     );

--- a/packages/react/src/components/OverflowMenu/next/index.tsx
+++ b/packages/react/src/components/OverflowMenu/next/index.tsx
@@ -329,4 +329,4 @@ OverflowMenu.propTypes = {
   ) as PropTypes.Validator<Element | null | undefined>,
 };
 
-export { OverflowMenu, type OverflowMenuProps };
+export { OverflowMenu };

--- a/packages/react/src/components/OverflowMenu/next/index.tsx
+++ b/packages/react/src/components/OverflowMenu/next/index.tsx
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useRef, type ElementType } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  type ComponentProps,
+  type ElementType,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { OverflowMenuVertical } from '@carbon/icons-react';
@@ -25,7 +30,7 @@ import { mapPopoverAlign } from '../../../tools/mapPopoverAlign';
 
 const defaultSize = 'md';
 
-interface OverflowMenuProps {
+export interface OverflowMenuProps extends ComponentProps<'div'> {
   /**
    * **Experimental**: Will attempt to automatically align the floating element
    * to avoid collisions with the viewport and being clipped by ancestor
@@ -324,4 +329,4 @@ OverflowMenu.propTypes = {
   ) as PropTypes.Validator<Element | null | undefined>,
 };
 
-export { OverflowMenu };
+export { OverflowMenu, type OverflowMenuProps };


### PR DESCRIPTION
Closes #16493

Two TypeScript gaps in the v12 `OverflowMenu` (`OverflowMenu/next`), found while adopting `enable-v12-overflowmenu` in a design system that wraps it.

**1. `OverflowMenuProps` was not exported.** Only the component was:

```ts
export { OverflowMenu };
```

Consumers wrapping the v12 component have no way to reference its props. The public `OverflowMenu` barrel is typed against the *v11* prop set (it re-exports `OverflowMenuProps` from `./OverflowMenu`), so anyone using the flag has to either restate the v12 props by hand or reach into the compiled output. Restating them means silent drift as the component evolves.

**2. `OverflowMenuProps` did not extend the container's attributes.** The implementation spreads rest props onto the container `div`:

```tsx
const OverflowMenu = React.forwardRef(
  ({ autoAlign, children, className, label, /* … */, ...rest }, forwardRef) => {
    // …
    return (
      <div
        {...rest}          // ← container div
        className={containerClasses}
```

…but the interface did not extend `HTMLAttributes` / `ComponentProps<'div'>`, so DOM props were rejected by TypeScript even though they work at runtime:

```
error TS2322: Property 'onClick' does not exist on type
  'IntrinsicAttributes & OverflowMenuProps & RefAttributes<HTMLDivElement>'.
```

`onClick` on the container is a real use case — a menu inside a clickable row needs it to `stopPropagation` so opening the menu doesn't activate the row.

Both changes follow `MenuButton`, the closest sibling (same trigger + `__container` div shape), which already does exactly this:

```ts
// packages/react/src/components/MenuButton/index.tsx
export interface MenuButtonProps extends ComponentProps<'div'> { … }
```

Export style matches `ComboButton`: `export { ComboButton, type ComboButtonProps };`

### Changelog

**New**

- `OverflowMenuProps` (v12, `OverflowMenu/next`) is now exported alongside the component

**Changed**

- `OverflowMenuProps` (v12) now extends `ComponentProps<'div'>`, matching the component's rest-prop spread onto the container element

**Removed**

- n/a

#### Testing / Reviewing

Types only — no runtime change. To verify:

1. With `enable-v12-overflowmenu` enabled, pass `onClick` to `OverflowMenu`. It should now typecheck, and the handler fires on the container div.
2. `import type { OverflowMenuProps } from '@carbon/react/lib/components/OverflowMenu/next'` should resolve.
3. Declared prop types are not widened by the `extends`: `menuAlignment` still rejects anything outside `'top-start' | 'top-end' | 'bottom-start' | 'bottom-end'`.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~ — types-only change, no behavior or API surface to document beyond the exported type
- [x] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12
- [ ] ~Wrote passing tests that cover this change~ — no runtime behavior changes; the guarantee is compile-time, covered by the repo's existing typecheck
- [ ] ~Addressed any impact on accessibility (a11y)~ — no rendered output changes
- [ ] ~Tested for cross-browser consistency~ — no rendered output changes
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)