### PR TITLE
chore: update feature flag sass docs

### DIFF
--- a/packages/react/src/components/FeatureFlags/overview.mdx
+++ b/packages/react/src/components/FeatureFlags/overview.mdx
@@ -32,7 +32,7 @@ time.
 ```jsx
 import { FeatureFlags } from '@carbon/react';
 
-<FeatureFlags enableV12TileDefaultIcons="true" enableASecondFeatureFlag="true">
+<FeatureFlags enableV12TileDefaultIcons enableASecondFeatureFlag>
   <Tile />
 </FeatureFlags>;
 ```
@@ -50,7 +50,7 @@ import App from './App';
 const root = createRoot(document.getElementById('root'));
 root.render(
   <StrictMode>
-    <FeatureFlags enableV12TileDefaultIcons="true">
+    <FeatureFlags enableV12TileDefaultIcons>
       <App />
     </FeatureFlags>
   </StrictMode>
@@ -68,6 +68,7 @@ this is done at the root/entrypoint stylesheet.
     'enable-tile-contrast': true,
   )
 );
+@use '@carbon/react';
 ```
 
 Feature flags can also be enabled via the provided `enable()` mixin

--- a/packages/react/src/components/FeatureFlags/overview.mdx
+++ b/packages/react/src/components/FeatureFlags/overview.mdx
@@ -63,7 +63,7 @@ In Sass, you can enable feature flags in any of your stylesheets. Most often
 this is done at the root/entrypoint stylesheet.
 
 ```sass
-@use '@carbon/react' with (
+@use '@carbon/react/scss/feature-flags' with (
   $feature-flags: (
     'enable-tile-contrast': true,
   )

--- a/packages/react/src/components/Tile/Tile.mdx
+++ b/packages/react/src/components/Tile/Tile.mdx
@@ -140,7 +140,7 @@ In Sass, you can enable the improved contrast tiles via a feature flag.
 or if you have multiple feature flags you can enable them this way.
 
 ```scss
-@use '@carbon/react' with (
+@use '@carbon/react/scss/feature-flags' with (
   $feature-flags: (
     'enable-tile-contrast': true,
   )

--- a/packages/react/src/components/Toggle/Toggle.featureflag.mdx
+++ b/packages/react/src/components/Toggle/Toggle.featureflag.mdx
@@ -8,7 +8,7 @@ Reduced spacing between the toggle control and its label to improve visual
 consistency with other form inputs.
 
 ```scss
-@use '@carbon/react' with (
+@use '@carbon/react/scss/feature-flags' with (
   $feature-flags: (
     'enable-v12-toggle-reduced-label-spacing': true,
   )


### PR DESCRIPTION
Closes #

The current documentation for enabling the sass feature-flags throws an error as `@carbon/styles` doesn't forward `scss/feature-flags`. See this [stackblitz](https://stackblitz.com/edit/github-47ycacyk?file=src%2Fmain.jsx,src%2Findex.scss,src%2FApp.jsx&preset=node=)

There's documentation in other places stating to use the `@carbon/react/scss/feature-flags` directly which works, so this PR updates the documentation to use the specific path.

### Changelog

**Changed**

- tweak feature flag documentation for enabling feature flags in sass

#### Testing / Reviewing

ci-checks should pass, you can use the linked stackblitz to test with the specific path to see that it works.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
~- [ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
