### PR TITLE
fix(search): prevent disabled expandable search from expanding

### DIFF
--- a/packages/react/src/components/Search/Search-test.js
+++ b/packages/react/src/components/Search/Search-test.js
@@ -165,6 +165,33 @@ describe('Search', () => {
       expect(onExpand).toHaveBeenCalledTimes(3);
     });
 
+    it('should not call onExpand if disabled', async () => {
+      const onExpand = jest.fn();
+      const { container } = render(
+        <Search
+          disabled
+          isExpanded={false}
+          labelText="test-search"
+          onExpand={onExpand}
+        />
+      );
+
+      const expandControl = screen.getAllByRole('button')[0];
+
+      expect(expandControl).toHaveAttribute('aria-disabled', 'true');
+      expect(expandControl).not.toHaveAttribute('tabIndex');
+      expect(
+        container.querySelector(`.${prefix}--search-magnifier-tooltip`)
+      ).toBeNull();
+
+      await userEvent.click(expandControl);
+      expandControl.focus();
+      await userEvent.keyboard('[Space]');
+      await userEvent.keyboard('[Enter]');
+
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+
     it('should call onKeyDown when expected', async () => {
       const onKeyDown = jest.fn();
       render(<Search labelText="test-search" onKeyDown={onKeyDown} />);

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -242,6 +242,10 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
     }
 
     function handleExpandButtonKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+      if (disabled) {
+        return;
+      }
+
       if (match(event, keys.Enter) || match(event, keys.Space)) {
         event.stopPropagation();
         if (onExpand) {
@@ -255,10 +259,11 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
         aria-labelledby={onExpand ? searchId : undefined}
         role={onExpand ? 'button' : undefined}
         className={`${prefix}--search-magnifier`}
-        onClick={onExpand}
+        onClick={disabled ? undefined : onExpand}
         onKeyDown={handleExpandButtonKeyDown}
-        tabIndex={isExpandableCollapsed ? 0 : -1}
+        tabIndex={isExpandableCollapsed ? (disabled ? undefined : 0) : -1}
         ref={expandButtonRef}
+        aria-disabled={onExpand && disabled ? true : undefined}
         aria-expanded={
           onExpand && isExpanded
             ? true
@@ -273,7 +278,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
 
     // Wrap magnifierButton in a tooltip if it's expandable
     const magnifierWithTooltip =
-      onExpand && !isExpanded ? (
+      onExpand && !isExpanded && !disabled ? (
         <Tooltip
           className={`${prefix}--search-tooltip ${prefix}--search-magnifier-tooltip ${prefix}--icon-tooltip`}
           align="top"

--- a/packages/web-components/src/components/search/__tests__/search-test.js
+++ b/packages/web-components/src/components/search/__tests__/search-test.js
@@ -289,6 +289,42 @@ describe('cds-search', () => {
       expect(el.shadowRoot?.activeElement).to.equal(input);
     });
 
+    it('should not expand when disabled', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" disabled expandable></cds-search>
+      `);
+
+      await el.updateComplete;
+
+      const magnifier = el.shadowRoot?.querySelector('.cds--search-magnifier');
+      expect(magnifier).to.exist;
+
+      magnifier?.click();
+      await el.updateComplete;
+
+      expect(el.expanded).to.be.false;
+
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+        })
+      );
+      await el.updateComplete;
+
+      expect(el.expanded).to.be.false;
+
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: ' ',
+          bubbles: true,
+        })
+      );
+      await el.updateComplete;
+
+      expect(el.expanded).to.be.false;
+    });
+
     it('should handle multiple clear operations correctly', async () => {
       const el = await fixture(html`
         <cds-search label-text="test-search" value="test1"></cds-search>

--- a/packages/web-components/src/components/search/search.ts
+++ b/packages/web-components/src/components/search/search.ts
@@ -97,6 +97,10 @@ class CDSSearch extends HostListenerMixin(FocusMixin(FormMixin(LitElement))) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleExpand(e: Event) {
+    if (this.disabled) {
+      return;
+    }
+
     // Check if the click came from the magnifier area
     const path = (e.composedPath && (e.composedPath() as unknown[])) || [];
     const isMagnifierClick = path.some((n: unknown) =>
@@ -123,6 +127,10 @@ class CDSSearch extends HostListenerMixin(FocusMixin(FormMixin(LitElement))) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore
   private _handleKeys(event: KeyboardEvent) {
+    if (this.disabled) {
+      return;
+    }
+
     const key = event.key;
 
     // Esc only works when the input is the active element


### PR DESCRIPTION
Closes N/A

While reviewing a PR, I noticed that disabled expandable Search could still expand. This PR blocks the expand action when Search is disabled and keeps the React and Web Components behavior aligned.

### Changelog

**New**

- ~None.~

**Changed**

- Prevent disabled expandable Search from expanding on click or keyboard interaction.
- Do not show the React expandable Search tooltip when Search is disabled.

**Removed**

- ~None.~

#### Testing / Reviewing

1. Go to `React` or` WC` `Deploy Preview` > Search > Expandable story.
2. Set `disabled` to `true`.
3. Confirm the search does not expand on click, Enter, or Space.
4. Confirm the tooltip does not show when disabled.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~[ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)