### PR TITLE
fix: compare normalized DataTable rows

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -386,14 +386,26 @@ export const DataTable = <RowType, ColTypes extends any[]>(
     const hasHeadersChanged = !isEqual(nextHeaders, currentHeaders);
     const currentRows = state.rowIds.map((id) => {
       const row = state.rowsById[id];
-      return {
-        id: row.id,
-        disabled: row.disabled,
-        isExpanded: row.isExpanded,
-        isSelected: row.isSelected,
-      };
+      return headers.reduce(
+        (acc, { key }) => ({
+          ...acc,
+          [key]: state.cellsById[getCellId(row.id, key)]?.value,
+        }),
+        {
+          id: row.id,
+          disabled: row.disabled,
+          isExpanded: row.isExpanded,
+          isSelected: row.isSelected,
+        }
+      );
     });
-    const hasRowsChanged = !isEqual(rows, currentRows);
+    const nextRows = rows.map((row) => ({
+      ...row,
+      disabled: row.disabled ?? false,
+      isExpanded: row.isExpanded ?? false,
+      isSelected: row.isSelected ?? false,
+    }));
+    const hasRowsChanged = !isEqual(nextRows, currentRows);
 
     if (hasRowIdsChanged || hasHeadersChanged || hasRowsChanged) {
       setState((prev) => getDerivedStateFromProps(props, prev));

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -1104,6 +1104,20 @@ describe('DataTable', () => {
         expect(nextArgs.rows.map((row) => row.id)).toEqual(['c', 'a', 'b']);
       });
 
+      it('should not update rows when receiving equivalent props', () => {
+        const { rerender } = render(<DataTable {...mockProps} />);
+        mockProps.render.mockClear();
+
+        rerender(
+          <DataTable
+            {...mockProps}
+            rows={mockProps.rows.map((row) => ({ ...row }))}
+          />
+        );
+
+        expect(mockProps.render).toHaveBeenCalledTimes(1);
+      });
+
       it('should update cells when receiving new props', () => {
         const { rerender } = render(<DataTable {...mockProps} />);
         const args = mockProps.render.mock.calls[0][0];


### PR DESCRIPTION
No issue. https://github.com/carbon-design-system/carbon/pull/23114#discussion_r3874581516

Compared normalized `DataTable` row values before rebuilding state.

### Changelog

**Changed**

- Compared normalized `DataTable` row values before rebuilding state.

#### Testing / Reviewing

```sh
yarn test packages/react/src/components/DataTable
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~~
- [x] Wrote passing tests that cover this change
- [ ] ~~Addressed any impact on accessibility (a11y)~~
- [ ] ~~Tested for cross-browser consistency~~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
