### PR TITLE
fix(web-components): resolve eslint suppressions

### DIFF
--- a/packages/web-components/src/components/breadcrumb/__tests__/breadcrumb-test.js
+++ b/packages/web-components/src/components/breadcrumb/__tests__/breadcrumb-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,6 +7,7 @@
 
 import { expect, fixture, html } from '@open-wc/testing';
 import '@carbon/web-components/es/components/breadcrumb/index.js';
+import '@carbon/web-components/es/components/overflow-menu/index.js';
 
 describe('cds-breadcrumb', () => {
   it('should accept an `aria-label` for nav element', async () => {
@@ -65,6 +66,21 @@ describe('cds-breadcrumb', () => {
     const item = el.querySelector('cds-breadcrumb-item');
     const link = item.querySelector('cds-breadcrumb-link');
     expect(link.shadowRoot.querySelector('a.cds--link--sm')).to.exist;
+  });
+
+  it('should pass the size attribute to an overflow menu item', async () => {
+    const el = await fixture(html`
+      <cds-breadcrumb-item size="sm">
+        <cds-overflow-menu>
+          <cds-overflow-menu-body></cds-overflow-menu-body>
+        </cds-overflow-menu>
+      </cds-breadcrumb-item>
+    `);
+    await el.updateComplete;
+
+    const overflowMenu = el.querySelector('cds-overflow-menu');
+
+    expect(overflowMenu).to.have.attribute('breadcrumb-size', 'sm');
   });
 
   it('should apply additional attributes to the outermost element', async () => {

--- a/packages/web-components/src/components/breadcrumb/breadcrumb-item.ts
+++ b/packages/web-components/src/components/breadcrumb/breadcrumb-item.ts
@@ -30,12 +30,9 @@ class CDSBreadcrumbItem extends LitElement {
       );
 
     items.forEach((item) => {
-      if (this.getAttribute('size')) {
-        (item as HTMLElement).setAttribute(
-          'breadcrumb-size',
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-          this.getAttribute('size')!
-        );
+      const size = this.getAttribute('size');
+      if (size) {
+        (item as HTMLElement).setAttribute('breadcrumb-size', size);
       }
 
       const overflowMenuBody = (item as HTMLElement).querySelector(

--- a/packages/web-components/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/web-components/src/components/breadcrumb/breadcrumb.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,10 +36,11 @@ class CDSBreadcrumb extends LitElement {
    * Handles `slotchange` event.
    */
   private _handleSlotChange({ target }: Event) {
-    const items = (target as HTMLSlotElement).assignedNodes().filter(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      (node) => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim()
-    );
+    const items = (target as HTMLSlotElement)
+      .assignedNodes()
+      .filter(
+        (node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim()
+      );
     items.forEach((item) => {
       (item as HTMLElement).setAttribute('size', this.size);
     });

--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -49,10 +49,11 @@ class CDSButton extends HostListenerMixin(FocusMixin(LitElement)) {
    */
   private _handleSlotChange({ target }: Event) {
     const { name } = target as HTMLSlotElement;
-    const hasContent = (target as HTMLSlotElement).assignedNodes().some(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      (node) => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim()
-    );
+    const hasContent = (target as HTMLSlotElement)
+      .assignedNodes()
+      .some(
+        (node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim()
+      );
     this[name === 'icon' ? '_hasIcon' : 'hasMainContent'] = hasContent;
     this.requestUpdate();
   }

--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -1253,8 +1253,7 @@ class CDSDropdown extends ValidityMixin(
   /**
    * The CSS class list for dropdown listbox
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  protected get _classes(): any {
+  protected get _classes(): ReturnType<typeof classMap> {
     const { size, type, open, autoalign } = this;
     const inline = type === DROPDOWN_TYPE.INLINE;
     const normalizedProps = this._normalizedProps;

--- a/packages/web-components/src/components/link/link.ts
+++ b/packages/web-components/src/components/link/link.ts
@@ -44,10 +44,11 @@ class CDSLink extends FocusMixin(LitElement) {
    */
   protected _handleSlotChange({ target }: Event) {
     const { name } = target as HTMLSlotElement;
-    const hasContent = (target as HTMLSlotElement).assignedNodes().some(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      (node) => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim()
-    );
+    const hasContent = (target as HTMLSlotElement)
+      .assignedNodes()
+      .some(
+        (node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim()
+      );
     this[name === 'icon' ? '_hasIcon' : ''] = hasContent;
     this.requestUpdate();
   }
@@ -58,8 +59,7 @@ class CDSLink extends FocusMixin(LitElement) {
   /**
    * The CSS class list for the link node.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  protected get _classes(): any {
+  protected get _classes(): ReturnType<typeof classMap> {
     const { disabled, size, inline, visited, _hasIcon } = this;
     return classMap({
       [`${prefix}--link`]: true,

--- a/packages/web-components/src/components/multi-select/multi-select.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.ts
@@ -659,8 +659,7 @@ class CDSMultiSelect extends CDSDropdown {
   /**
    * The CSS class list for multi-select listbox
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  protected get _classes(): any {
+  protected get _classes(): ReturnType<typeof classMap> {
     const {
       disabled,
       size,

--- a/packages/web-components/src/components/notification/__tests__/actionable-notification-test.js
+++ b/packages/web-components/src/components/notification/__tests__/actionable-notification-test.js
@@ -146,4 +146,39 @@ describe('cds-actionable-notification', () => {
 
     expect(actionButton).to.have.attribute('kind', 'tertiary');
   });
+
+  it('wraps focus to the notification when no tabbable content receives focus', async () => {
+    const el = await createActionable();
+    const closeButton = el.shadowRoot.querySelector('button');
+    const details = el.shadowRoot.querySelector(
+      `.${prefix}--actionable-notification__details`
+    );
+    const startSentinel = el.shadowRoot.querySelector('#start-sentinel');
+    const endSentinel = el.shadowRoot.querySelector('#end-sentinel');
+    let focusCount = 0;
+
+    closeButton.focus = () => {};
+    el.focus = () => {
+      focusCount++;
+    };
+
+    details.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: startSentinel,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(focusCount).to.equal(1);
+
+    details.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: endSentinel,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(focusCount).to.equal(2);
+  });
 });

--- a/packages/web-components/src/components/notification/actionable-notification-button.ts
+++ b/packages/web-components/src/components/notification/actionable-notification-button.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,10 +19,9 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 class CDSActionableNotificationButton extends CDSButton {
   update(changedProperties) {
     super.update(changedProperties);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-    this.shadowRoot!.getElementById('button')?.classList.add(
-      `${prefix}--actionable-notification__action-button`
-    );
+    this.shadowRoot
+      ?.getElementById('button')
+      ?.classList.add(`${prefix}--actionable-notification__action-button`);
 
     this.setAttribute('size', 'sm');
   }

--- a/packages/web-components/src/components/notification/actionable-notification.ts
+++ b/packages/web-components/src/components/notification/actionable-notification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -52,8 +52,7 @@ function tryFocusElems(elems: NodeListOf<HTMLElement>, reverse = false) {
     for (let i = 0; i < elems.length; ++i) {
       const elem = elems[i];
       elem.focus();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      const active = elem.ownerDocument!.activeElement;
+      const active = elem.ownerDocument.activeElement;
       if (
         active === elem ||
         active?.contains(elem) ||
@@ -66,8 +65,7 @@ function tryFocusElems(elems: NodeListOf<HTMLElement>, reverse = false) {
     for (let i = elems.length - 1; i >= 0; --i) {
       const elem = elems[i];
       elem.focus();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      const active = elem.ownerDocument!.activeElement;
+      const active = elem.ownerDocument.activeElement;
       if (
         active === elem ||
         active?.contains(elem) ||
@@ -188,8 +186,7 @@ class CDSActionableNotification extends HostListenerMixin(
         relatedTarget as Node
       );
       // tabbable elements in Shadow root
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-      const shadowElems = this.shadowRoot!.querySelectorAll(
+      const shadowElems = this.shadowRoot?.querySelectorAll(
         selectorTabbableForActionableNotification
       );
       // tabbable elements in light DOM
@@ -200,7 +197,8 @@ class CDSActionableNotification extends HostListenerMixin(
       if (relatedTarget === startSentinelNode || comparisonResult & PRECEDING) {
         await (this.constructor as typeof CDSActionableNotification)._delay();
         if (
-          !tryFocusElems(shadowElems as NodeListOf<HTMLElement>, true) &&
+          (!shadowElems ||
+            !tryFocusElems(shadowElems as NodeListOf<HTMLElement>, true)) &&
           !tryFocusElems(lightElems as NodeListOf<HTMLElement>, true) &&
           relatedTarget !== this
         ) {
@@ -213,7 +211,8 @@ class CDSActionableNotification extends HostListenerMixin(
         await (this.constructor as typeof CDSActionableNotification)._delay();
         if (
           !tryFocusElems(lightElems as NodeListOf<HTMLElement>) &&
-          !tryFocusElems(shadowElems as NodeListOf<HTMLElement>)
+          (!shadowElems ||
+            !tryFocusElems(shadowElems as NodeListOf<HTMLElement>))
         ) {
           this.focus();
         }

--- a/packages/web-components/src/components/page-header/page-header-tabs.ts
+++ b/packages/web-components/src/components/page-header/page-header-tabs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,8 +24,6 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 @customElement(`${prefix}-page-header-tabs`)
 class CDSPageHeaderTabs extends LitElement {
   render() {
-    // eslint-disable-next-line no-empty-pattern -- https://github.com/carbon-design-system/carbon/issues/20452
-    const {} = this;
     return html` <div class="${prefix}--css-grid">
       <div
         class="${prefix}--sm:col-span-4 ${prefix}--md:col-span-8 ${prefix}--lg:col-span-16 ${prefix}--css-grid-column">

--- a/packages/web-components/src/components/page-header/page-header.ts
+++ b/packages/web-components/src/components/page-header/page-header.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,8 +24,6 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 @customElement(`${prefix}-page-header`)
 class CDSPageHeader extends LitElement {
   render() {
-    // eslint-disable-next-line no-empty-pattern -- https://github.com/carbon-design-system/carbon/issues/20452
-    const {} = this;
     return html` <slot></slot>`;
   }
 

--- a/packages/web-components/src/components/tag/dismissible-tag.ts
+++ b/packages/web-components/src/components/tag/dismissible-tag.ts
@@ -88,8 +88,10 @@ class CDSDismissibleTag extends HostListenerMixin(FocusMixin(CDSTag)) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleClick = (event: MouseEvent) => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-    if (event.composedPath().indexOf(this._buttonNode!) >= 0) {
+    if (
+      this._buttonNode &&
+      event.composedPath().indexOf(this._buttonNode) >= 0
+    ) {
       if (this.disabled) {
         event.stopPropagation();
       } else if (this.open) {

--- a/packages/web-components/src/components/tag/tag.ts
+++ b/packages/web-components/src/components/tag/tag.ts
@@ -77,8 +77,10 @@ class CDSTag extends HostListenerMixin(FocusMixin(LitElement)) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleClick = (event: MouseEvent) => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- https://github.com/carbon-design-system/carbon/issues/20452
-    if (event.composedPath().indexOf(this._buttonNode!) >= 0) {
+    if (
+      this._buttonNode &&
+      event.composedPath().indexOf(this._buttonNode) >= 0
+    ) {
       if (this.disabled) {
         event.stopPropagation();
       } else if (this.open) {

--- a/packages/web-components/src/components/tile/clickable-tile.ts
+++ b/packages/web-components/src/components/tile/clickable-tile.ts
@@ -26,8 +26,7 @@ import { isFeatureFlagEnabled } from '../feature-flags';
  */
 @customElement(`${prefix}-clickable-tile`)
 class CDSClickableTile extends CDSLink {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  protected get _classes(): any {
+  protected get _classes(): ReturnType<typeof classMap> {
     const { colorScheme, disabled, hasRoundedCorners, aiLabel, slug } = this;
     return classMap({
       [`${prefix}--link`]: true,

--- a/packages/web-components/src/globals/controllers/floating-controller.ts
+++ b/packages/web-components/src/globals/controllers/floating-controller.ts
@@ -235,13 +235,12 @@ export default class FloatingController implements ReactiveController {
         // @ts-ignore
         const { x: arrowX, y: arrowY } = middlewareData.arrow;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-        const staticSide: any = {
+        const staticSide = {
           top: 'bottom',
           right: 'left',
           bottom: 'top',
           left: 'right',
-        }[placement.split('-')[0]];
+        }[placement.split('-')[0] as 'top' | 'right' | 'bottom' | 'left'];
 
         arrowElement.style.left = arrowX != null ? `${arrowX}px` : '';
         arrowElement.style.top = arrowY != null ? `${arrowY}px` : '';

--- a/packages/web-components/src/globals/internal/collection-helpers.ts
+++ b/packages/web-components/src/globals/internal/collection-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,8 +14,7 @@
 export const filter = (
   a: NodeListOf<Node> | HTMLCollectionOf<Element>,
   predicate: (search: Node, index?: number) => boolean,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  thisObject?: any
+  thisObject?: unknown
 ) => Array.prototype.filter.call(a, predicate, thisObject);
 
 /**
@@ -27,8 +26,7 @@ export const filter = (
 export const findIndex = (
   a: NodeListOf<Node> | HTMLCollectionOf<Element>,
   predicate: (search: Node, index?: number) => boolean,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  thisObject?: any
+  thisObject?: unknown
 ) => Array.prototype.findIndex.call(a, predicate, thisObject);
 
 /**
@@ -40,8 +38,7 @@ export const findIndex = (
 export const find = (
   a: NodeListOf<Node> | HTMLCollectionOf<Element>,
   predicate: (search: Node, index?: number) => boolean,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  thisObject?: any
+  thisObject?: unknown
 ) => Array.prototype.find.call(a, predicate, thisObject);
 
 /**
@@ -54,8 +51,7 @@ export const find = (
 export const forEach = (
   a: NodeListOf<Node> | HTMLCollectionOf<Element>,
   predicate: (search: Element, index?: number) => void,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  thisObject?: any
+  thisObject?: unknown
 ) => Array.prototype.forEach.call(a, predicate, thisObject);
 
 /**

--- a/packages/web-components/src/globals/mixins/on.ts
+++ b/packages/web-components/src/globals/mixins/on.ts
@@ -1,16 +1,28 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-export default function on(element: any, ...args: any) {
-  element.addEventListener(...args);
+export default function on<TEvent extends Event = Event>(
+  element: EventTarget,
+  type: string,
+  listener: EventListenerObject | ((event: TEvent) => void),
+  options?: boolean | AddEventListenerOptions
+) {
+  element.addEventListener(
+    type,
+    listener as EventListenerOrEventListenerObject,
+    options
+  );
   return {
     release() {
-      element.removeEventListener(...args);
+      element.removeEventListener(
+        type,
+        listener as EventListenerOrEventListenerObject,
+        options
+      );
       return null;
     },
   };

--- a/packages/web-components/src/polyfills/index.ts
+++ b/packages/web-components/src/polyfills/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,7 +18,7 @@ import 'core-js/modules/es.object.is.js'; // For src/globals/directives/spread.t
 import 'core-js/modules/es.object.values.js';
 import 'core-js/modules/es.object.entries';
 
-import ResizeObserver from '@juggle/resize-observer';
+import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
 
 import './element-closest';
 import './element-matches';
@@ -27,7 +27,7 @@ import './toggle-class';
 
 import '@webcomponents/webcomponentsjs';
 
-if (typeof ResizeObserver === 'undefined') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20452
-  (window as any).ResizeObserver = ResizeObserver;
+if (typeof window.ResizeObserver === 'undefined') {
+  window.ResizeObserver =
+    ResizeObserverPolyfill as unknown as typeof window.ResizeObserver;
 }


### PR DESCRIPTION
Part of #20071

Removes eslint suppressions from Web components files related to #20452. This includes simple type cleanups, redundant non-null assertion removals, empty destructuring cleanup, and a `ResizeObserver` polyfill fix.

### Changelog

**New**

- Added tests for breadcrumb overflow menu size forwarding and actionable notification focus wrapping

**Changed**

- Updated the `ResizeObserver` polyfill check to use `window.ResizeObserver` and the named polyfill import

**Removed**

- Removed #20452 eslint suppressions from web-components source files

#### Testing / Reviewing

- Review the changes, CI should pass
- Confirm no rendered markup, props, refs, styling, or event behavior changed
- Targeted eslint passes for all changed files

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- [X] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)