### PR TITLE
fix: prevent loading overlay from stealing focus

### DIFF
--- a/packages/react/src/components/Loading/Loading-test.js
+++ b/packages/react/src/components/Loading/Loading-test.js
@@ -65,7 +65,7 @@ describe('Loading', () => {
       render(<Loading withOverlay />);
 
       const dialog = screen.getByRole('dialog');
-      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).not.toHaveAttribute('aria-modal');
       expect(screen.getByRole('presentation')).toContainElement(dialog);
     });
 
@@ -223,6 +223,7 @@ describe('Loading', () => {
       );
 
       const overlayDialog = screen.getByRole('dialog', { name: 'loading' });
+      expect(overlayDialog).not.toHaveAttribute('aria-modal');
 
       await waitFor(() => {
         expect(document.activeElement).toBe(overlayDialog);

--- a/packages/react/src/components/Loading/Loading-test.js
+++ b/packages/react/src/components/Loading/Loading-test.js
@@ -114,6 +114,27 @@ describe('Loading', () => {
   });
 
   describe('focus trap', () => {
+    it('should not steal focus when the overlay becomes active', () => {
+      const { rerender } = render(
+        <div>
+          <button data-testid="page-control">Page control</button>
+          <Loading withOverlay active={false} />
+        </div>
+      );
+
+      const pageControl = screen.getByTestId('page-control');
+      pageControl.focus();
+
+      rerender(
+        <div>
+          <button data-testid="page-control">Page control</button>
+          <Loading withOverlay active />
+        </div>
+      );
+
+      expect(document.activeElement).toBe(pageControl);
+    });
+
     it('should prevent Tab from moving focus outside overlay', async () => {
       const user = userEvent.setup();
 
@@ -403,7 +424,7 @@ describe('Loading', () => {
         </div>
       );
 
-      expect(document.activeElement).toBe(screen.getByRole('dialog'));
+      screen.getByRole('dialog').focus();
 
       rerender(
         <div>
@@ -429,13 +450,11 @@ describe('Loading', () => {
       expect(document.activeElement).toBe(glyph);
 
       rerender(withGlyph(<Loading withOverlay active />));
-      expect(document.activeElement).toBe(
-        screen.getByRole('dialog', { name: 'loading' })
-      );
+      expect(document.activeElement).toBe(glyph);
 
       rerender(withGlyph(null));
 
-      expect(document.activeElement).toBe(document.body);
+      expect(document.activeElement).toBe(glyph);
     });
 
     it('should restore focus next to the trigger when the trigger is disabled', () => {
@@ -453,9 +472,7 @@ describe('Loading', () => {
       screen.getByTestId('trigger').focus();
 
       rerender(withForm(<Loading withOverlay active />, false));
-      expect(document.activeElement).toBe(
-        screen.getByRole('dialog', { name: 'loading' })
-      );
+      screen.getByRole('dialog', { name: 'loading' }).focus();
 
       rerender(withForm(null, true));
 
@@ -483,6 +500,7 @@ describe('Loading', () => {
       screen.getByTestId('trigger').focus();
 
       rerender(withForm(<Loading withOverlay active />, false));
+      screen.getByRole('dialog', { name: 'loading' }).focus();
       rerender(withForm(null, true));
 
       const formElement = screen.getByTestId('form');
@@ -512,6 +530,7 @@ describe('Loading', () => {
       screen.getByTestId('trigger').focus();
 
       rerender(withForm(<Loading withOverlay active />, false));
+      screen.getByRole('dialog', { name: 'loading' }).focus();
 
       const rival = screen.getByTestId('rival');
       const steal = (event) => {

--- a/packages/react/src/components/Loading/Loading.tsx
+++ b/packages/react/src/components/Loading/Loading.tsx
@@ -104,7 +104,10 @@ const useFocusTrap = (
         ? document.activeElement
         : null;
 
-    if (!isLayeredOnTop(previouslyFocused, overlay)) {
+    if (
+      document.activeElement === document.body &&
+      !isLayeredOnTop(previouslyFocused, overlay)
+    ) {
       overlay.focus();
     }
 

--- a/packages/react/src/components/Loading/Loading.tsx
+++ b/packages/react/src/components/Loading/Loading.tsx
@@ -242,7 +242,6 @@ function Loading({
       <div
         ref={overlayRef}
         role={active ? 'dialog' : undefined}
-        aria-modal={active ? 'true' : undefined}
         aria-label={active ? description : undefined}
         tabIndex={active ? -1 : undefined}>
         {loading}


### PR DESCRIPTION
No issue. Related to https://github.com/carbon-design-system/carbon/pull/22196

Prevented active loading overlays from stealing focus from already focused page controls during navigation. Also prevented loading overlays behind modals from exposing a second modal dialog to assistive tech.

### Changelog

**Changed**

- Prevented active loading overlays from stealing focus from an already focused page control during navigation.
- Removed `aria-modal="true"` from loading dialogs to avoid conflicting modal semantics when a loading overlay appears behind a modal.

#### Testing / Reviewing

These changes fix the unexpected focus behavior introduced by https://github.com/carbon-design-system/carbon/commit/5d916f1652b293d026fd1bbf20da8c7f4f8efda5, which may be considered a regression. I noticed issues after updating Carbon in one of the products I work on and seeing unexpected behavior related to `Loading` components.

Loading overlays should only claim focus when the document is focused on `body`.

Focus a page control, activate a `Loading` component with `withOverlay`, and verify that focus remains on the page control. Verify that focus trapping still works when focus moves outside the active overlay.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
