### PR TITLE
fix(timepicker): v12 joined border styles

### DIFF
--- a/docs/migration/v12.md
+++ b/docs/migration/v12.md
@@ -143,8 +143,8 @@ snapshots or application overrides that depend on the previous pill shape.
 There is no React component API change. When a Time picker includes adjacent
 select fields, joined edges follow the same treatment as Date picker range
 inputs through the
-[Sass Time picker joined fields change](#sass-time-picker-joined-fields).
-Review visual snapshots and custom margin or border-radius overrides.
+[Sass Time picker joined fields change](#sass-time-picker-joined-fields). Review
+visual snapshots and custom margin or border-radius overrides.
 
 ### React Pagination preview APIs
 
@@ -311,5 +311,5 @@ snapshots and custom radius overrides.
 There is no Web Components API change. `cds-time-picker` with
 `cds-time-picker-select` children receives the same joined-field treatment as
 Date picker range inputs through the related
-[Sass Time picker joined fields change](#sass-time-picker-joined-fields).
-Review visual snapshots and custom margin or border-radius overrides.
+[Sass Time picker joined fields change](#sass-time-picker-joined-fields). Review
+visual snapshots and custom margin or border-radius overrides.

--- a/docs/migration/v12.md
+++ b/docs/migration/v12.md
@@ -138,6 +138,14 @@ through its `@carbon/styles` re-export. See the
 [Sass Tag border radius change](#sass-tag-border-radius) and review visual
 snapshots or application overrides that depend on the previous pill shape.
 
+### React Time picker joined fields
+
+There is no React component API change. When a Time picker includes adjacent
+select fields, joined edges follow the same treatment as Date picker range
+inputs through the
+[Sass Time picker joined fields change](#sass-time-picker-joined-fields).
+Review visual snapshots and custom margin or border-radius overrides.
+
 ### React Pagination preview APIs
 
 `unstable_Pagination` / `preview_Pagination` and `unstable_PageSelector` /
@@ -221,6 +229,18 @@ This style change supports both the [React Tag](#react-tag-border-radius) and
 the [Web Components Tag](#web-components-tag-border-radius). Review custom Tag
 radius overrides and visual snapshots in both packages.
 
+### Sass Time picker joined fields
+
+When a Time picker includes select fields next to the time input, adjacent
+segment edges are squared, facing borders are removed, and the gap between
+segments is `1px`. This matches the Date picker range joined-field treatment.
+
+This style change supports both the
+[React Time picker](#react-time-picker-joined-fields) and the
+[Web Components Time picker](#web-components-time-picker-joined-fields). Review
+custom Time picker margin, border, or border-radius overrides and visual
+snapshots in both packages.
+
 ## `@carbon/web-components`
 
 ### Web Components tile default icons
@@ -285,3 +305,11 @@ There is no Web Components API change. `cds-tag`, `cds-dismissible-tag`,
 size-based corner radii through the related
 [Sass Tag border radius change](#sass-tag-border-radius). Review visual
 snapshots and custom radius overrides.
+
+### Web Components Time picker joined fields
+
+There is no Web Components API change. `cds-time-picker` with
+`cds-time-picker-select` children receives the same joined-field treatment as
+Date picker range inputs through the related
+[Sass Time picker joined fields change](#sass-time-picker-joined-fields).
+Review visual snapshots and custom margin or border-radius overrides.

--- a/packages/react/src/components/Form/Form.stories.js
+++ b/packages/react/src/components/Form/Form.stories.js
@@ -32,6 +32,8 @@ import ComboBox from '../ComboBox';
 import Dropdown, { DropdownSkeleton } from '../Dropdown';
 import DatePicker, { DatePickerSkeleton } from '../DatePicker';
 import DatePickerInput from '../DatePickerInput';
+import TimePicker from '../TimePicker';
+import TimePickerSelect from '../TimePickerSelect';
 import { MultiSelect, FilterableMultiSelect } from '../MultiSelect';
 import { IconButton } from '../IconButton';
 import { View, FolderOpen, Folders } from '@carbon/icons-react';
@@ -286,6 +288,11 @@ export const Default = (args) => {
         </div>
         <div style={formRowStyle}>
           <div style={formColStyle}>
+            <TimePicker id="skeleton-time" labelText="Time" disabled />
+          </div>
+        </div>
+        <div style={formRowStyle}>
+          <div style={formColStyle}>
             <NumberInputSkeleton />
           </div>
           <div style={formColStyle}>
@@ -409,6 +416,36 @@ export const Default = (args) => {
                 {...sharedProps}
               />
             </DatePicker>
+          </div>
+        </div>
+
+        <div style={formRowStyle}>
+          <div style={formColStyle}>
+            <TimePicker
+              id="start-time"
+              labelText="Start time"
+              disabled={disabled}
+              readOnly={readOnly}
+              invalid={invalid}
+              invalidText={invalidText}
+              warning={warn}
+              warningText={warnText}
+              size={size}>
+              <TimePickerSelect
+                id="start-time-format"
+                labelText="AM/PM"
+                disabled={disabled}>
+                <SelectItem value="AM" text="AM" />
+                <SelectItem value="PM" text="PM" />
+              </TimePickerSelect>
+              <TimePickerSelect
+                id="start-time-zone"
+                labelText="Timezone"
+                disabled={disabled}>
+                <SelectItem value="Time zone 1" text="Time zone 1" />
+                <SelectItem value="Time zone 2" text="Time zone 2" />
+              </TimePickerSelect>
+            </TimePicker>
           </div>
         </div>
 

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -147,6 +147,7 @@
   .#{$prefix}--number input[type='number']:disabled,
   .#{$prefix}--number input[type='text']:disabled {
     background-color: $field;
+    border-block-end: 1px solid transparent;
     color: $text-disabled;
     cursor: not-allowed;
 

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -210,6 +210,7 @@
     @include focus-outline('reset');
 
     background: $field;
+    border-block-end: 1px solid transparent;
     color: $text-disabled;
     cursor: not-allowed;
     // Needed to fix disabled text in Safari #6673

--- a/packages/styles/scss/components/time-picker/_time-picker.scss
+++ b/packages/styles/scss/components/time-picker/_time-picker.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2023
+// Copyright IBM Corp. 2016, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,7 +7,9 @@
 
 @use '../text-input';
 @use '../select';
+@use '../../border-radius' as *;
 @use '../../config' as *;
+@use '../../feature-flags' as *;
 @use '../../motion' as *;
 @use '../../spacing' as *;
 @use '../../theme' as *;
@@ -27,7 +29,12 @@
 
   .#{$prefix}--time-picker__select {
     justify-content: center;
-    margin-inline-start: $spacing-01;
+
+    @if enabled('enable-v12-release') {
+      margin-inline-start: convert.to-rem(1px);
+    } @else {
+      margin-inline-start: $spacing-01;
+    }
   }
 
   .#{$prefix}--time-picker__input {
@@ -125,5 +132,27 @@
     .#{$prefix}--select-input
     + .#{$prefix}--select__arrow {
     fill: $icon-disabled;
+  }
+
+  @if enabled('enable-v12-release') {
+    .#{$prefix}--time-picker__input:has(+ .#{$prefix}--time-picker__select)
+      .#{$prefix}--time-picker__input-field {
+      border-end-end-radius: $border-radius-00;
+      border-inline-end: none;
+      border-start-end-radius: $border-radius-00;
+    }
+
+    .#{$prefix}--time-picker__select .#{$prefix}--select-input {
+      border-end-start-radius: $border-radius-00;
+      border-inline-start: none;
+      border-start-start-radius: $border-radius-00;
+    }
+
+    .#{$prefix}--time-picker__select:has(+ .#{$prefix}--time-picker__select)
+      .#{$prefix}--select-input {
+      border-end-end-radius: $border-radius-00;
+      border-inline-end: none;
+      border-start-end-radius: $border-radius-00;
+    }
   }
 }

--- a/packages/styles/scss/components/time-picker/_time-picker.scss
+++ b/packages/styles/scss/components/time-picker/_time-picker.scss
@@ -118,14 +118,22 @@
 
   // readonly
   .#{$prefix}--time-picker--readonly .#{$prefix}--time-picker__input-field {
-    background-color: transparent;
+    background: transparent;
     border-block-end-color: $border-subtle;
+
+    @if enabled('enable-v12-release') {
+      border-radius: $border-radius-00;
+    }
   }
 
   .#{$prefix}--time-picker--readonly .#{$prefix}--select-input {
-    background-color: transparent;
+    background: transparent;
     border-block-end-color: $border-subtle;
     cursor: default;
+
+    @if enabled('enable-v12-release') {
+      border-radius: $border-radius-00;
+    }
   }
 
   .#{$prefix}--time-picker--readonly

--- a/packages/web-components/src/components/form/form.stories.ts
+++ b/packages/web-components/src/components/form/form.stories.ts
@@ -27,6 +27,7 @@ import '../password-input/index';
 import '../textarea/index';
 import '../button/index';
 import '../date-picker/index';
+import '../time-picker/index';
 import '../dropdown/index';
 import '../multi-select/index';
 import '../combo-box/index';
@@ -351,6 +352,14 @@ const renderDefaultForm = (args) => {
               )}
             `)}
             ${row(html`
+              ${col(html`
+                <cds-time-picker
+                  id="skeleton-time"
+                  label-text="Time"
+                  disabled></cds-time-picker>
+              `)}
+            `)}
+            ${row(html`
               ${col(
                 html`<cds-number-input-skeleton></cds-number-input-skeleton>`
               )}
@@ -519,6 +528,42 @@ const renderDefaultForm = (args) => {
                   ${decorator()} ${dateHelper('Final delivery date.')}
                 </cds-date-picker-input>
               </cds-date-picker>
+            `)}
+          `)}
+          ${row(html`
+            ${col(html`
+              <cds-time-picker
+                id="start-time"
+                label-text="Start time"
+                placeholder="hh:mm"
+                ?disabled="${disabled}"
+                ?readonly="${readOnly}"
+                ?invalid="${invalid}"
+                invalid-text="${ifDefined(invalidText)}"
+                ?warning="${warn}"
+                warning-text="${ifDefined(warnText)}"
+                size="${ifDefined(size)}">
+                <cds-time-picker-select
+                  id="start-time-format"
+                  default-value="AM"
+                  ?disabled="${disabled}"
+                  aria-label="Select AM/PM">
+                  <cds-select-item value="AM">AM</cds-select-item>
+                  <cds-select-item value="PM">PM</cds-select-item>
+                </cds-time-picker-select>
+                <cds-time-picker-select
+                  id="start-time-zone"
+                  default-value="Time zone 1"
+                  ?disabled="${disabled}"
+                  aria-label="Select timezone">
+                  <cds-select-item value="Time zone 1"
+                    >Time zone 1</cds-select-item
+                  >
+                  <cds-select-item value="Time zone 2"
+                    >Time zone 2</cds-select-item
+                  >
+                </cds-time-picker-select>
+              </cds-time-picker>
             `)}
           `)}
           ${row(html`

--- a/packages/web-components/src/components/time-picker/time-picker.scss
+++ b/packages/web-components/src/components/time-picker/time-picker.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,7 +7,9 @@
 
 $css--plex: true !default;
 
+@use '@carbon/styles/scss/border-radius' as *;
 @use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/feature-flags' as flags;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/utilities' as *;
@@ -22,7 +24,14 @@ $css--plex: true !default;
 
 :host(#{$prefix}-time-picker-select) {
   @extend .#{$prefix}--select;
-  @extend .#{$prefix}--time-picker__select;
+
+  justify-content: center;
+
+  @if flags.enabled('enable-v12-release') {
+    margin-inline-start: convert.to-rem(1px);
+  } @else {
+    margin-inline-start: $spacing-01;
+  }
 }
 
 :host(#{$prefix}-time-picker-select) .#{$prefix}--select {
@@ -47,4 +56,34 @@ $css--plex: true !default;
   line-height: 1;
   min-inline-size: auto;
   padding-inline-end: convert.to-rem(48px);
+}
+
+@if flags.enabled('enable-v12-release') {
+  :host(#{$prefix}-time-picker) {
+    .#{$prefix}--time-picker__input-field {
+      border-end-end-radius: $border-radius-00;
+      border-inline-end: none;
+      border-start-end-radius: $border-radius-00;
+    }
+
+    ::slotted(#{$prefix}-time-picker-select:not(:last-of-type)) {
+      --#{$prefix}-time-picker-join-end-radius: #{$border-radius-00};
+      --#{$prefix}-time-picker-join-end-width: 0;
+    }
+  }
+
+  :host(#{$prefix}-time-picker-select) .#{$prefix}--select-input {
+    border-end-end-radius: var(
+      --#{$prefix}-time-picker-join-end-radius,
+      #{$border-radius-04}
+    );
+    border-end-start-radius: $border-radius-00;
+    border-inline-end-width: var(--#{$prefix}-time-picker-join-end-width, 1px);
+    border-inline-start: none;
+    border-start-end-radius: var(
+      --#{$prefix}-time-picker-join-end-radius,
+      #{$border-radius-04}
+    );
+    border-start-start-radius: $border-radius-00;
+  }
 }


### PR DESCRIPTION


joins and removes borders for time picker with 1px gap on timepicker as per design

### Changelog

**Changed**

- timepicker styles

#### Testing / Reviewing

compare timepicker in v11 v12 in both react and web components. and they must look like one from the issue acceptance criteria on v12

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
