### PR TITLE
fix(TextInput): prevent Storybook click action crash

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -7,13 +7,40 @@
 
 import React from 'react';
 import { WithLayer } from '../../../.storybook/templates/WithLayer';
-import { View, FolderOpen, Folders, Information } from '@carbon/icons-react';
+import { View, FolderOpen, Folders } from '@carbon/icons-react';
 import Button from '../Button';
 import { AILabel, AILabelContent, AILabelActions } from '../AILabel';
 import { IconButton } from '../IconButton';
 import mdx from './TextInput.mdx';
 
 import { default as TextInput, TextInputSkeleton } from '../TextInput';
+
+const getTextInputStoryArgs = ({
+  defaultWidth,
+  onChange,
+  onClick,
+  ...textInputArgs
+}) => {
+  const handleChange = (event) => {
+    onChange?.({
+      value: event.target.value,
+    });
+  };
+  const handleClick = (event) => {
+    onClick?.({
+      value: event.target.value,
+    });
+  };
+
+  return {
+    defaultWidth,
+    textInputArgs: {
+      ...textInputArgs,
+      onChange: handleChange,
+      onClick: handleClick,
+    },
+  };
+};
 
 export default {
   title: 'Components/TextInput',
@@ -166,7 +193,7 @@ export default {
 };
 
 export const Default = (args) => {
-  const { defaultWidth, ...textInputArgs } = args;
+  const { defaultWidth, textInputArgs } = getTextInputStoryArgs(args);
 
   return (
     <div style={{ width: defaultWidth }}>
@@ -176,7 +203,7 @@ export const Default = (args) => {
 };
 
 export const Inline = (args) => {
-  const { defaultWidth, ...textInputArgs } = args;
+  const { defaultWidth, textInputArgs } = getTextInputStoryArgs(args);
 
   return (
     <div style={{ width: defaultWidth }}>
@@ -197,7 +224,7 @@ Inline.parameters = {
 };
 
 export const ReadOnly = (args) => {
-  const { defaultWidth, ...textInputArgs } = args;
+  const { defaultWidth, textInputArgs } = getTextInputStoryArgs(args);
 
   return (
     <div style={{ width: defaultWidth }}>
@@ -228,7 +255,7 @@ ReadOnly.parameters = {
 };
 
 export const _WithLayer = (args) => {
-  const { defaultWidth, ...textInputArgs } = args;
+  const { defaultWidth, textInputArgs } = getTextInputStoryArgs(args);
 
   return (
     <WithLayer>
@@ -242,7 +269,7 @@ export const _WithLayer = (args) => {
 };
 
 export const withAILabel = (args) => {
-  const { defaultWidth, ...textInputArgs } = args;
+  const { defaultWidth, textInputArgs } = getTextInputStoryArgs(args);
   const aiLabel = (
     <AILabel className="ai-label-container">
       <AILabelContent>


### PR DESCRIPTION
Closes #23303

Prevents the TextInput Storybook docs page from crashing after repeated clicks by keeping TextInput action payloads small and serializable. The stories still expose `onClick` and `onChange` actions, but they now send only the input value to Storybook instead of the full React event object.

### Changelog

**New**

- None.

**Changed**

- Updated TextInput stories to wrap `onClick` and `onChange` action handlers with compact payloads.
- Removed an unused icon import from the TextInput story file.

**Removed**

- None.

#### Testing / Reviewing

1. Use the repository Node version:

       nvm use

2. Run formatting and build checks:

       yarn prettier --check packages/react/src/components/TextInput/TextInput.stories.js
       yarn workspace @carbon/react storybook:build

3. Start React Storybook:

       yarn workspace @carbon/react storybook

4. Open the TextInput docs page.

5. Reproduce the original interaction:

   - Click the regular TextInput several times.
   - Navigate to the Read Only TextInput story and click it several times.
   - Repeat the interaction and confirm the iframe does not crash with `RangeError: Invalid string length`.

6. Optional focused unit test:

       ./node_modules/.bin/jest packages/react/src/components/TextInput/__tests__/TextInput-test.js --runInBand

   Note: In this local environment, all TextInput assertions passed, but the suite exited nonzero because `accessibility-checker` attempted a blocked network config request.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated Storybook story behavior
- [x] Wrote or ran focused checks that cover this change
- [x] Addressed any impact on accessibility (a11y)
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)