### PR TITLE
fix(react): resolve display-name eslint suppressions

### DIFF
--- a/packages/react/src/components/FluidNumberInput/FluidNumberInput.tsx
+++ b/packages/react/src/components/FluidNumberInput/FluidNumberInput.tsx
@@ -168,7 +168,6 @@ export interface FluidNumberInputProps
   readOnly?: boolean;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const FluidNumberInput = React.forwardRef<
   HTMLInputElement,
   FluidNumberInputProps
@@ -183,6 +182,7 @@ const FluidNumberInput = React.forwardRef<
   );
 });
 
+FluidNumberInput.displayName = 'FluidNumberInput';
 FluidNumberInput.propTypes = {
   /**
    * `true` to allow empty string.

--- a/packages/react/src/components/FluidSelect/FluidSelect.tsx
+++ b/packages/react/src/components/FluidSelect/FluidSelect.tsx
@@ -76,7 +76,6 @@ export interface FluidSelectProps {
   readOnly?: boolean;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const FluidSelect = React.forwardRef<HTMLSelectElement, FluidSelectProps>(
   ({ className, children, ...other }, ref) => {
     const prefix = usePrefix();
@@ -92,6 +91,7 @@ const FluidSelect = React.forwardRef<HTMLSelectElement, FluidSelectProps>(
   }
 );
 
+FluidSelect.displayName = 'FluidSelect';
 FluidSelect.propTypes = {
   /**
    * Provide the contents of your Select

--- a/packages/react/src/components/FluidTextInput/FluidTextInput.tsx
+++ b/packages/react/src/components/FluidTextInput/FluidTextInput.tsx
@@ -102,7 +102,6 @@ export interface FluidTextInputProps {
   readOnly?: boolean;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const FluidTextInput = React.forwardRef<HTMLInputElement, FluidTextInputProps>(
   ({ className, isPassword, ...other }, ref) => {
     const prefix = usePrefix();
@@ -122,6 +121,7 @@ const FluidTextInput = React.forwardRef<HTMLInputElement, FluidTextInputProps>(
   }
 );
 
+FluidTextInput.displayName = 'FluidTextInput';
 FluidTextInput.propTypes = {
   /**
    * Specify an optional className to be applied to the outer FluidForm wrapper

--- a/packages/react/src/components/FluidTimePicker/FluidTimePicker.tsx
+++ b/packages/react/src/components/FluidTimePicker/FluidTimePicker.tsx
@@ -61,7 +61,6 @@ export interface FluidTimePickerProps extends FluidTextInputProps {
   readOnly?: boolean;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const FluidTimePicker = React.forwardRef<
   HTMLInputElement,
   FluidTimePickerProps
@@ -154,6 +153,7 @@ const FluidTimePicker = React.forwardRef<
   }
 );
 
+FluidTimePicker.displayName = 'FluidTimePicker';
 FluidTimePicker.propTypes = {
   /**
    * The child node(s)

--- a/packages/react/src/components/FluidTimePickerSelect/FluidTimePickerSelect.tsx
+++ b/packages/react/src/components/FluidTimePickerSelect/FluidTimePickerSelect.tsx
@@ -53,7 +53,6 @@ export interface FluidTimePickerSelectProps {
   readOnly?: boolean;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const FluidTimePickerSelect = React.forwardRef<
   HTMLSelectElement,
   FluidTimePickerSelectProps
@@ -65,6 +64,7 @@ const FluidTimePickerSelect = React.forwardRef<
   );
 });
 
+FluidTimePickerSelect.displayName = 'FluidTimePickerSelect';
 FluidTimePickerSelect.propTypes = {
   /**
    * Provide the contents of your Select

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -147,7 +147,6 @@ export interface IconButtonProps
   wrapperClasses?: string;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const IconButton = forwardRef<unknown, IconButtonProps>(
   (
     {
@@ -226,6 +225,7 @@ const IconButton = forwardRef<unknown, IconButtonProps>(
   }
 );
 
+IconButton.displayName = 'IconButton';
 IconButton.propTypes = {
   /**
    * Specify how the trigger should align with the tooltip

--- a/packages/react/src/components/IconIndicator/index.tsx
+++ b/packages/react/src/components/IconIndicator/index.tsx
@@ -90,7 +90,6 @@ export interface IconIndicatorProps {
   size?: 16 | 20;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 export const IconIndicator = React.forwardRef(
   (
     {
@@ -149,6 +148,7 @@ export const IconIndicator = React.forwardRef(
   }
 );
 
+IconIndicator.displayName = 'IconIndicator';
 IconIndicator.propTypes = {
   /**
    * Specify how the tooltip should align with the icon in compact mode

--- a/packages/react/src/components/InlineCheckbox/InlineCheckbox.tsx
+++ b/packages/react/src/components/InlineCheckbox/InlineCheckbox.tsx
@@ -75,7 +75,6 @@ export interface InlineCheckboxProps {
   title?: string;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const InlineCheckbox = React.forwardRef<HTMLInputElement, InlineCheckboxProps>(
   (props, forwardRef) => {
     const {
@@ -151,6 +150,7 @@ const InlineCheckbox = React.forwardRef<HTMLInputElement, InlineCheckboxProps>(
   }
 );
 
+InlineCheckbox.displayName = 'InlineCheckbox';
 InlineCheckbox.propTypes = {
   /**
    * Specify the label for the control

--- a/packages/react/src/components/ListBox/next/ListBoxTrigger.tsx
+++ b/packages/react/src/components/ListBox/next/ListBoxTrigger.tsx
@@ -43,7 +43,6 @@ export interface ListBoxTriggerProps
  * state of the menu for a given `ListBox`
  */
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const ListBoxTrigger = React.forwardRef<HTMLButtonElement, ListBoxTriggerProps>(
   ({ isOpen, translateWithId: t = defaultTranslateWithId, ...rest }, ref) => {
     const prefix = usePrefix();
@@ -67,6 +66,7 @@ const ListBoxTrigger = React.forwardRef<HTMLButtonElement, ListBoxTriggerProps>(
   }
 );
 
+ListBoxTrigger.displayName = 'ListBoxTrigger';
 ListBoxTrigger.propTypes = {
   /**
    * Specify whether the menu is currently open, which will influence the

--- a/packages/react/src/components/ShapeIndicator/index.tsx
+++ b/packages/react/src/components/ShapeIndicator/index.tsx
@@ -118,7 +118,6 @@ export interface ShapeIndicatorProps {
   textSize?: 12 | 14;
 }
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 export const ShapeIndicator = React.forwardRef(
   (
     {
@@ -177,6 +176,7 @@ export const ShapeIndicator = React.forwardRef(
   }
 );
 
+ShapeIndicator.displayName = 'ShapeIndicator';
 ShapeIndicator.propTypes = {
   /**
    * Specify how the tooltip should align with the shape in compact mode

--- a/packages/react/src/components/Stack/HStack.tsx
+++ b/packages/react/src/components/Stack/HStack.tsx
@@ -9,9 +9,9 @@ import React, { forwardRef } from 'react';
 
 import { Stack, StackProps } from './Stack';
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 export const HStack = forwardRef<HTMLElement, StackProps>((props, ref) => {
   return <Stack {...props} ref={ref} orientation="horizontal" />;
 });
 
+HStack.displayName = 'HStack';
 HStack.propTypes = Stack.propTypes;

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -69,7 +69,6 @@ export interface StackProps extends React.HTMLAttributes<HTMLElement> {
  * - https://paste.twilio.design/layout/stack/
  * - https://github.com/Workday/canvas-kit/blob/f2f599654876700f483a1d8c5de82a41315c76f1/modules/labs-react/layout/lib/Stack.tsx
  */
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
   const {
     as: BaseComponent = 'div',
@@ -97,6 +96,7 @@ export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
   );
 });
 
+Stack.displayName = 'Stack';
 Stack.propTypes = {
   /**
    * Provide a custom element type to render as the outermost element in

--- a/packages/react/src/components/Stack/VStack.tsx
+++ b/packages/react/src/components/Stack/VStack.tsx
@@ -9,9 +9,9 @@ import React, { forwardRef } from 'react';
 
 import { Stack, StackProps } from './Stack';
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 export const VStack = forwardRef<HTMLElement, StackProps>((props, ref) => {
   return <Stack {...props} ref={ref} orientation="vertical" />;
 });
 
+VStack.displayName = 'VStack';
 VStack.propTypes = Stack.propTypes;

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -109,7 +109,6 @@ export type DismissibleTagProps<T extends React.ElementType> = PolymorphicProps<
   DismissibleTagBaseProps
 >;
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const DismissibleTag = forwardRef(
   <T extends React.ElementType>(
     {
@@ -213,6 +212,8 @@ const DismissibleTag = forwardRef(
     );
   }
 );
+
+DismissibleTag.displayName = 'DismissibleTag';
 DismissibleTag.propTypes = {
   /**
    * Provide a custom className that is applied to the containing <span>

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -81,7 +81,6 @@ export type OperationalTagProps<T extends React.ElementType> = PolymorphicProps<
   OperationalTagBaseProps
 >;
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const OperationalTag = forwardRef(
   <T extends React.ElementType>(
     {
@@ -161,6 +160,7 @@ const OperationalTag = forwardRef(
   }
 );
 
+OperationalTag.displayName = 'OperationalTag';
 OperationalTag.propTypes = {
   /**
    * Provide a custom className that is applied to the containing <span>

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -83,7 +83,6 @@ export type SelectableTagProps<T extends React.ElementType> = PolymorphicProps<
   SelectableTagBaseProps
 >;
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const SelectableTag = forwardRef(
   <T extends React.ElementType>(
     {
@@ -178,6 +177,7 @@ const SelectableTag = forwardRef(
   }
 );
 
+SelectableTag.displayName = 'SelectableTag';
 SelectableTag.propTypes = {
   /**
    * Provide a custom className that is applied to the containing <span>

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -127,7 +127,6 @@ type TagComponent = <T extends React.ElementType = 'div'>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
 ) => React.ReactElement | any;
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 const TagBase = React.forwardRef<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
   any,
@@ -320,6 +319,8 @@ const TagBase = React.forwardRef<
     );
   }
 );
+
+TagBase.displayName = 'Tag';
 const Tag = TagBase as TagComponent;
 
 // @ts-expect-error - `propTypes` isn't typed.

--- a/packages/react/src/components/Theme/index.tsx
+++ b/packages/react/src/components/Theme/index.tsx
@@ -29,7 +29,6 @@ export const ThemeContext = React.createContext<GlobalThemeProps>({
   theme: 'white',
 });
 
-// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
 export const GlobalTheme = React.forwardRef(
   (
     { children, theme }: PropsWithChildren<GlobalThemeProps>,
@@ -53,6 +52,7 @@ export const GlobalTheme = React.forwardRef(
   }
 );
 
+GlobalTheme.displayName = 'GlobalTheme';
 GlobalTheme.propTypes = {
   /**
    * Provide child elements to be rendered inside of `GlobalTheme`, this is
@@ -97,13 +97,12 @@ export function Theme<E extends ElementType = 'div'>({
       isDark,
     };
   }, [theme]);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  const BaseComponentAsAny = BaseComponent as any;
+  const BaseComponentAsElement = BaseComponent as ElementType;
 
   return (
     <ThemeContext.Provider value={value}>
       <LayerContext.Provider value={1}>
-        <BaseComponentAsAny {...rest} className={className} />
+        <BaseComponentAsElement {...rest} className={className} />
       </LayerContext.Provider>
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
Part of #20071

Removes a small set of ESLint suppressions for `react/display-name` and adds explicit `displayName` values to the affected React components.

### Changelog

**New**

- Added explicit `displayName` values for several React `forwardRef` components

**Changed**

- Replaced one internal `Theme` component cast from `any` to `ElementType`

**Removed**

- Removed selected ESLint ignore comments referencing `carbon/issues/20452` - `// eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452`

#### Testing / Reviewing

- Review that each added `displayName` matches the component name
- Confirm no rendered markup, props, refs, styling, or event behavior changed

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)