### PR TITLE
fix(ci): increase wait-for-it timeout from 3 to 5 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
       - uses: ./actions/wait-for-it
         with:
           URL: 'http://localhost:3000'
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Run AVT
         if: github.repository == 'carbon-design-system/carbon'
         run: |


### PR DESCRIPTION
Closes #

The `wait-for-it` action in CI has been timing out consistently. The action runs inside a Docker container that installs dependencies fresh on every CI run, and the Docker build + `npm install` time has been exceeding the current 3-minute limit. This increases the timeout from 3 to 5 minutes to give the Docker build enough headroom.

### Changelog

**Changed**

- `.github/workflows/ci.yml` — increased `timeout-minutes` for the `wait-for-it` step from `3` to `5`

#### Testing / Reviewing

- Trigger a CI run and confirm the `avt` job no longer times out at the `wait-for-it` step
- No functional change to the action itself or any other part of the pipeline

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- ~Updated documentation and storybook examples~
- ~Followed the [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation) for any code change that affects v12, or struck through this item because the PR does not affect v12~
- ~Wrote passing tests that cover this change~
- ~Addressed any impact on accessibility (a11y)~
- ~Tested for cross-browser consistency~
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)