### PR TITLE
chore: add 'upcoming in v12' section to changelogs

### DIFF
--- a/packages/cli/src/changelog.js
+++ b/packages/cli/src/changelog.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/cli/src/changelog.js
+++ b/packages/cli/src/changelog.js
@@ -50,7 +50,24 @@ export async function generate(packages, lastTag, latestTag) {
   ].join('\n');
 }
 
+/**
+ * Returns true when the conventional commit scope (the text in parentheses)
+ * mentions v12, for example `chore(v12): update card`. These commits are
+ * listed under "Upcoming in v12" instead of their conventional type section.
+ *
+ * @param {{ info: { scope?: string | null } }} commit
+ * @returns {boolean}
+ */
+function isUpcomingV12Commit(commit) {
+  const { scope } = commit.info;
+  return typeof scope === 'string' && /\bv12\b/i.test(scope);
+}
+
 const sectionTypes = [
+  {
+    title: 'Upcoming in v12 :next:',
+    match: isUpcomingV12Commit,
+  },
   {
     title: 'New features :rocket:',
     types: ['feat'],
@@ -82,14 +99,27 @@ const commitUrl = 'https://github.com/carbon-design-system/carbon/commit';
 function getMarkdownSections(packages) {
   return packages.map(({ name, version, commits }) => {
     let section = `## \`${name}@${version}\`\n`;
+    const claimed = new Set();
 
-    for (const { title, types } of sectionTypes) {
+    for (const { title, types, match } of sectionTypes) {
       const commitsForSection = commits.filter((commit) => {
+        if (claimed.has(commit)) {
+          return false;
+        }
+
+        if (match) {
+          return match(commit);
+        }
+
         return types.includes(commit.info.type);
       });
 
       if (commitsForSection.length === 0) {
         continue;
+      }
+
+      for (const commit of commitsForSection) {
+        claimed.add(commit);
       }
 
       let subsection = `### ${title}\n`;

--- a/packages/cli/src/changelog.js
+++ b/packages/cli/src/changelog.js
@@ -51,16 +51,16 @@ export async function generate(packages, lastTag, latestTag) {
 }
 
 /**
- * Returns true when the conventional commit scope (the text in parentheses)
- * mentions v12, for example `chore(v12): update card`. These commits are
- * listed under "Upcoming in v12" instead of their conventional type section.
+ * Returns true when the commit header contains "v12" anywhere, for example
+ * `chore(v12): update card` or `chore(table): v12 switching`. These commits
+ * are listed under "Upcoming in v12" instead of their conventional type
+ * section.
  *
- * @param {{ info: { scope?: string | null } }} commit
+ * @param {{ info: { header?: string } }} commit
  * @returns {boolean}
  */
 function isUpcomingV12Commit(commit) {
-  const { scope } = commit.info;
-  return typeof scope === 'string' && /\bv12\b/i.test(scope);
+  return /v12/i.test(commit.info.header);
 }
 
 const sectionTypes = [


### PR DESCRIPTION
We currently have work going in that is behind the `enable-v12-release` feature flag. These features aren't visible in the v11 storybooks but the commits are outputted in our changelogs. This can cause confusion for folks looking through our changelog and not finding those changes in the v11 storybook. In order to differentiate between the v11 and v12 work behind the feature flag, we can add an "Upcoming in v12" section under each package within our changelogs.

Any commits that have "v12" in the commit message (ex: feat(v12): add updates to card) will be placed under the "Upcoming in v12" section.

The proposed section will look like so:

----------------------------------------------------------------------------------------
## `@carbon/react@1.116.0-rc.0`
### Upcoming in v12 ⏭️ 
- chore(v12): update card 
- feat(v12): add preview tile 
- chore(table): v12 switching 
- fix(datepicker): v12 temporal polyfill follow-up 
### New features :rocket:
- feat(Card): implement clickable card 
### Bug fixes :bug:
- fix(react): correct focus order 
### Housekeeping :house:
- chore(release): v11.115.0 

----------------------------------------------------------------------------------------

### Changelog

**New**

- in our changelog file, look for commits that have `v12` in the subject and organize them to the "Upcoming in v12" section for each package.

#### Testing / Reviewing

We can test locally once we have some commits with v12 in the subject merged in

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
