### PR TITLE
chore: add pagination codemod to upgrade list and docs

### DIFF
--- a/packages/upgrade/README.md
+++ b/packages/upgrade/README.md
@@ -342,6 +342,47 @@ npx @carbon/upgrade migrate slug-prop-to-decorator-prop --write
 <Component decorator="my-identifier">Content</Component>
 ```
 
+### Unstable / preview Pagination to Pagination
+
+Migrates `unstable_Pagination` / `preview_Pagination` to the stable
+`Pagination` component. Drops `PageSelector` imports and children render-props,
+since the stable component renders an equivalent page-select control by default.
+
+**Usage:**
+
+```bash
+npx @carbon/upgrade migrate unstable-pagination-to-pagination --write
+```
+
+**Example:**
+
+```jsx
+// Before
+import {
+  unstable_Pagination as Pagination,
+  unstable_PageSelector as PageSelector,
+} from '@carbon/react';
+
+<Pagination pageSizes={[10, 20, 30]} totalItems={100}>
+  {({ currentPage, onSetPage, totalPages }) => (
+    <PageSelector
+      currentPage={currentPage}
+      onChange={(event) => onSetPage(event.target.value)}
+      totalPages={totalPages}
+    />
+  )}
+</Pagination>;
+
+// After
+import { Pagination } from '@carbon/react';
+
+<Pagination pageSizes={[10, 20, 30]} totalItems={100} />;
+```
+
+Custom page-select children are removed and a `TODO` comment is left to migrate
+them with `renderPageSelect` if needed. Omit `pageSizes` to hide the items per
+page selector.
+
 ### FeatureFlag deprecate flags prop
 
 Updates FeatureFlags component to use individual boolean props instead of the

--- a/packages/upgrade/README.md
+++ b/packages/upgrade/README.md
@@ -344,9 +344,9 @@ npx @carbon/upgrade migrate slug-prop-to-decorator-prop --write
 
 ### Unstable / preview Pagination to Pagination
 
-Migrates `unstable_Pagination` / `preview_Pagination` to the stable
-`Pagination` component. Drops `PageSelector` imports and children render-props,
-since the stable component renders an equivalent page-select control by default.
+Migrates `unstable_Pagination` / `preview_Pagination` to the stable `Pagination`
+component. Drops `PageSelector` imports and children render-props, since the
+stable component renders an equivalent page-select control by default.
 
 **Usage:**
 

--- a/packages/upgrade/src/upgrades.js
+++ b/packages/upgrade/src/upgrades.js
@@ -1003,6 +1003,42 @@ export const upgrades = [
           });
         },
       },
+      {
+        name: 'unstable-pagination-to-pagination',
+        description:
+          'Replace unstable_Pagination / preview_Pagination with Pagination and remove unstable_PageSelector / preview_PageSelector. Custom page-select children must use renderPageSelect and may need a manual update.',
+        migrate: async (options) => {
+          const transform = path.join(
+            TRANSFORM_DIR,
+            'unstable-pagination-to-pagination.js'
+          );
+          const paths =
+            Array.isArray(options.paths) && options.paths.length > 0
+              ? options.paths
+              : await glob(['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'], {
+                  cwd: options.workspaceDir,
+                  ignore: [
+                    '**/es/**',
+                    '**/lib/**',
+                    '**/umd/**',
+                    '**/node_modules/**',
+                    '**/storybook-static/**',
+                    '**/dist/**',
+                    '**/build/**',
+                    '**/*.d.ts',
+                    '**/coverage/**',
+                  ],
+                });
+
+          await runCodemod(options, {
+            dry: !options.write,
+            transform,
+            paths,
+            verbose: options.verbose,
+            parser: 'tsx',
+          });
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
follow up on https://github.com/carbon-design-system/carbon/pull/22626#discussion_r3866483671

adds the codemod to upgrade list and updates the readme doc

### Changelog

**New**

- adds the codemod entry in the upgrade list. and update readme

#### Testing / Reviewing
run
```
yarn workspace @carbon/upgrade build 
node packages/upgrade/bin/carbon-upgrade.js migrate list
```
find the codemod in the bottom of the list

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
