### PR TITLE
 fix: improve hcm rendering for date picker, popover, and contained list

### DIFF
--- a/packages/styles/scss/components/contained-list/_contained-list.scss
+++ b/packages/styles/scss/components/contained-list/_contained-list.scss
@@ -17,6 +17,7 @@
 @use '../../utilities/convert';
 @use '../../utilities/button-reset';
 @use '../../utilities/focus-outline' as *;
+@use '../../utilities/high-contrast-mode' as *;
 @use '../../utilities/custom-property';
 @use '../../utilities/layout';
 
@@ -200,6 +201,13 @@
     content: '';
     inset-block-end: 0;
     inset-inline: 0;
+
+    @include high-contrast-mode {
+      // Keep row separators visible above item content in forced-colors mode.
+      z-index: 1;
+      background-color: CanvasText;
+      pointer-events: none;
+    }
   }
 
   .#{$prefix}--contained-list--inset-rulers

--- a/packages/styles/scss/components/date-picker/_flatpickr.scss
+++ b/packages/styles/scss/components/date-picker/_flatpickr.scss
@@ -382,6 +382,44 @@
     }
   }
 
+  @include high-contrast-mode {
+    .numInputWrapper .arrowUp,
+    .numInputWrapper .arrowDown {
+      opacity: 1;
+    }
+
+    .numInput[disabled] ~ .arrowUp,
+    .numInput[disabled] ~ .arrowDown {
+      opacity: 0;
+    }
+
+    .numInputWrapper .arrowUp::after,
+    .numInputWrapper .arrowDown::after {
+      // Flatpickr renders year controls as CSS border triangles. Preserve the
+      // transparent sides so forced-colors mode does not render them as boxes.
+      border-color: transparent;
+      forced-color-adjust: none;
+    }
+
+    .numInputWrapper .arrowUp::after {
+      border-block-end-color: ButtonText;
+    }
+
+    .numInputWrapper .arrowDown::after {
+      border-block-start-color: ButtonText;
+    }
+
+    @media (any-hover: hover) {
+      .numInputWrapper .arrowUp:hover::after {
+        border-block-end-color: Highlight;
+      }
+
+      .numInputWrapper .arrowDown:hover::after {
+        border-block-start-color: Highlight;
+      }
+    }
+  }
+
   .numInput[disabled] ~ .arrowUp::after {
     border-block-end-color: $text-disabled;
   }

--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -216,6 +216,8 @@ $popover-caret-height: custom-property.get-var(
     inline-size: max-content;
     max-inline-size: convert.to-rem(368px);
     pointer-events: auto;
+
+    @include high-contrast-mode('outline');
   }
 
   .#{$prefix}--popover--open

--- a/packages/web-components/src/components/contained-list/contained-list.scss
+++ b/packages/web-components/src/components/contained-list/contained-list.scss
@@ -11,6 +11,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
+@use '@carbon/styles/scss/utilities/high-contrast-mode' as *;
 @use '@carbon/styles/scss/utilities/layout' as *;
 @use '@carbon/styles/scss/components/contained-list';
 @use '@carbon/styles/scss/components/form' as *;
@@ -54,6 +55,13 @@ $css--plex: true !default;
     content: '';
     inset-block-end: 0;
     inset-inline: 0;
+
+    @include high-contrast-mode {
+      // Keep row separators visible above item content in forced-colors mode.
+      z-index: 1;
+      background-color: CanvasText;
+      pointer-events: none;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #22098

Fix `High Contrast Mode` rendering for `DatePicker`, `Popover`, and `ContainedList` across `React` and `Web Components`.

### Changelog

**New**

- ~None.~

**Changed**

- Updated `DatePicker` year navigation arrows so they remain visible and show hover feedback in HCM.
- Added a visible HCM outline to `Popover` content.
- Updated `ContainedList` item separators so dividers remain visible in HCM, including Web Components.

**Removed**

- ~None.~

#### Testing / Reviewing

1. Go to the `React` and `WC` `Deploy preview` > `DatePicker` > `Default`
2. Open `DevTools` with `Cmd + Option + I` on macOS or `Ctrl + Shift + I` on Windows.
3. Open the Command Menu with `Cmd + Shift + P` on macOS or `Ctrl + Shift + P` on Windows.
4. Search for **Emulate CSS forced-colors**.
5. Select **forced-colors: active**.
6. Open the `DatePicker` calendar and verify the small year navigation arrows render as arrows, not solid boxes.
7. Repeat the same forced-colors check for `Popover > Default` and verify the popover content has a visible boundary.
8. Repeat the same forced-colors check for `ContainedList > Default` and verify row separators are visible.

**_Screenshots below to make it easier:_**

<details>

<summary>DatePicker</summary>
<img width="276" height="137" alt="image" src="https://github.com/user-attachments/assets/cade7b0f-1ba2-422f-b170-8571ebedc5f8" />

<img width="300" height="214" alt="image" src="https://github.com/user-attachments/assets/09199df9-939f-444a-91ba-94dec978e2be" />

</details>

<details>
<summary>ContainedList</summary>
<img width="974" height="366" alt="image" src="https://github.com/user-attachments/assets/e7cd708c-893b-4242-92b5-e7b7a4edaf32" />

<img width="983" height="390" alt="image" src="https://github.com/user-attachments/assets/aa82645e-267d-4250-a860-faf6ae9eb8ea" />

</details>

<details>
<summary>Popover</summary>
<img width="468" height="152" alt="image" src="https://github.com/user-attachments/assets/6a29cf5a-995a-4a7a-bd92-5630045b51ba" />
<img width="393" height="138" alt="image" src="https://github.com/user-attachments/assets/9d905312-7a3b-4111-8b60-d5bee9134214" />

</details>

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Followed the
      [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation)
      for any code change that affects v12, or struck through this item because
      the PR does not affect v12~
- ~[ ] Wrote passing tests that cover this change~
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)