### PR TITLE
feat(react): v12 migrate Create pattern and Delete & Remove examples from ibm-products to core

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -233,6 +233,7 @@ export default defineConfig(
       '**/types/',
 
       'packages/*/examples/*',
+      'packages/*/src/examples/**/example/**',
 
       // Components
       'packages/components/demo/*.css',

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/preset-react": "^8.0.0",
     "@babel/runtime": "^8.0.0",
     "@carbon/cli": "workspace:packages/cli",
+    "@carbon/ibm-products": "2.98.0",
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",
     "@eslint/compat": "^2.0.1",

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -8,6 +8,7 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
 import remarkGfm from 'remark-gfm';
 import glob from 'fast-glob';
@@ -87,6 +88,10 @@ const config: StorybookConfig = {
         preprocessorOptions: {
           scss: {
             api: 'modern',
+            // Ensure Sass can resolve packages installed at the monorepo root
+            // (e.g. @carbon/ibm-products) even when the build runs from
+            // packages/react/ where those packages are not locally installed.
+            loadPaths: [path.resolve(configDir, '../../../node_modules')],
           },
         },
       },

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -7,6 +7,7 @@
 
 import type { StorybookConfig } from '@storybook/react-vite';
 
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -83,11 +84,52 @@ const config: StorybookConfig = {
     reactDocgen: 'react-docgen', // Favor docgen from prop-types instead of TS interfaces
   },
   async viteFinal(config) {
+    // Sass importer that resolves @carbon/ibm-products-styles/ imports to the
+    // absolute path in the monorepo root node_modules. Vite's internal Sass
+    // resolver walks up from the importing file's directory, which fails for
+    // files deep in src/examples/*/example/ because the package is installed at
+    // the repo root, not in packages/react/node_modules/.
+    const ibmProductsStylesRoot = path.resolve(
+      configDir,
+      '../../../node_modules/@carbon/ibm-products-styles'
+    );
+    const ibmProductsStylesImporter = {
+      canonicalize(url: string) {
+        if (!url.startsWith('@carbon/ibm-products-styles/')) return null;
+        const rel = url.slice('@carbon/ibm-products-styles/'.length);
+        // Try _<name>.scss, <name>.scss, <name>/_index.scss in order
+        const base = path.join(ibmProductsStylesRoot, rel);
+        const dir = path.dirname(base);
+        const name = path.basename(base);
+        const candidates = [
+          path.join(dir, `_${name}.scss`),
+          `${base}.scss`,
+          path.join(base, '_index.scss'),
+          path.join(base, 'index.scss'),
+        ];
+        for (const candidate of candidates) {
+          try {
+            fs.accessSync(candidate);
+            return new URL(`file://${candidate}`);
+          } catch {
+            // try next
+          }
+        }
+        return null;
+      },
+      load(canonicalUrl: URL) {
+        const filePath = canonicalUrl.pathname;
+        const contents = fs.readFileSync(filePath, 'utf-8');
+        return { contents, syntax: 'scss' as const };
+      },
+    };
+
     return mergeConfig(config, {
       css: {
         preprocessorOptions: {
           scss: {
             api: 'modern',
+            importers: [ibmProductsStylesImporter],
           },
         },
       },
@@ -124,17 +166,10 @@ const config: StorybookConfig = {
       ],
       resolve: {
         preserveSymlinks: true,
-        alias: [
-          { find: /^~@ibm\/plex\//, replacement: '@ibm/plex/' },
-          { find: /^~@ibm\/plex$/, replacement: '@ibm/plex' },
-          {
-            find: /^@carbon\/ibm-products-styles\//,
-            replacement: path.resolve(
-              configDir,
-              '../../../node_modules/@carbon/ibm-products-styles/'
-            ),
-          },
-        ],
+        alias: {
+          '~@ibm/plex': '@ibm/plex',
+          '~@ibm/plex/': '@ibm/plex/',
+        },
       },
       build: {
         rollupOptions: {

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -7,6 +7,7 @@
 
 import type { StorybookConfig } from '@storybook/react-vite';
 
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import remarkGfm from 'remark-gfm';
@@ -123,10 +124,17 @@ const config: StorybookConfig = {
       ],
       resolve: {
         preserveSymlinks: true,
-        alias: {
-          '~@ibm/plex': '@ibm/plex',
-          '~@ibm/plex/': '@ibm/plex/',
-        },
+        alias: [
+          { find: /^~@ibm\/plex\//, replacement: '@ibm/plex/' },
+          { find: /^~@ibm\/plex$/, replacement: '@ibm/plex' },
+          {
+            find: /^@carbon\/ibm-products-styles\//,
+            replacement: path.resolve(
+              configDir,
+              '../../../node_modules/@carbon/ibm-products-styles/'
+            ),
+          },
+        ],
       },
       build: {
         rollupOptions: {

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -88,10 +88,6 @@ const config: StorybookConfig = {
         preprocessorOptions: {
           scss: {
             api: 'modern',
-            // Ensure Sass can resolve packages installed at the monorepo root
-            // (e.g. @carbon/ibm-products) even when the build runs from
-            // packages/react/ where those packages are not locally installed.
-            loadPaths: [path.resolve(configDir, '../../../node_modules')],
           },
         },
       },
@@ -128,10 +124,20 @@ const config: StorybookConfig = {
       ],
       resolve: {
         preserveSymlinks: true,
-        alias: {
-          '~@ibm/plex': '@ibm/plex',
-          '~@ibm/plex/': '@ibm/plex/',
-        },
+        alias: [
+          { find: /^~@ibm\/plex\//, replacement: '@ibm/plex/' },
+          { find: /^~@ibm\/plex$/, replacement: '@ibm/plex' },
+          // Redirect @carbon/ibm-products SCSS imports to the copy installed
+          // at the monorepo root so the Sass resolver always finds it,
+          // regardless of where in the workspace the build is invoked.
+          {
+            find: /^@carbon\/ibm-products\//,
+            replacement: path.resolve(
+              configDir,
+              '../../../node_modules/@carbon/ibm-products/'
+            ),
+          },
+        ],
       },
       build: {
         rollupOptions: {

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -8,7 +8,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 import { fileURLToPath } from 'node:url';
-import path from 'node:path';
 
 import remarkGfm from 'remark-gfm';
 import glob from 'fast-glob';
@@ -124,20 +123,10 @@ const config: StorybookConfig = {
       ],
       resolve: {
         preserveSymlinks: true,
-        alias: [
-          { find: /^~@ibm\/plex\//, replacement: '@ibm/plex/' },
-          { find: /^~@ibm\/plex$/, replacement: '@ibm/plex' },
-          // Redirect @carbon/ibm-products SCSS imports to the copy installed
-          // at the monorepo root so the Sass resolver always finds it,
-          // regardless of where in the workspace the build is invoked.
-          {
-            find: /^@carbon\/ibm-products\//,
-            replacement: path.resolve(
-              configDir,
-              '../../../node_modules/@carbon/ibm-products/'
-            ),
-          },
-        ],
+        alias: {
+          '~@ibm/plex': '@ibm/plex',
+          '~@ibm/plex/': '@ibm/plex/',
+        },
       },
       build: {
         rollupOptions: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,6 +83,7 @@
     "@babel/preset-env": "^8.0.0",
     "@babel/preset-react": "^8.0.0",
     "@babel/preset-typescript": "^8.0.0",
+    "@carbon/ibm-products": "latest",
     "@carbon/test-utils": "^10.41.0",
     "@carbon/themes": "^11.81.0",
     "@figma/code-connect": "^2.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,6 +83,7 @@
     "@babel/preset-env": "^8.0.0",
     "@babel/preset-react": "^8.0.0",
     "@babel/preset-typescript": "^8.0.0",
+    "@carbon/ibm-products-styles": "2.94.0",
     "@carbon/test-utils": "^10.41.0",
     "@carbon/themes": "^11.81.0",
     "@figma/code-connect": "^2.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,7 +83,6 @@
     "@babel/preset-env": "^8.0.0",
     "@babel/preset-react": "^8.0.0",
     "@babel/preset-typescript": "^8.0.0",
-    "@carbon/ibm-products": "latest",
     "@carbon/test-utils": "^10.41.0",
     "@carbon/themes": "^11.81.0",
     "@figma/code-connect": "^2.0.0",

--- a/packages/react/product-migrated-components.mjs
+++ b/packages/react/product-migrated-components.mjs
@@ -30,6 +30,16 @@ export const productMigratedStoryGlobs = [
   // Pattern examples migrated from ibm-products
   '../src/examples/DeleteAndRemove/DeleteAndRemove.stories.js',
   '../src/examples/DeleteAndRemove/DeleteAndRemove.mdx',
+  '../src/examples/CreateFullPage/CreateFullPage.stories.js',
+  '../src/examples/CreateFullPage/CreateFullPage.mdx',
+  '../src/examples/CreateModal/CreateModal.stories.js',
+  '../src/examples/CreateModal/CreateModal.mdx',
+  '../src/examples/CreateSidePanel/CreateSidePanel.stories.js',
+  '../src/examples/CreateSidePanel/CreateSidePanel.mdx',
+  '../src/examples/CreateTearsheet/CreateTearsheet.stories.js',
+  '../src/examples/CreateTearsheet/CreateTearsheet.mdx',
+  '../src/examples/CreateTearsheetNarrow/CreateTearsheet.stories.js',
+  '../src/examples/CreateTearsheetNarrow/CreateTearsheet.mdx',
 ];
 
 /**

--- a/packages/react/product-migrated-components.mjs
+++ b/packages/react/product-migrated-components.mjs
@@ -27,6 +27,9 @@ export const productMigratedStoryGlobs = [
   '../src/components/Tearsheet/Tearsheet.stories.js',
   '../src/components/UserAvatar/UserAvatar.stories.js',
   '../src/components/TruncatedText/TruncatedText.stories.js',
+  // Pattern examples migrated from ibm-products
+  '../src/examples/DeleteAndRemove/DeleteAndRemove.stories.js',
+  '../src/examples/DeleteAndRemove/DeleteAndRemove.mdx',
 ];
 
 /**

--- a/packages/react/src/examples/CreateFullPage/CreateFullPage.mdx
+++ b/packages/react/src/examples/CreateFullPage/CreateFullPage.mdx
@@ -1,0 +1,295 @@
+import { Story, Controls, Source, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import * as stories from './CreateFullPage.stories';
+
+<Meta isTemplate />
+
+# CreateFullPage Pattern
+
+[Usage guidelines](https://carbondesignsystem.com/patterns/create-flows/usage/#full-page)
+|
+[Carbon page usage guidelines](https://www.carbondesignsystem.com/patterns/common-actions/#create)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [What is a Pattern?](#what-is-a-pattern)
+- [Getting Started](#getting-started)
+- [Example Usage](#example-usage)
+- [Architecture](#architecture)
+- [Customization](#customization)
+
+## Overview
+
+The `CreateFullPage` is a **pattern** (not a component) that provides a recipe
+for building multi-step workflow interfaces for creating resources using a full
+page experience. It demonstrates how to compose a full-page layout with StepFlow
+from `@carbon/utilities-react` for managing step navigation and state.
+
+> 💡 Try our
+> [StackBlitz example](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateFullPage/example)
+> for a complete implementation.
+
+[![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateFullPage/example)
+
+## What is a Pattern?
+
+Unlike components that are exported from the package, **patterns are recipes**
+that you copy into your codebase and customize to fit your specific needs. This
+approach offers:
+
+- **Full Control**: Modify the code to match your exact requirements
+- **No Breaking Changes**: Updates to the pattern don't affect your
+  implementation
+- **Seamless Customization**: Adapt the pattern without workarounds or prop
+  drilling
+- **Scalability**: Build upon the foundation with your own features
+
+The CreateFullPage pattern consists of:
+
+- `CreateFullPage.jsx` - Main full-page wrapper component
+- `CreateFullPageStep.jsx` - Individual step component
+- `CreateInfluencer.tsx` - Progress indicator component
+- `SimpleHeader.jsx` - Header with breadcrumbs and title
+- `ActionSet.tsx` - Footer action buttons
+- `BreadcrumbWithOverflow.jsx` - Breadcrumb with overflow handling
+- Styles and utilities
+
+## Getting Started
+
+1. **Copy the pattern code** from the
+   [example directory](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateFullPage/example/components)
+   into your project
+2. **Install dependencies**: `@carbon/react`, `@carbon/utilities-react`
+3. **Import and use** the pattern components in your application
+4. **Customize** as needed for your use case
+
+The pattern uses:
+
+- **StepProvider** (`@carbon/utilities-react`): Manages step navigation and form
+  state
+- **Carbon React components**: For form inputs, layout, and UI elements
+- **Custom components**: SimpleHeader, CreateInfluencer, ActionSet for layout
+  structure
+
+### Key Features
+
+- **Multi-step workflow**: Guide users through complex creation processes
+- **Progress indication**: Visual feedback with vertical progress indicators
+- **Breadcrumb navigation**: Optional breadcrumbs with overflow handling
+- **Page header**: Support for page title and breadcrumbs
+- **Step management**: Built-in navigation with back, next, and submit actions
+- **Form state management**: Integrated state management across steps
+- **Global header integration**: Works seamlessly with Carbon's global header
+- **Responsive design**: Adapts to different screen sizes
+
+### Key Implementation Steps
+
+1. **Copy Pattern Files**: Copy all pattern components from the example
+   directory into your project
+2. **StepProvider Wrapper**: Always wrap `CreateFullPage` with `StepProvider`
+   for step management
+3. **Form State Management**: Use `useStepContext()` hook to access and update
+   form state across steps
+4. **Close Handler**: Implement `onClose` callback to handle tearsheet dismissal
+5. **Submit Handler**: Implement `onRequestSubmit` callback for form submission
+6. **Customization**: Modify the copied pattern files to fit your specific needs
+
+## Example Usage
+
+### Standard CreateFullPage
+
+<Canvas
+  of={stories.CreateFullPage}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.CreateFullPage),
+    },
+  ]}
+/>
+
+### With Sections
+
+Demonstrates how to organize form fields into logical sections within a step.
+
+<Canvas
+  of={stories.CreateFullPageWithSections}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.CreateFullPageWithSections),
+    },
+  ]}
+/>
+
+### With Header
+
+Shows breadcrumbs and page title in the header.
+
+<Canvas
+  of={stories.CreateFullPageWithHeader}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.CreateFullPageWithHeader),
+    },
+  ]}
+/>
+
+### With Step in Error State
+
+Demonstrates error handling and validation in steps.
+
+<Canvas
+  of={stories.CreateFullPageWithStepInErrorState}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig(stories.CreateFullPageWithStepInErrorState),
+    },
+  ]}
+/>
+
+### With Global Header
+
+Shows integration with Carbon's global header and side navigation.
+
+<Canvas
+  of={stories.CreateFullPageWithGlobalHeader}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig(stories.CreateFullPageWithGlobalHeader),
+    },
+  ]}
+/>
+
+## Customization
+
+Since this is a pattern (not a component), you have full control to customize:
+
+### Modify Validation Logic
+
+Edit the `onNext` handler in your copied `CreateFullPageStep.jsx`:
+
+```jsx
+<CreateFullPageStep
+  title="Step title"
+  onNext={() => {
+    return new Promise((resolve, reject) => {
+      // Add your custom validation logic
+      if (!formState.requiredField) {
+        reject(new Error('Required field is missing'));
+      } else {
+        resolve();
+      }
+    });
+  }}
+  disableSubmit={!formState.requiredField}
+>
+  {/* Step content */}
+</CreateFullPageStep>
+```
+
+### Add Custom Header Content
+
+Modify the SimpleHeader component or pass custom breadcrumbs:
+
+```jsx
+<CreateFullPage
+  title="Custom Page Title"
+  breadcrumbs={[
+    { key: '0', label: 'Home', href: '/' },
+    { key: '1', label: 'Resources', href: '/resources' },
+    { key: '2', label: 'Create', isCurrentPage: true },
+  ]}
+  maxVisibleBreadcrumbs={3}
+  breadcrumbOverflowTooltipAlign="right"
+>
+  {/* Steps */}
+</CreateFullPage>
+```
+
+### Customize Action Buttons
+
+Modify the ActionSet component to change button labels or add custom buttons:
+
+```jsx
+<CreateFullPage
+  submitButtonText="Create Resource"
+  nextButtonText="Continue"
+  backButtonText="Previous"
+  cancelButtonText="Cancel"
+>
+  {/* Steps */}
+</CreateFullPage>
+```
+
+## Architecture
+
+The CreateFullPage pattern is built on top of:
+
+- **StepProvider** (`@carbon/utilities-react`): Manages step navigation and
+  state through `useStepContext`
+- **Carbon React components**: For form inputs, layout (Grid/Column), and UI
+  elements
+- **Custom Layout Components**:
+  - `SimpleHeader`: Handles breadcrumbs and page title
+  - `CreateInfluencer`: Displays vertical progress indicator
+  - `ActionSet`: Manages footer action buttons
+  - `BreadcrumbWithOverflow`: Handles breadcrumb overflow
+
+### Step Management
+
+Steps are managed using the `StepProvider` and `useStepContext` from
+`@carbon/utilities-react`. The provider wraps the CreateFullPage and provides:
+
+- Current step tracking
+- Navigation methods (`handleNext`, `handlePrevious`, `handleGoToStep`)
+- Form state management (`formState`, `setFormState`)
+- Total step count
+
+**Important**: Always wrap your `CreateFullPage` with `<StepProvider>` for
+proper step management.
+
+### Layout Structure
+
+The full-page layout consists of:
+
+1. **Header** (optional): Breadcrumbs and page title via SimpleHeader
+2. **Main Content Area**:
+   - **Influencer Panel** (left): Vertical progress indicator
+   - **Form Area** (right): Step content with form fields
+3. **Footer**: Action buttons (Cancel, Back, Next/Submit)
+
+### State Management
+
+- **Step state**: Managed by `StepProvider` from `@carbon/utilities-react`
+- **Form state**: Shared across steps via `useStepContext()` hook
+- **Loading state**: Managed internally for async `onNext` handlers
+- **Validation**: Each step can have its own `onNext` handler for validation
+
+### Form Validation
+
+All forms within the `CreateFullPage` should follow Carbon's guidelines for form
+validation:
+
+- The `Submit` button should be disabled until all required inputs are filled in
+  and valid
+- All required inputs should only throw an invalid error after the element loses
+  focus
+- All optional form fields should have an `(optional)` text at the end of the
+  input `labelText`. Optional should always be in parentheses
+- Use the `disableSubmit` prop on `CreateFullPageStep` to control button state
+- Use the `onNext` handler to perform async validation before proceeding
+
+You can find more information on how to validate your form fields in
+[Carbon's Form usage page](https://carbondesignsystem.com/components/form/usage/).
+
+## Feedback
+
+Help us improve this pattern by providing feedback through
+[GitHub issues](https://github.com/carbon-design-system/carbon/issues/new/choose).

--- a/packages/react/src/examples/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/react/src/examples/CreateFullPage/CreateFullPage.stories.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import './_storybook-styles.scss';
+import DocsPage from './CreateFullPage.mdx';
+import { StandardCreateFullPage as StandardCreateFullPageComponent } from './example/preview-components/StandardCreateFullPage';
+import { CreateFullPageWithSections as CreateFullPageWithSectionsComponent } from './example/preview-components/CreateFullPageWithSections';
+import { CreateFullPageWithHeader as CreateFullPageWithHeaderComponent } from './example/preview-components/CreateFullPageWithHeader';
+import { CreateFullPageWithStepInErrorState as CreateFullPageWithStepInErrorStateComponent } from './example/preview-components/CreateFullPageWithStepInErrorState';
+import { CreateFullPageWithGlobalHeader as CreateFullPageWithGlobalHeaderComponent } from './example/preview-components/CreateFullPageWithGlobalHeader';
+
+export default {
+  title: 'Examples/Create flows/Create Full Page',
+  component: () => {},
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      page: DocsPage,
+    },
+  },
+};
+
+const CreateFullPagePattern = (args) => {
+  return <StandardCreateFullPageComponent {...args} />;
+};
+
+export const CreateFullPage = CreateFullPagePattern.bind({});
+CreateFullPage.args = {};
+CreateFullPage.parameters = {
+  layout: 'fullscreen',
+};
+
+const CreateFullPageWithSectionsPattern = (args) => {
+  return <CreateFullPageWithSectionsComponent {...args} />;
+};
+
+export const CreateFullPageWithSections =
+  CreateFullPageWithSectionsPattern.bind({});
+CreateFullPageWithSections.args = {};
+CreateFullPageWithSections.parameters = {
+  layout: 'fullscreen',
+};
+
+const CreateFullPageWithHeaderPattern = (args) => {
+  return <CreateFullPageWithHeaderComponent {...args} />;
+};
+
+export const CreateFullPageWithHeader = CreateFullPageWithHeaderPattern.bind(
+  {}
+);
+CreateFullPageWithHeader.args = {};
+CreateFullPageWithHeader.parameters = {
+  layout: 'fullscreen',
+};
+
+const CreateFullPageWithStepInErrorStatePattern = (args) => {
+  return <CreateFullPageWithStepInErrorStateComponent {...args} />;
+};
+
+export const CreateFullPageWithStepInErrorState =
+  CreateFullPageWithStepInErrorStatePattern.bind({});
+CreateFullPageWithStepInErrorState.args = {};
+CreateFullPageWithStepInErrorState.parameters = {
+  layout: 'fullscreen',
+};
+
+const CreateFullPageWithGlobalHeaderPattern = (args) => {
+  return <CreateFullPageWithGlobalHeaderComponent {...args} />;
+};
+
+export const CreateFullPageWithGlobalHeader =
+  CreateFullPageWithGlobalHeaderPattern.bind({});
+CreateFullPageWithGlobalHeader.args = {};
+CreateFullPageWithGlobalHeader.parameters = {
+  layout: 'fullscreen',
+};

--- a/packages/react/src/examples/CreateFullPage/_storybook-styles.scss
+++ b/packages/react/src/examples/CreateFullPage/_storybook-styles.scss
@@ -1,0 +1,190 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config' as carbon-config;
+
+// Import example component styles for use in Storybook
+@use './example/index';
+
+$story-class: 'create-full-page-stories';
+$block-class: create-full-page-pattern;
+$step-block-class: #{$block-class}__step;
+
+// Viewport styles for full-page display
+.sbdocs .#{$story-class}__viewport {
+  background-color: $background;
+  block-size: 100vh;
+  box-shadow: 0 0 4px 1px $border-subtle-01;
+  color: $text-primary;
+  overflow-y: auto;
+  @supports (overflow-block: auto) {
+    overflow-block: auto;
+  }
+}
+
+.#{$story-class}__viewport {
+  overflow: hidden;
+  block-size: 100vh;
+}
+
+.#{$story-class}__viewport .#{$story-class}__content-container {
+  block-size: 100%;
+  overflow-y: auto;
+  @supports (overflow-block: auto) {
+    overflow-block: auto;
+  }
+}
+
+.#{$story-class}__viewport
+  .#{$story-class}__content-container--with-global-header {
+  block-size: calc(100% - #{$spacing-09});
+  margin-block-start: $spacing-09;
+}
+
+.#{$story-class}__step-fieldset--no-label
+  .#{carbon-config.$prefix}--fieldset
+  legend {
+  position: absolute;
+  overflow: hidden;
+  block-size: 1px;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  inline-size: 1px;
+  white-space: nowrap;
+}
+
+.#{carbon-config.$prefix}--form-item {
+  margin-block-end: $spacing-05;
+}
+
+.#{$story-class}__error--text {
+  @include type.type-style('label-01');
+
+  margin-block-end: $spacing-05;
+}
+
+.#{$block-class} {
+  display: grid;
+  block-size: 100%;
+  color: $text-primary;
+  grid-template-rows: minmax(auto, 100%);
+
+  &:has(.#{$block-class}__header) {
+    grid-template-rows: auto minmax(auto, 100%);
+  }
+}
+
+.#{$block-class} .#{$block-class}__content .#{carbon-config.$prefix}--grid {
+  margin-inline: 0;
+  padding-block-start: $spacing-06;
+}
+
+.#{$block-class} .#{$step-block-class}--hidden-step {
+  display: none;
+}
+
+.#{$block-class} .#{$step-block-class}--visible-step {
+  display: block;
+}
+
+.#{$block-class} .#{$block-class}__step-subtitle {
+  @include type.type-style('heading-compact-01');
+
+  margin-block-end: $spacing-03;
+}
+
+.#{$block-class} .#{$block-class}__step-description {
+  @include type.type-style('body-01');
+
+  margin-block-end: $spacing-06;
+}
+
+.#{$block-class} .#{carbon-config.$prefix}--fieldset {
+  margin-block-end: 0;
+}
+
+.#{$block-class} .#{$block-class}__step-fieldset > * {
+  margin-block-end: $spacing-05;
+}
+
+.#{$block-class} .#{carbon-config.$prefix}--modal-close {
+  display: none;
+}
+
+.#{$block-class}__influencer-and-body-container {
+  display: flex;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  max-block-size: 100%;
+}
+
+.#{$block-class} .#{$block-class}__influencer {
+  display: grid;
+  flex: 0 0 257px;
+  background-color: $layer-01;
+  border-inline-end: 1px solid $layer-accent-01;
+  grid-template-columns: 100%;
+  grid-template-rows: 1fr auto;
+}
+
+.#{$block-class} .#{$block-class}__left-nav {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  overflow-y: auto;
+  @supports (overflow-block: auto) {
+    overflow-block: auto;
+  }
+}
+
+.#{$block-class} .#{$block-class}__body {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.#{$block-class} .#{$block-class}__main {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  max-block-size: 100%;
+}
+
+.#{$block-class} .#{$block-class}__content {
+  overflow: auto;
+  flex-grow: 1;
+  background-color: $background;
+  color: $text-primary;
+  overflow-x: hidden;
+  @supports (overflow-inline: hidden) {
+    overflow-inline: hidden;
+  }
+
+  padding-block-start: $spacing-06;
+}
+
+.#{$block-class} .#{$block-class}__form {
+  block-size: 100%;
+}
+
+.#{$block-class} .#{$block-class}__step {
+  position: relative;
+  padding-block-end: $spacing-07;
+}
+
+.#{$block-class}__step .#{carbon-config.$prefix}--css-grid {
+  margin-inline-start: 0;
+}
+
+.#{$block-class}__step-title {
+  @include type.type-style('heading-04');
+
+  margin-block-end: $spacing-05;
+}

--- a/packages/react/src/examples/CreateFullPage/example/App.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/App.tsx
@@ -1,0 +1,78 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import { StandardCreateFullPage } from './preview-components/StandardCreateFullPage';
+import { CreateFullPageWithSections } from './preview-components/CreateFullPageWithSections';
+import { CreateFullPageWithHeader } from './preview-components/CreateFullPageWithHeader';
+import { CreateFullPageWithStepInErrorState } from './preview-components/CreateFullPageWithStepInErrorState';
+import { CreateFullPageWithGlobalHeader } from './preview-components/CreateFullPageWithGlobalHeader';
+
+function App() {
+  const [showStandard, setShowStandard] = useState(false);
+  const [showSections, setShowSections] = useState(false);
+  const [showHeader, setShowHeader] = useState(false);
+  const [showError, setShowError] = useState(false);
+  const [showGlobalHeader, setShowGlobalHeader] = useState(false);
+
+  if (showStandard) return <StandardCreateFullPage />;
+  if (showSections) return <CreateFullPageWithSections />;
+  if (showHeader) return <CreateFullPageWithHeader />;
+  if (showError) return <CreateFullPageWithStepInErrorState />;
+  if (showGlobalHeader) return <CreateFullPageWithGlobalHeader />;
+
+  return (
+    <div className="example-container">
+      <h1>Create Full Page Examples</h1>
+
+      <section className="example-section">
+        <h2>Standard Create Full Page</h2>
+        <p>Basic multi-step form with 5 steps</p>
+        <Button onClick={() => setShowStandard(true)}>
+          Launch Standard Full Page
+        </Button>
+      </section>
+
+      <section className="example-section">
+        <h2>Create Full Page with Sections</h2>
+        <p>Form with section dividers within steps</p>
+        <Button onClick={() => setShowSections(true)}>
+          Launch Full Page with Sections
+        </Button>
+      </section>
+
+      <section className="example-section">
+        <h2>Create Full Page with Header</h2>
+        <p>Includes breadcrumbs and page title</p>
+        <Button onClick={() => setShowHeader(true)}>
+          Launch Full Page with Header
+        </Button>
+      </section>
+
+      <section className="example-section">
+        <h2>Create Full Page with Step in Error State</h2>
+        <p>Demonstrates error handling and validation</p>
+        <Button onClick={() => setShowError(true)}>
+          Launch Full Page with Error State
+        </Button>
+      </section>
+
+      <section className="example-section">
+        <h2>Create Full Page with Global Header</h2>
+        <p>Integration with Carbon global header and side nav</p>
+        <Button onClick={() => setShowGlobalHeader(true)}>
+          Launch Full Page with Global Header
+        </Button>
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/packages/react/src/examples/CreateFullPage/example/components/CreateFullPage.jsx
+++ b/packages/react/src/examples/CreateFullPage/example/components/CreateFullPage.jsx
@@ -1,0 +1,319 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  ButtonSet,
+  ComposedModal,
+  Form,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  BreadcrumbItem,
+  OverflowMenu,
+  OverflowMenuItem,
+} from '@carbon/react';
+import {
+  StepProvider,
+  StepGroup,
+  useStepContext,
+} from '@carbon/utilities-react';
+import { preview__PageHeader as PageHeader } from '@carbon/ibm-products';
+import { CreateInfluencer } from './CreateInfluencer';
+
+const blockClass = 'create-full-page-pattern';
+
+const CreateFullPage = ({
+  breadcrumbs,
+  breadcrumbsOverflowAriaLabel,
+  breadcrumbOverflowTooltipAlign,
+  title,
+  secondaryTitle,
+  children,
+  cancelButtonText,
+  submitButtonText,
+  nextButtonText,
+  backButtonText,
+  modalTitle,
+  modalDescription,
+  modalDangerButtonText,
+  modalSecondaryButtonText,
+  onClose,
+  onRequestSubmit,
+}) => {
+  return (
+    <StepProvider>
+      <CreateFullPageContent
+        breadcrumbs={breadcrumbs}
+        breadcrumbsOverflowAriaLabel={breadcrumbsOverflowAriaLabel}
+        breadcrumbOverflowTooltipAlign={breadcrumbOverflowTooltipAlign}
+        title={title}
+        secondaryTitle={secondaryTitle}
+        cancelButtonText={cancelButtonText}
+        submitButtonText={submitButtonText}
+        nextButtonText={nextButtonText}
+        backButtonText={backButtonText}
+        modalTitle={modalTitle}
+        modalDescription={modalDescription}
+        modalDangerButtonText={modalDangerButtonText}
+        modalSecondaryButtonText={modalSecondaryButtonText}
+        onClose={onClose}
+        onRequestSubmit={onRequestSubmit}
+      >
+        {children}
+      </CreateFullPageContent>
+    </StepProvider>
+  );
+};
+
+const CreateFullPageContent = ({
+  breadcrumbs,
+  breadcrumbsOverflowAriaLabel,
+  breadcrumbOverflowTooltipAlign,
+  title,
+  secondaryTitle,
+  children,
+  cancelButtonText,
+  submitButtonText,
+  nextButtonText,
+  backButtonText,
+  modalTitle,
+  modalDescription,
+  modalDangerButtonText,
+  modalSecondaryButtonText,
+  onClose,
+  onRequestSubmit,
+  onClickInfluencerStep,
+}) => {
+  const {
+    currentStep,
+    totalSteps,
+    handleNext,
+    handlePrevious,
+    handleGoToStep,
+    formState,
+    setFormState,
+  } = useStepContext();
+
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [modalIsOpen, setModalIsOpen] = React.useState(false);
+
+  // Build step data for CreateInfluencer and collect step props
+  const stepData = React.Children.map(children, (child, index) => {
+    if (React.isValidElement(child)) {
+      return {
+        title: child.props.title,
+        secondaryLabel: child.props.secondaryLabel,
+        shouldIncludeStep: true,
+        disableSubmit: child.props.disableSubmit,
+        invalid: child.props.invalid,
+        onNext: child.props.onNext,
+        onPrevious: child.props.onPrevious,
+      };
+    }
+    return null;
+  }).filter(Boolean);
+
+  // Get current step's disableSubmit value and onNext handler
+  const currentStepData = stepData[currentStep - 1];
+  const isNextDisabled = currentStepData?.disableSubmit || false;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (currentStep === totalSteps) {
+      setIsSubmitting(true);
+      try {
+        await onRequestSubmit?.(formState);
+        // Don't reset to step 1 after submission - let the parent handle navigation
+      } finally {
+        setIsSubmitting(false);
+      }
+    } else {
+      // Call the current step's onNext handler if it exists
+      const currentOnNext = currentStepData?.onNext;
+      if (currentOnNext) {
+        setIsSubmitting(true);
+        try {
+          await currentOnNext();
+          handleNext();
+        } catch (error) {
+          // If onNext rejects, don't proceed to next step
+          console.error('Step validation failed:', error);
+        } finally {
+          setIsSubmitting(false);
+        }
+      } else {
+        handleNext();
+      }
+    }
+  };
+
+  const handleBack = () => {
+    if (currentStep > 1) {
+      handlePrevious();
+    }
+  };
+
+  const handleCancel = () => {
+    console.log('cancel partition');
+
+    setModalIsOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setModalIsOpen(false);
+  };
+
+  const handleModalConfirm = () => {
+    onClose?.();
+    handleGoToStep(1);
+    setFormState({});
+    setModalIsOpen(false);
+  };
+
+  return (
+    <div className={blockClass}>
+      {(title || breadcrumbs) && (
+        <PageHeader.Root className={`${blockClass}__header`}>
+          <PageHeader.BreadcrumbBar>
+            <PageHeader.BreadcrumbOverflow
+              renderOverflowBreadcrumb={(hiddenItems) => (
+                <BreadcrumbItem data-floating-menu-container>
+                  <OverflowMenu
+                    align="bottom"
+                    aria-label={
+                      breadcrumbsOverflowAriaLabel ||
+                      'Open and close additional breadcrumb item list.'
+                    }
+                  >
+                    {hiddenItems.map((el, index) => (
+                      <OverflowMenuItem key={index} itemText={el.innerText} />
+                    ))}
+                  </OverflowMenu>
+                </BreadcrumbItem>
+              )}
+            >
+              {breadcrumbs?.map((crumb, index) => (
+                <BreadcrumbItem
+                  key={crumb.key || index}
+                  href={crumb.href || '/#'}
+                >
+                  {crumb.label}
+                </BreadcrumbItem>
+              ))}
+            </PageHeader.BreadcrumbOverflow>
+          </PageHeader.BreadcrumbBar>
+          <PageHeader.Content title={title} />
+        </PageHeader.Root>
+      )}
+      <div className={`${blockClass}__influencer-and-body-container`}>
+        <div className={`${blockClass}__influencer`}>
+          <CreateInfluencer
+            stepData={stepData}
+            currentStep={currentStep}
+            title={secondaryTitle}
+            onClickStep={onClickInfluencerStep}
+          />
+        </div>
+        <div className={`${blockClass}__body`}>
+          <div className={`${blockClass}__main`}>
+            <div className={`${blockClass}__content`}>
+              <Form
+                className={`${blockClass}__form`}
+                aria-label={title}
+                onSubmit={handleSubmit}
+              >
+                <StepGroup>{children}</StepGroup>
+              </Form>
+            </div>
+            <ButtonSet
+              fluid
+              className={`${blockClass}__buttons ${blockClass}__footer-button-set`}
+            >
+              <Button kind="ghost" size="2xl" onClick={handleCancel}>
+                {cancelButtonText}
+              </Button>
+              <Button
+                kind="secondary"
+                size="2xl"
+                onClick={handleBack}
+                disabled={currentStep === 1}
+              >
+                {backButtonText}
+              </Button>
+              <Button
+                kind="primary"
+                size="2xl"
+                onClick={handleSubmit}
+                disabled={isNextDisabled || isSubmitting}
+              >
+                {currentStep === totalSteps ? submitButtonText : nextButtonText}
+              </Button>
+            </ButtonSet>
+          </div>
+        </div>
+        <ComposedModal
+          className={`${blockClass}__modal`}
+          size="sm"
+          open={modalIsOpen}
+          aria-label={modalTitle}
+          onClose={handleModalClose}
+        >
+          <ModalHeader title={modalTitle} />
+          <ModalBody>
+            <p>{modalDescription}</p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              type="button"
+              kind="secondary"
+              onClick={handleModalClose}
+              data-modal-primary-focus
+            >
+              {modalSecondaryButtonText}
+            </Button>
+            <Button type="button" kind="danger" onClick={handleModalConfirm}>
+              {modalDangerButtonText}
+            </Button>
+          </ModalFooter>
+        </ComposedModal>
+      </div>
+    </div>
+  );
+};
+
+CreateFullPage.propTypes = {
+  backButtonText: PropTypes.string,
+  breadcrumbsOverflowAriaLabel: PropTypes.string,
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      label: PropTypes.string.isRequired,
+      href: PropTypes.string,
+      isCurrentPage: PropTypes.bool,
+    })
+  ),
+  cancelButtonText: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  maxVisibleBreadcrumbs: PropTypes.number,
+  modalDangerButtonText: PropTypes.string.isRequired,
+  modalDescription: PropTypes.string,
+  modalSecondaryButtonText: PropTypes.string.isRequired,
+  modalTitle: PropTypes.string.isRequired,
+  nextButtonText: PropTypes.string.isRequired,
+  noTrailingSlash: PropTypes.bool,
+  onClose: PropTypes.func,
+  onRequestSubmit: PropTypes.func.isRequired,
+  secondaryTitle: PropTypes.string,
+  submitButtonText: PropTypes.string.isRequired,
+  title: PropTypes.string,
+};
+
+export { CreateFullPage };
+export default CreateFullPage;

--- a/packages/react/src/examples/CreateFullPage/example/components/CreateFullPageStep.jsx
+++ b/packages/react/src/examples/CreateFullPage/example/components/CreateFullPageStep.jsx
@@ -1,0 +1,93 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Column, FormGroup, Grid, Heading, Section } from '@carbon/react';
+
+const blockClass = 'create-full-page-pattern';
+const stepBlockClass = `${blockClass}__step`;
+
+export const CreateFullPageStep = ({
+  title,
+  subtitle,
+  description,
+  children,
+  hasFieldset,
+  fieldsetLegendText,
+  // Note: disableSubmit, onNext, onPrevious, secondaryLabel are passed to CreateFullPage parent
+  // and handled there, not used directly in this component
+}) => {
+  const span = { span: 50 }; // Half width
+
+  const renderDescription = () => {
+    if (description) {
+      const common = {
+        children: description,
+        className: `${blockClass}__step-description`,
+        ...span,
+      };
+
+      if (typeof description === 'string') {
+        return <Column {...common} as="p" />;
+      } else if (React.isValidElement(description)) {
+        return <Column {...common} as="div" />;
+      }
+    }
+    return null;
+  };
+
+  return (
+    <Section className={stepBlockClass}>
+      <Grid>
+        <Column {...span}>
+          <Grid>
+            <Column
+              className={`${blockClass}__step-title`}
+              as={Heading}
+              {...span}
+            >
+              {title}
+            </Column>
+
+            {subtitle && (
+              <Column
+                className={`${blockClass}__step-subtitle`}
+                as="p"
+                {...span}
+              >
+                {subtitle}
+              </Column>
+            )}
+
+            {renderDescription()}
+          </Grid>
+        </Column>
+      </Grid>
+
+      {hasFieldset ? (
+        <FormGroup
+          legendText={fieldsetLegendText}
+          className={`${blockClass}__step-fieldset`}
+        >
+          {children}
+        </FormGroup>
+      ) : (
+        children
+      )}
+    </Section>
+  );
+};
+
+CreateFullPageStep.propTypes = {
+  children: PropTypes.node.isRequired,
+  description: PropTypes.node,
+  fieldsetLegendText: PropTypes.string,
+  hasFieldset: PropTypes.bool,
+  subtitle: PropTypes.string,
+  title: PropTypes.node.isRequired,
+};

--- a/packages/react/src/examples/CreateFullPage/example/components/CreateInfluencer.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/components/CreateInfluencer.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React, { PropsWithChildren, ReactNode } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Heading, ProgressIndicator, ProgressStep } from '@carbon/react';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = 'create-influencer';
+const componentName = 'CreateInfluencer';
+
+interface Step {
+  introStep?: boolean;
+  invalid?: boolean;
+  secondaryLabel?: string;
+  shouldIncludeStep?: boolean;
+  title?: ReactNode;
+}
+interface CreateInfluencerProps {
+  className?: string;
+  currentStep: number;
+  onClickStep?: (step: number) => void;
+  stepData: Step[];
+  title?: string | undefined;
+}
+
+export const CreateInfluencer = ({
+  className,
+  currentStep,
+  onClickStep,
+  stepData,
+  title,
+}: PropsWithChildren<CreateInfluencerProps>) => {
+  const getNumberOfDynamicStepsBeforeCurrentStep = (array, key) => {
+    const dynamicSteps: any[] = [];
+    array.forEach((item, index) => {
+      if (array[index]?.[key] === false && index <= currentStep - 1) {
+        dynamicSteps.push(item);
+      }
+    });
+    return dynamicSteps.length;
+  };
+
+  // renders the step progression components in the left influencer area
+  const renderProgressSteps = () => {
+    const extractedSteps = stepData?.filter((item) => !item?.introStep);
+    const progressSteps = extractedSteps?.filter(
+      (item) => item?.shouldIncludeStep
+    );
+
+    // To get the ProgressIndicator's `currentIndex`, accounting for dynamic steps,
+    // we need to subtract the number of !shouldIncludeStep/s before the current step
+    // which we get from `getNumberOfDynamicStepsBeforeCurrentStep()`
+    const totalDynamicSteps =
+      getNumberOfDynamicStepsBeforeCurrentStep(stepData, 'shouldIncludeStep') ||
+      0;
+
+    return (
+      <div className={`${blockClass}__left-nav`}>
+        {title && <Heading className={`${blockClass}__title`}>{title}</Heading>}
+        {currentStep === 1 && stepData[0]?.introStep ? null : (
+          <ProgressIndicator
+            currentIndex={
+              stepData[0]?.introStep
+                ? currentStep - totalDynamicSteps - 2 // minus 2 because we need to account for the intro step in addition to `currentIndex` being 0 index based and our steps being 1 index based
+                : currentStep - totalDynamicSteps - 1 // minus 1 because ProgressIndicator currentIndex prop is 0 index based, but our steps are 1 index based
+            }
+            spaceEqually
+            vertical
+            className={cx(`${blockClass}__progress-indicator`)}
+            onChange={onClickStep}
+          >
+            {progressSteps.map((step: Step, stepIndex: number) => {
+              return (
+                <ProgressStep
+                  label={step?.title as string}
+                  key={stepIndex}
+                  secondaryLabel={step.secondaryLabel || undefined}
+                  invalid={step.invalid}
+                />
+              );
+            })}
+          </ProgressIndicator>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className={cx(blockClass, className)}>{renderProgressSteps()}</div>
+  );
+};
+
+CreateInfluencer.displayName = componentName;

--- a/packages/react/src/examples/CreateFullPage/example/index.html
+++ b/packages/react/src/examples/CreateFullPage/example/index.html
@@ -1,0 +1,20 @@
+<!--
+@license
+
+Copyright IBM Corp. 2026
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CreateFullPage Pattern Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/examples/CreateFullPage/example/index.scss
+++ b/packages/react/src/examples/CreateFullPage/example/index.scss
@@ -15,7 +15,7 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/config' as carbon-config;
 @use '@carbon/styles/scss/components/button/button' as button-mixin;
-@use '@carbon/ibm-products/scss/components/Pageheader';
+@use '@carbon/ibm-products-styles/scss/components/Pageheader';
 
 
 // Pattern-specific block classes

--- a/packages/react/src/examples/CreateFullPage/example/index.scss
+++ b/packages/react/src/examples/CreateFullPage/example/index.scss
@@ -15,7 +15,7 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/config' as carbon-config;
 @use '@carbon/styles/scss/components/button/button' as button-mixin;
-@use '@carbon/ibm-products-styles/scss/components/Pageheader';
+@use '@carbon/ibm-products-styles/scss/components/PageHeader';
 
 
 // Pattern-specific block classes

--- a/packages/react/src/examples/CreateFullPage/example/index.scss
+++ b/packages/react/src/examples/CreateFullPage/example/index.scss
@@ -1,0 +1,369 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Standard imports.
+@use '@carbon/layout/scss/convert' as *;
+@use '@carbon/styles/scss/breakpoint' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/config' as carbon-config;
+@use '@carbon/styles/scss/components/button/button' as button-mixin;
+@use '@carbon/ibm-products/scss/components/Pageheader';
+
+
+// Pattern-specific block classes
+$block-class: create-full-page-pattern;
+$breadcrumb-block-class: breadcrumb-with-overflow;
+$influencer-block-class: create-influencer;
+
+// BreadcrumbWithOverflow styles
+.#{$breadcrumb-block-class} {
+  display: block;
+}
+
+.#{$breadcrumb-block-class}__space {
+  position: relative;
+  display: block;
+  inline-size: 100%;
+  white-space: nowrap;
+}
+
+.#{$breadcrumb-block-class}__breadcrumb-container.#{$breadcrumb-block-class}__breadcrumb-container-with-items {
+  display: inline-flex;
+  inline-size: 100%;
+}
+
+.#{$breadcrumb-block-class}__breadcrumb-container
+  .#{carbon-config.$prefix}--breadcrumb {
+  flex-wrap: nowrap;
+  align-items: flex-start;
+  inline-size: 100%;
+}
+
+.#{$breadcrumb-block-class}__breadcrumb-container--hidden {
+  position: absolute;
+  overflow: hidden;
+  block-size: 1px;
+  clip: rect(0, 0, 0, 0);
+  inline-size: 1px;
+  white-space: nowrap;
+}
+
+.#{$breadcrumb-block-class}__breadcrumb-back {
+  display: none;
+
+  svg {
+    fill: $icon-primary;
+  }
+}
+
+.#{$breadcrumb-block-class}__back__button.#{carbon-config.$prefix}--btn {
+  padding: 0;
+  min-block-size: revert;
+}
+
+.#{$breadcrumb-block-class}__back__button.#{carbon-config.$prefix}--btn--ghost:hover {
+  background-color: inherit;
+}
+
+@include breakpoint-down(md) {
+  .#{carbon-config.$prefix}--breadcrumb-item {
+    display: none;
+  }
+
+  .#{$breadcrumb-block-class}__breadcrumb-back,
+  .#{carbon-config.$prefix}--breadcrumb-item:last-child {
+    display: inline-flex;
+    vertical-align: middle;
+  }
+
+  .#{$breadcrumb-block-class}__displayed-breadcrumb:last-child {
+    max-inline-size: calc(100% - $spacing-07);
+  }
+}
+
+.#{carbon-config.$prefix}--breadcrumb-item:last-child {
+  display: inline-flex;
+}
+
+.#{$breadcrumb-block-class}__displayed-breadcrumb:last-child {
+  display: inline-flex;
+}
+
+.#{$breadcrumb-block-class}__displayed-breadcrumb:last-child
+  .#{carbon-config.$prefix}--link {
+  display: inline-block;
+  overflow: hidden;
+  inline-size: 100%;
+  text-overflow: ellipsis;
+}
+
+.#{$breadcrumb-block-class}__overflow-menu {
+  /* stylelint-disable-next-line carbon/type-use */
+  line-height: 0;
+}
+
+// CreateInfluencer styles
+$influencerAnimationStart: calc(-1 * #{$spacing-05});
+
+@keyframes influencer-menu-entrance {
+  0% {
+    opacity: 0;
+    /* stylelint-disable-next-line carbon/layout-use */
+    transform: translateX($influencerAnimationStart);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes influencer-menu-exit {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  100% {
+    opacity: 0;
+    /* stylelint-disable-next-line carbon/layout-use */
+    transform: translateX($influencerAnimationStart);
+  }
+}
+
+.#{$influencer-block-class} {
+  display: grid;
+  padding: $spacing-06 $spacing-07;
+  block-size: 100%;
+  grid-template-columns: 100%;
+  grid-template-rows: 1fr auto;
+}
+
+.#{$influencer-block-class}__left-nav {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  overflow-y: auto;
+  @supports (overflow-block: auto) {
+    overflow-block: auto;
+  }
+}
+
+.#{$influencer-block-class}__title {
+  @include type.type-style('heading-03');
+
+  margin-block-end: $spacing-06;
+}
+
+.#{$influencer-block-class}__view-all-toggle {
+  padding: $spacing-06;
+  grid-column: 1 / -1;
+  grid-row: -1 / -1;
+}
+
+.#{$influencer-block-class}__side-nav-opening,
+.#{$influencer-block-class}__progress-indicator-opening {
+  /* stylelint-disable-next-line carbon/motion-easing-use */
+  animation: influencer-menu-entrance $duration-moderate-02 1;
+  animation-fill-mode: forwards;
+  @include motion(entrance, productive);
+}
+
+.#{$influencer-block-class}__side-nav-closing,
+.#{$influencer-block-class}__progress-indicator-closing {
+  /* stylelint-disable-next-line carbon/motion-easing-use */
+  animation: influencer-menu-exit $duration-moderate-02 1;
+  animation-fill-mode: forwards;
+  @include motion(exit, productive);
+}
+
+@media (prefers-reduced-motion) {
+  .#{$influencer-block-class}__side-nav-opening,
+  .#{$influencer-block-class}__progress-indicator-opening,
+  .#{$influencer-block-class}__side-nav-closing,
+  .#{$influencer-block-class}__progress-indicator-closing {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+// CreateFullPage pattern styles
+.#{$block-class} {
+  display: grid;
+  block-size: 100%;
+  color: $text-primary;
+  grid-template-rows: minmax(auto, 100%);
+
+  &:has(.#{$block-class}__header) {
+    grid-template-rows: auto minmax(auto, 100%);
+  }
+}
+
+.#{$block-class}__influencer-and-body-container {
+  display: flex;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  max-block-size: 100%;
+}
+
+.#{$block-class}__influencer {
+  display: grid;
+  flex: 0 0 257px;
+  background-color: $layer-01;
+  border-inline-end: 1px solid $layer-accent-01;
+  grid-template-columns: 100%;
+  grid-template-rows: 1fr auto;
+}
+
+.#{$block-class}__left-nav {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  overflow-y: auto;
+  @supports (overflow-block: auto) {
+    overflow-block: auto;
+  }
+}
+
+.#{$block-class}__body {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.#{$block-class}__main {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  max-block-size: 100%;
+}
+
+.#{$block-class}__content {
+  overflow: auto;
+  flex-grow: 1;
+  background-color: $background;
+  color: $text-primary;
+  overflow-x: hidden;
+  @supports (overflow-inline: hidden) {
+    overflow-inline: hidden;
+  }
+
+  padding-block-start: $spacing-06;
+}
+
+.#{$block-class}__content .#{carbon-config.$prefix}--grid {
+  margin-inline: 0;
+  padding-block-start: $spacing-06;
+}
+
+.#{$block-class}__form {
+  block-size: 100%;
+
+  .#{carbon-config.$prefix}--inline-notification--error {
+    margin-block-start: $spacing-04;
+  }
+}
+
+.#{$block-class}__buttons {
+  display: inline-flex;
+  border-block-start: 1px solid $layer-accent-01;
+  min-inline-size: 100%;
+
+  &.#{$block-class}__footer-button-set {
+    &.#{carbon-config.$prefix}--btn-set--fluid {
+      @include button-mixin.button-set-fluid-layout(
+        $min-inline-size: to-rem(120px)
+      );
+    }
+  }
+}
+
+.#{$block-class}__section-divider {
+  position: relative;
+  display: block;
+  margin: $spacing-07 calc(-1 * #{$spacing-08}) $spacing-07
+    calc(-1 * #{$spacing-08});
+  block-size: 1px;
+  inline-size: 0;
+
+  &::after {
+    position: absolute;
+    background-color: $layer-accent-01;
+    block-size: 1px;
+    content: '';
+    inline-size: 100vw;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+  }
+}
+
+.#{$block-class}__header {
+  button:first-of-type {
+    background: none;
+  }
+}
+
+// Example app container styles
+.example-container {
+  padding: $spacing-07;
+  max-inline-size: 800px;
+
+  h1 {
+    @include type.type-style('heading-05');
+
+    margin-block-end: $spacing-05;
+  }
+
+  .example-section {
+    padding: $spacing-05;
+    border: 1px solid $border-subtle-01;
+    border-radius: 4px;
+    margin-block-end: $spacing-07;
+
+    h2 {
+      @include type.type-style('heading-03');
+
+      margin-block-end: $spacing-03;
+    }
+
+    p {
+      @include type.type-style('body-short-01');
+
+      color: $text-secondary;
+      margin-block-end: $spacing-05;
+    }
+  }
+}
+
+// Viewport styles for full-page display
+.create-full-page-stories__viewport {
+  position: fixed;
+  z-index: 9999;
+  overflow: hidden;
+  background-color: $background;
+  block-size: 100vh;
+  inline-size: 100vw;
+  inset: 0;
+}
+
+.create-full-page-stories__viewport
+  .create-full-page-stories__content-container {
+  block-size: 100%;
+  overflow-y: auto;
+  @supports (overflow-block: auto) {
+    overflow-block: auto;
+  }
+}
+
+.create-full-page-stories__viewport
+  .create-full-page-stories__content-container--with-global-header {
+  block-size: calc(100% - #{$spacing-09});
+  margin-block-start: $spacing-09;
+}

--- a/packages/react/src/examples/CreateFullPage/example/main.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/main.tsx
@@ -1,0 +1,24 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.scss';
+
+// eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/packages/react/src/examples/CreateFullPage/example/package.json
+++ b/packages/react/src/examples/CreateFullPage/example/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ibm-products-createfullpage-pattern-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the createfullpage pattern using Carbon for IBM Products",
+  "license": "Apache-2.0",
+  "main": "index.html",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@carbon/ibm-products": "latest",
+    "@carbon/react": "latest",
+    "@carbon/utilities": "latest",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "sass": "^1.93.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^8.0.0"
+  }
+}

--- a/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithGlobalHeader.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithGlobalHeader.tsx
@@ -1,0 +1,297 @@
+// @ts-nocheck
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  Checkbox,
+  Column,
+  DefinitionTooltip,
+  Grid,
+  Header,
+  HeaderMenuButton,
+  HeaderName,
+  InlineNotification,
+  NumberInput,
+  RadioButton,
+  RadioButtonGroup,
+  SideNav,
+  SideNavItems,
+  SideNavLink,
+  TextInput,
+  Toggle,
+} from '@carbon/react';
+import { usePrefix } from '@carbon/react';
+
+import { CreateFullPage } from '../components/CreateFullPage';
+import { CreateFullPageStep } from '../components/CreateFullPageStep';
+
+const storyClass = 'create-full-page-stories';
+
+export const CreateFullPageWithGlobalHeader = () => {
+  const carbonPrefix = usePrefix();
+  const [textInput, setTextInput] = useState('');
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const [shouldReject, setShouldReject] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [simulatedDelay] = useState(750);
+  const [shouldIncludeAdditionalStep, setShouldIncludeAdditionalStep] =
+    useState(false);
+  const [isSideNavExpanded, setIsSideNavExpanded] = useState(false);
+  const [topicName2, setTopicName2] = useState('');
+  const [numberInput1, setNumberInput1] = useState(0);
+  const [numberInput2, setNumberInput2] = useState(0);
+  const [replicas, setReplicas] = useState('');
+  const [replicationFactor, setReplicationFactor] = useState('standard');
+
+  return (
+    <div className={`${storyClass}__viewport`}>
+      <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
+      <Header aria-label="IBM Platform Name">
+        <HeaderMenuButton
+          aria-label="Open menu"
+          isCollapsible
+          onClick={() => {
+            setIsSideNavExpanded((prev) => !prev);
+          }}
+          isActive={isSideNavExpanded}
+        />
+        <HeaderName href="#" prefix="IBM">
+          Products application
+        </HeaderName>
+        <SideNav
+          aria-label="Side navigation"
+          expanded={isSideNavExpanded}
+          isFixedNav
+        >
+          <SideNavItems>
+            <SideNavLink
+              href="https://pages.github.ibm.com/carbon/ibm-products/"
+              target="_blank"
+            >
+              Sample link: Carbon for IBM Products
+            </SideNavLink>
+          </SideNavItems>
+        </SideNav>
+      </Header>
+      <div
+        className={`${storyClass}__content-container ${storyClass}__content-container--with-global-header`}
+      >
+        <CreateFullPage
+          title="Page title"
+          breadcrumbsOverflowAriaLabel="Open and close additional breadcrumb item list."
+          breadcrumbs={[
+            { key: '0', label: 'Breadcrumb 1', href: '/', title: 'home page' },
+            { key: '1', label: 'Breadcrumb 2', href: '/' },
+            { key: '2', label: 'Breadcrumb 3', href: '/' },
+            { key: '3', label: 'Breadcrumb 4', isCurrentPage: true },
+          ]}
+          breadcrumbOverflowTooltipAlign="right"
+          secondaryTitle="Create topic"
+          nextButtonText="Next"
+          backButtonText="Back"
+          cancelButtonText="Cancel"
+          submitButtonText="Create"
+          modalTitle="Are you sure you want to cancel?"
+          modalDescription="If you cancel, the information you have entered won't be saved."
+          modalDangerButtonText="Cancel partition"
+          modalSecondaryButtonText="Return to form"
+          onRequestSubmit={async () => {
+            console.log('Form submitted');
+          }}
+          onClose={() => {
+            console.log('CreateFullPage closed');
+          }}
+        >
+          <CreateFullPageStep
+            className={`${storyClass}__step-fieldset--no-label`}
+            title="Partition"
+            subtitle="One or more partitions make up a topic. A partition is an ordered list of messages."
+            description="Partitions are distributed across the brokers in order to increase the scalability of your topic. You can also use them to distribute messages across the members of a consumer group."
+            onNext={() => {
+              return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  if (shouldReject) {
+                    setHasSubmitError(true);
+                    reject();
+                  }
+                  setIsInvalid(false);
+                  resolve();
+                }, simulatedDelay);
+              });
+            }}
+            disableSubmit={!textInput}
+          >
+            <Grid>
+              <Column xlg={5} lg={5} md={4} sm={4}>
+                <TextInput
+                  id="test-1"
+                  invalidText="A valid value is required"
+                  labelText="Topic name"
+                  placeholder="Enter topic name"
+                  onChange={(e) => {
+                    setTextInput(e.target.value);
+                    setIsInvalid(false);
+                  }}
+                  onBlur={() => {
+                    textInput.length === 0 && setIsInvalid(true);
+                  }}
+                  invalid={isInvalid}
+                />
+                {hasSubmitError && (
+                  <InlineNotification
+                    lowContrast
+                    kind="error"
+                    title="Error"
+                    subtitle="Resolve errors to continue"
+                    onClose={() => setHasSubmitError(false)}
+                  />
+                )}
+                <div>
+                  <div>
+                    <DefinitionTooltip
+                      className={`${storyClass}__error--text`}
+                      size="sm"
+                      definition={
+                        'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                      }
+                    >
+                      Simulate error
+                    </DefinitionTooltip>
+                  </div>
+                  <Toggle
+                    labelText="Simulate error"
+                    hideLabel
+                    id="simulated-error-toggle"
+                    size="sm"
+                    onToggle={(event) => setShouldReject(event)}
+                  />
+                </div>
+                <Checkbox
+                  labelText={`Include additional step`}
+                  id="include-additional-step-checkbox"
+                  onChange={(checked) =>
+                    setShouldIncludeAdditionalStep(checked)
+                  }
+                  checked={shouldIncludeAdditionalStep}
+                />
+              </Column>
+            </Grid>
+          </CreateFullPageStep>
+
+          <CreateFullPageStep
+            title="Dynamic step"
+            description="Example dynamic step"
+            includeStep={shouldIncludeAdditionalStep}
+          />
+
+          <CreateFullPageStep
+            title="Empty"
+            secondaryLabel="Optional"
+            description="Empty step for demonstration purposes"
+          />
+
+          <CreateFullPageStep
+            className={`${storyClass}__step-fieldset--no-label`}
+            title="Core configuration"
+            description="Here is an example description for the 'Core configuration' step."
+            secondaryLabel="Optional"
+          >
+            <Grid>
+              <Column xlg={5} lg={5} md={4} sm={4}>
+                <Grid>
+                  <Column xlg={5} lg={5} md={4} sm={4}>
+                    <TextInput
+                      id="test-2"
+                      invalidText="A valid value is required"
+                      labelText="Topic name (optional)"
+                      placeholder="Enter topic name"
+                      value={topicName2}
+                      onChange={(e) => setTopicName2(e.target.value)}
+                    />
+                  </Column>
+
+                  <Column span={3}>
+                    <NumberInput
+                      id="test-3"
+                      invalidText="Number is not valid"
+                      label="Label (optional)"
+                      max={100}
+                      min={0}
+                      step={10}
+                      value={numberInput1}
+                      onChange={(e) => setNumberInput1(e.imaginaryTarget.value)}
+                      iconDescription="Choose a number"
+                    />
+
+                    <NumberInput
+                      id="test-4"
+                      invalidText="Number is not valid"
+                      label="Label (optional)"
+                      max={100}
+                      min={0}
+                      step={10}
+                      value={numberInput2}
+                      onChange={(e) => setNumberInput2(e.imaginaryTarget.value)}
+                      iconDescription="Choose a number"
+                    />
+                  </Column>
+
+                  <Column xlg={5} lg={5} md={4} sm={4}>
+                    <TextInput
+                      id="test-5"
+                      invalidText="A valid value is required"
+                      labelText="Minimum in-sync replicas (optional)"
+                      placeholder="Enter topic name"
+                      value={replicas}
+                      onChange={(e) => setReplicas(e.target.value)}
+                    />
+                  </Column>
+                </Grid>
+              </Column>
+            </Grid>
+          </CreateFullPageStep>
+
+          <CreateFullPageStep
+            title="Message retention"
+            subtitle="This is how many copies of a topic will be made for high availability"
+            description="The partitions of each topic can be replicated across a configurable number of brokers"
+          >
+            <Grid>
+              <Column span={100}>
+                <RadioButtonGroup
+                  defaultSelected="standard"
+                  legend="Group Legend"
+                  name="radio-button-group"
+                  valueSelected={replicationFactor}
+                  onChange={(value) => setReplicationFactor(value)}
+                  orientation="vertical"
+                >
+                  <RadioButton
+                    id="radio-1"
+                    labelText="Replication factor: 1"
+                    value="standard"
+                  />
+                  <RadioButton
+                    id="radio-2"
+                    labelText="Replication factor: 2"
+                    value="default-selected"
+                  />
+                  <RadioButton
+                    id="radio-3"
+                    labelText="Replication factor: 3"
+                    value="disabled"
+                  />
+                </RadioButtonGroup>
+              </Column>
+            </Grid>
+          </CreateFullPageStep>
+        </CreateFullPage>
+      </div>
+    </div>
+  );
+};

--- a/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithHeader.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithHeader.tsx
@@ -1,0 +1,266 @@
+// @ts-nocheck
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  Checkbox,
+  Column,
+  DefinitionTooltip,
+  Grid,
+  InlineNotification,
+  Link,
+  NumberInput,
+  RadioButton,
+  RadioButtonGroup,
+  TextInput,
+  Toggle,
+} from '@carbon/react';
+import { usePrefix } from '@carbon/react';
+
+import { CreateFullPage } from '../components/CreateFullPage';
+import { CreateFullPageStep } from '../components/CreateFullPageStep';
+
+const storyClass = 'create-full-page-stories';
+
+export const CreateFullPageWithHeader = () => {
+  const carbonPrefix = usePrefix();
+  const [textInput, setTextInput] = useState('');
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const [shouldReject, setShouldReject] = useState(false);
+  const [shouldIncludeAdditionalStep, setShouldIncludeAdditionalStep] =
+    useState(false);
+  const [simulatedDelay] = useState(750);
+  const [topicName2, setTopicName2] = useState('');
+  const [numberInput1, setNumberInput1] = useState(0);
+  const [numberInput2, setNumberInput2] = useState(0);
+  const [replicas, setReplicas] = useState('');
+  const [replicationFactor, setReplicationFactor] = useState('standard');
+
+  return (
+    <div className={`${storyClass}__viewport`}>
+      <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
+      <CreateFullPage
+        secondaryTitle="Create topic"
+        title="Page title"
+        breadcrumbsOverflowAriaLabel="Open and close additional breadcrumb item list."
+        breadcrumbs={[
+          { key: '0', label: 'Breadcrumb 1', href: '/', title: 'home page' },
+          { key: '1', label: 'Breadcrumb 2', href: '/' },
+          { key: '2', label: 'Breadcrumb 3', href: '/' },
+          { key: '3', label: 'Breadcrumb 4', isCurrentPage: true },
+        ]}
+        breadcrumbOverflowTooltipAlign="right"
+        nextButtonText="Next"
+        backButtonText="Back"
+        cancelButtonText="Cancel"
+        submitButtonText="Create"
+        modalTitle="Are you sure you want to cancel?"
+        modalDescription="If you cancel, the information you have entered won't be saved."
+        modalDangerButtonText="Cancel partition"
+        modalSecondaryButtonText="Return to form"
+        onRequestSubmit={async () => {
+          console.log('Form submitted');
+        }}
+        onClose={() => {
+          console.log('CreateFullPage closed');
+        }}
+      >
+        <CreateFullPageStep
+          className={`${storyClass}__step-fieldset--no-label`}
+          title="Partition"
+          subtitle="One or more partitions make up a topic. A partition is an ordered list of messages."
+          description="Partitions are distributed across the brokers in order to increase the scalability of your topic. You can also use them to distribute messages across the members of a consumer group."
+          onNext={() => {
+            return new Promise((resolve, reject) => {
+              setTimeout(() => {
+                if (shouldReject) {
+                  setHasSubmitError(true);
+                  reject();
+                }
+                setIsInvalid(false);
+                resolve();
+              }, simulatedDelay);
+            });
+          }}
+          disableSubmit={!textInput}
+        >
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              <TextInput
+                id="test-1"
+                invalidText="A valid value is required"
+                labelText="Topic name"
+                placeholder="Enter topic name"
+                onChange={(e) => {
+                  setTextInput(e.target.value);
+                  setIsInvalid(false);
+                }}
+                onBlur={() => {
+                  textInput.length === 0 && setIsInvalid(true);
+                }}
+                invalid={isInvalid}
+              />
+              {hasSubmitError && (
+                <InlineNotification
+                  lowContrast
+                  kind="error"
+                  title="Error"
+                  subtitle="Resolve errors to continue"
+                  onClose={() => setHasSubmitError(false)}
+                />
+              )}
+              <div>
+                <div>
+                  <DefinitionTooltip
+                    className={`${storyClass}__error--text`}
+                    size="sm"
+                    definition={
+                      'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                    }
+                  >
+                    Simulate error
+                  </DefinitionTooltip>
+                </div>
+                <Toggle
+                  labelText="Simulate error"
+                  hideLabel
+                  id="simulated-error-toggle"
+                  size="sm"
+                  onToggle={(event) => setShouldReject(event)}
+                />
+              </div>
+              <div>
+                <Checkbox
+                  labelText={`Include additional step`}
+                  id="include-additional-step-checkbox"
+                  onChange={(event, { checked }) =>
+                    setShouldIncludeAdditionalStep(checked)
+                  }
+                  checked={shouldIncludeAdditionalStep}
+                />
+              </div>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+
+        {shouldIncludeAdditionalStep && (
+          <CreateFullPageStep
+            title="Dynamic step"
+            description="Example dynamic step"
+          />
+        )}
+
+        <CreateFullPageStep
+          title="Empty"
+          secondaryLabel="Optional"
+          description="Empty step for demonstration purposes"
+          onPrevious={() => console.log('custom onPrevious handler')}
+        />
+
+        <CreateFullPageStep
+          className={`${storyClass}__step-fieldset--no-label`}
+          title="Core configuration"
+          description="Here is an example description for the 'Core configuration' step."
+          secondaryLabel="Optional"
+          onPrevious={() => console.log('custom onPrevious handler')}
+        >
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              <Grid>
+                <Column xlg={5} lg={5} md={4} sm={4}>
+                  <TextInput
+                    id="test-2"
+                    invalidText="A valid value is required"
+                    labelText="Topic name (optional)"
+                    placeholder="Enter topic name"
+                    value={topicName2}
+                    onChange={(e) => setTopicName2(e.target.value)}
+                  />
+                </Column>
+
+                <Column span={3}>
+                  <NumberInput
+                    id="test-3"
+                    invalidText="Number is not valid"
+                    label="Label (optional)"
+                    max={100}
+                    min={0}
+                    step={10}
+                    value={numberInput1}
+                    onChange={(e) => setNumberInput1(e.imaginaryTarget.value)}
+                    iconDescription="Choose a number"
+                  />
+
+                  <NumberInput
+                    id="test-4"
+                    invalidText="Number is not valid"
+                    label="Label (optional)"
+                    max={100}
+                    min={0}
+                    step={10}
+                    value={numberInput2}
+                    onChange={(e) => setNumberInput2(e.imaginaryTarget.value)}
+                    iconDescription="Choose a number"
+                  />
+                </Column>
+
+                <Column xlg={5} lg={5} md={4} sm={4}>
+                  <TextInput
+                    id="test-5"
+                    invalidText="A valid value is required"
+                    labelText="Minimum in-sync replicas (optional)"
+                    placeholder="Enter topic name"
+                    value={replicas}
+                    onChange={(e) => setReplicas(e.target.value)}
+                  />
+                </Column>
+              </Grid>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+
+        <CreateFullPageStep
+          title="Message retention"
+          subtitle="This is how many copies of a topic will be made for high availability"
+          description="The partitions of each topic can be replicated across a configurable number of brokers"
+          onPrevious={() => console.log('custom onPrevious handler')}
+        >
+          <Grid>
+            <Column span={100}>
+              <RadioButtonGroup
+                defaultSelected="standard"
+                legend="Group Legend"
+                name="radio-button-group"
+                valueSelected={replicationFactor}
+                onChange={(value) => setReplicationFactor(value)}
+                orientation="vertical"
+              >
+                <RadioButton
+                  id="radio-1"
+                  labelText="Replication factor: 1"
+                  value="standard"
+                />
+                <RadioButton
+                  id="radio-2"
+                  labelText="Replication factor: 2"
+                  value="default-selected"
+                />
+                <RadioButton
+                  id="radio-3"
+                  labelText="Replication factor: 3"
+                  value="disabled"
+                />
+              </RadioButtonGroup>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+      </CreateFullPage>
+    </div>
+  );
+};

--- a/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithSections.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithSections.tsx
@@ -1,0 +1,249 @@
+// @ts-nocheck
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  Column,
+  FormGroup,
+  Grid,
+  InlineNotification,
+  NumberInput,
+  RadioButton,
+  RadioButtonGroup,
+  TextInput,
+  Toggle,
+} from '@carbon/react';
+import { DefinitionTooltip } from '@carbon/react';
+import { usePrefix } from '@carbon/react';
+
+import { CreateFullPage } from '../components/CreateFullPage';
+import { CreateFullPageStep } from '../components/CreateFullPageStep';
+
+const blockClass = 'create-full-page-pattern';
+const storyClass = 'create-full-page-stories';
+
+export const CreateFullPageWithSections = () => {
+  const carbonPrefix = usePrefix();
+  const [textInput, setTextInput] = useState('');
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const [shouldReject, setShouldReject] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [simulatedDelay] = useState(750);
+
+  return (
+    <div className="create-full-page-stories__viewport">
+      <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
+      <CreateFullPage
+        className={`${blockClass}`}
+        secondaryTitle="Create topic"
+        nextButtonText="Next"
+        backButtonText="Back"
+        cancelButtonText="Cancel"
+        submitButtonText="Create"
+        modalTitle="Are you sure you want to cancel?"
+        modalDescription="If you cancel, the information you have entered won't be saved."
+        modalDangerButtonText="Cancel partition"
+        modalSecondaryButtonText="Return to form"
+        onRequestSubmit={async () => {
+          console.log('Form submitted');
+        }}
+        onClose={() => {
+          console.log('CreateFullPage closed');
+        }}
+      >
+        <CreateFullPageStep
+          title="Partition"
+          subtitle="One or more partitions make up a topic. A partition is an ordered list of messages."
+          description="Partitions are distributed across the brokers in order to increase the scalability of your topic. You can also use them to distribute messages across the members of a consumer group."
+          onNext={() => {
+            return new Promise((resolve, reject) => {
+              setTimeout(() => {
+                // Example usage of how to prevent the next step if some kind
+                // of error occurred during the `onNext` handler.
+                if (shouldReject) {
+                  setHasSubmitError(true);
+                  reject();
+                }
+                setIsInvalid(false);
+                resolve();
+              }, simulatedDelay);
+            });
+          }}
+          disableSubmit={!textInput}
+        >
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              <FormGroup
+                className={`${blockClass}__step-fieldset ${storyClass}__step-fieldset--label`}
+                legendText="Partition"
+              >
+                <TextInput
+                  id="test-6"
+                  invalidText="A valid value is required"
+                  labelText="Topic name"
+                  placeholder="Enter topic name"
+                  onChange={(e) => {
+                    setTextInput(e.target.value);
+                    setIsInvalid(false);
+                  }}
+                  onBlur={() => {
+                    textInput.length === 0 && setIsInvalid(true);
+                  }}
+                  invalid={isInvalid}
+                />
+                {hasSubmitError && (
+                  <InlineNotification
+                    lowContrast
+                    kind="error"
+                    title="Error"
+                    subtitle="Resolve errors to continue"
+                    onClose={() => setHasSubmitError(false)}
+                  />
+                )}
+                <div>
+                  <div>
+                    <DefinitionTooltip
+                      className={`${storyClass}__error--text`}
+                      size="sm"
+                      definition={
+                        'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                      }
+                    >
+                      Simulate error
+                    </DefinitionTooltip>
+                  </div>
+                  <Toggle
+                    labelText="Simulate error"
+                    hideLabel
+                    id="simulated-error-toggle"
+                    size="sm"
+                    onToggle={(event) => setShouldReject(event)}
+                  />
+                </div>
+              </FormGroup>
+            </Column>
+          </Grid>
+
+          <span className={`${blockClass}__section-divider`} />
+
+          <Grid>
+            <Column span={50}>
+              <h5 className={`${blockClass}__step-title`}>
+                Core configuration
+              </h5>
+
+              <h6 className={`${blockClass}__step-subtitle`}>
+                This is how long messages are retained before they are deleted.
+              </h6>
+            </Column>
+          </Grid>
+
+          <Grid>
+            <Column xlg={8} lg={8} md={4} sm={4}>
+              <FormGroup
+                className={`${blockClass}__step-fieldset ${storyClass}__step-fieldset--label`}
+                legendText="Core configuration"
+              >
+                <Grid>
+                  <Column span={50}>
+                    <p
+                      className={`${blockClass}__step-description ${storyClass}__step-description`}
+                    >
+                      If your messages are not read by a consumer within this
+                      time, they will be missed.
+                    </p>
+                  </Column>
+
+                  <Column xlg={5} lg={5} md={4} sm={4}>
+                    <Grid>
+                      <Column xlg={5} lg={5} md={4} sm={4}>
+                        <TextInput
+                          id="test-7"
+                          invalidText="A valid value is required"
+                          labelText="Topic name (optional)"
+                          placeholder="Enter topic name"
+                        />
+                      </Column>
+
+                      <Column span={3}>
+                        <NumberInput
+                          id="test-8"
+                          invalidText="Number is not valid"
+                          label="Label (optional)"
+                          max={100}
+                          min={0}
+                          step={10}
+                          value={0}
+                          iconDescription="Choose a number"
+                        />
+
+                        <NumberInput
+                          id="test-9"
+                          invalidText="Number is not valid"
+                          label="Label (optional)"
+                          max={100}
+                          min={0}
+                          step={10}
+                          value={0}
+                          iconDescription="Choose a number"
+                        />
+                      </Column>
+
+                      <Column xlg={5} lg={5} md={4} sm={4}>
+                        <TextInput
+                          id="test-10"
+                          invalidText="A valid value is required"
+                          labelText="Minimum in-sync replicas (optional)"
+                          placeholder="Enter topic name"
+                        />
+                      </Column>
+                    </Grid>
+                  </Column>
+                </Grid>
+              </FormGroup>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+
+        <CreateFullPageStep
+          title="Message retention"
+          subtitle="This is how many copies of a topic will be made for high availability"
+          description="The partitions of each topic can be replicated across a configurable number of brokers."
+        >
+          <Grid>
+            <Column span={100}>
+              <RadioButtonGroup
+                defaultSelected="standard"
+                legend="Group Legend"
+                name="radio-button-group"
+                valueSelected="standard"
+                orientation="vertical"
+              >
+                <RadioButton
+                  id="radio-4"
+                  labelText="Replication factor: 1"
+                  value="standard"
+                />
+                <RadioButton
+                  id="radio-5"
+                  labelText="Replication factor: 2"
+                  value="default-selected"
+                />
+                <RadioButton
+                  id="radio-6"
+                  labelText="Replication factor: 3"
+                  value="disabled"
+                />
+              </RadioButtonGroup>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+      </CreateFullPage>
+    </div>
+  );
+};

--- a/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithStepInErrorState.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/preview-components/CreateFullPageWithStepInErrorState.tsx
@@ -1,0 +1,80 @@
+// @ts-nocheck
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Column, Grid, TextInput } from '@carbon/react';
+import { usePrefix } from '@carbon/react';
+
+import { CreateFullPage } from '../components/CreateFullPage';
+import { CreateFullPageStep } from '../components/CreateFullPageStep';
+
+const storyClass = 'create-full-page-stories';
+
+export const CreateFullPageWithStepInErrorState = () => {
+  const carbonPrefix = usePrefix();
+  const [textInput, setTextInput] = useState('');
+  const [isInvalid, setIsInvalid] = useState(true);
+  const [isFirstStepInvalid, setIsFirstStepInvalid] = useState(true);
+
+  return (
+    <div className={`${storyClass}__viewport`}>
+      <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
+      <CreateFullPage
+        secondaryTitle="Create topic"
+        nextButtonText="Next"
+        backButtonText="Back"
+        cancelButtonText="Cancel"
+        submitButtonText="Create"
+        modalTitle="Are you sure you want to cancel?"
+        modalDescription="If you cancel, the information you have entered won't be saved."
+        modalDangerButtonText="Cancel partition"
+        modalSecondaryButtonText="Return to form"
+        onRequestSubmit={async () => {
+          console.log('Form submitted');
+        }}
+        onClose={() => {
+          console.log('CreateFullPage closed');
+        }}
+      >
+        <CreateFullPageStep
+          title="Partition"
+          subtitle="One or more partitions make up a topic. A partition is an ordered list of messages."
+          invalid={isFirstStepInvalid}
+          disableSubmit={isFirstStepInvalid}
+        >
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              <TextInput
+                id="test-6"
+                invalidText="A valid value is required"
+                labelText="Topic name"
+                placeholder="Enter topic name"
+                onChange={(e) => {
+                  setTextInput(e.target.value);
+                  setIsInvalid(e.target.value ? false : true);
+                  setIsFirstStepInvalid(e.target.value ? false : true);
+                }}
+                onBlur={() => {
+                  textInput.length === 0 && setIsInvalid(true);
+                }}
+                invalid={isInvalid}
+              />
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+        <CreateFullPageStep title="Core Configuration">
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              Test step
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+      </CreateFullPage>
+    </div>
+  );
+};

--- a/packages/react/src/examples/CreateFullPage/example/preview-components/StandardCreateFullPage.tsx
+++ b/packages/react/src/examples/CreateFullPage/example/preview-components/StandardCreateFullPage.tsx
@@ -1,0 +1,259 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// @ts-nocheck
+import React, { useState } from 'react';
+import {
+  Checkbox,
+  Column,
+  DefinitionTooltip,
+  Grid,
+  InlineNotification,
+  Link,
+  NumberInput,
+  RadioButton,
+  RadioButtonGroup,
+  TextInput,
+  Toggle,
+} from '@carbon/react';
+import CreateFullPage from '../components/CreateFullPage';
+import { CreateFullPageStep } from '../components/CreateFullPageStep';
+
+const storyClass = 'create-full-page-stories';
+
+export const StandardCreateFullPage: React.FC = () => {
+  const [textInput, setTextInput] = useState('');
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const [shouldReject, setShouldReject] = useState(false);
+  const [shouldIncludeAdditionalStep, setShouldIncludeAdditionalStep] =
+    useState(false);
+  const [simulatedDelay] = useState(750);
+  const [topicName2, setTopicName2] = useState('');
+  const [numberInput1, setNumberInput1] = useState(0);
+  const [numberInput2, setNumberInput2] = useState(0);
+  const [replicas, setReplicas] = useState('');
+  const [replicationFactor, setReplicationFactor] = useState('standard');
+
+  return (
+    <div className={`${storyClass}__viewport`}>
+      <CreateFullPage
+        secondaryTitle="Create topic"
+        nextButtonText="Next"
+        backButtonText="Back"
+        cancelButtonText="Cancel"
+        submitButtonText="Create"
+        modalTitle="Are you sure you want to cancel?"
+        modalDescription="If you cancel, the information you have entered won't be saved."
+        modalDangerButtonText="Cancel partition"
+        modalSecondaryButtonText="Return to form"
+        onRequestSubmit={async () => {
+          console.log('Form submitted');
+        }}
+        onClose={() => {
+          console.log('CreateFullPage closed');
+        }}
+      >
+        <CreateFullPageStep
+          title="Partition"
+          subtitle="One or more partitions make up a topic. A partition is an ordered list of messages."
+          description={
+            <>
+              <span>
+                Partitions are distributed across the brokers in order to
+                increase the scalability of your topic. You can also use them to
+                distribute messages across the members of a consumer group.
+              </span>
+              &nbsp;<Link href="#">Learn more.</Link>
+            </>
+          }
+          onNext={() => {
+            return new Promise((resolve, reject) => {
+              setTimeout(() => {
+                // Example usage of how to prevent the next step if some kind
+                // of error occurred during the `onNext` handler.
+                if (shouldReject) {
+                  setHasSubmitError(true);
+                  reject();
+                }
+                setIsInvalid(false);
+                resolve();
+              }, simulatedDelay);
+            });
+          }}
+          disableSubmit={!textInput}
+        >
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              <TextInput
+                id="topic-name-input"
+                invalidText="A valid value is required"
+                labelText="Topic name"
+                placeholder="Enter topic name"
+                value={textInput}
+                onChange={(e) => {
+                  setTextInput(e.target.value);
+                  setIsInvalid(false);
+                }}
+                onBlur={() => {
+                  textInput.length === 0 && setIsInvalid(true);
+                }}
+                invalid={isInvalid}
+              />
+              {hasSubmitError && (
+                <InlineNotification
+                  lowContrast
+                  kind="error"
+                  title="Error"
+                  subtitle="Resolve errors to continue"
+                  onClose={() => setHasSubmitError(false)}
+                />
+              )}
+              <div>
+                <div>
+                  <DefinitionTooltip
+                    className={`${storyClass}__error--text`}
+                    size="sm"
+                    definition={
+                      'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                    }
+                  >
+                    Simulate error
+                  </DefinitionTooltip>
+                </div>
+                <Toggle
+                  labelText="Simulate error"
+                  hideLabel
+                  id="simulated-error-toggle"
+                  size="sm"
+                  onToggle={(event) => setShouldReject(event)}
+                />
+              </div>
+              <Checkbox
+                labelText={`Include additional step`}
+                id="include-additional-step-checkbox"
+                onChange={(event, { checked }) =>
+                  setShouldIncludeAdditionalStep(checked)
+                }
+                checked={shouldIncludeAdditionalStep}
+              />
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+
+        {shouldIncludeAdditionalStep && (
+          <CreateFullPageStep
+            title="Dynamic step"
+            description="Example dynamic step"
+          />
+        )}
+
+        <CreateFullPageStep
+          title="Empty"
+          description="Empty step for demonstration purposes"
+        >
+          <div />
+        </CreateFullPageStep>
+
+        <CreateFullPageStep
+          title="Core configuration"
+          description="Here is an example description for the 'Core configuration' step."
+        >
+          <Grid>
+            <Column xlg={5} lg={5} md={4} sm={4}>
+              <Grid>
+                <Column xlg={5} lg={5} md={4} sm={4}>
+                  <TextInput
+                    id="topic-name-optional"
+                    invalidText="A valid value is required"
+                    labelText="Topic name (optional)"
+                    placeholder="Enter topic name"
+                    value={topicName2}
+                    onChange={(e) => setTopicName2(e.target.value)}
+                  />
+                </Column>
+
+                <Column span={3}>
+                  <NumberInput
+                    id="number-input-1"
+                    invalidText="Number is not valid"
+                    label="Label (optional)"
+                    max={100}
+                    min={0}
+                    step={10}
+                    value={numberInput1}
+                    onChange={(e, { value }) => setNumberInput1(value)}
+                    iconDescription="Choose a number"
+                  />
+
+                  <NumberInput
+                    id="number-input-2"
+                    invalidText="Number is not valid"
+                    label="Label (optional)"
+                    max={100}
+                    min={0}
+                    step={10}
+                    value={numberInput2}
+                    onChange={(e, { value }) => setNumberInput2(value)}
+                    iconDescription="Choose a number"
+                  />
+                </Column>
+
+                <Column xlg={5} lg={5} md={4} sm={4}>
+                  <TextInput
+                    id="replicas-input"
+                    invalidText="A valid value is required"
+                    labelText="Minimum in-sync replicas (optional)"
+                    placeholder="Enter topic name"
+                    value={replicas}
+                    onChange={(e) => setReplicas(e.target.value)}
+                  />
+                </Column>
+              </Grid>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+
+        <CreateFullPageStep
+          title="Message retention"
+          subtitle="This is how many copies of a topic will be made for high availability"
+          description="The partitions of each topic can be replicated across a configurable number of brokers"
+        >
+          <Grid>
+            <Column span={100}>
+              <RadioButtonGroup
+                legend="Group Legend"
+                name="radio-button-group"
+                valueSelected={replicationFactor}
+                onChange={(value) => setReplicationFactor(value)}
+                orientation="vertical"
+              >
+                <RadioButton
+                  id="radio-1"
+                  labelText="Replication factor: 1"
+                  value="standard"
+                />
+                <RadioButton
+                  id="radio-2"
+                  labelText="Replication factor: 2"
+                  value="default-selected"
+                />
+                <RadioButton
+                  id="radio-3"
+                  labelText="Replication factor: 3"
+                  value="disabled"
+                />
+              </RadioButtonGroup>
+            </Column>
+          </Grid>
+        </CreateFullPageStep>
+      </CreateFullPage>
+    </div>
+  );
+};

--- a/packages/react/src/examples/CreateFullPage/example/vite.config.js
+++ b/packages/react/src/examples/CreateFullPage/example/vite.config.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/react/src/examples/CreateModal/CreateModal.mdx
+++ b/packages/react/src/examples/CreateModal/CreateModal.mdx
@@ -1,0 +1,102 @@
+import { Story, Controls, Source, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import * as stories from './CreateModal.stories';
+
+<Meta isTemplate />
+
+# Create Modal
+
+[Usage guidelines](https://carbondesignsystem.com/patterns/create-flows/usage/#modal)
+|
+[Carbon modal usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
+|
+[Carbon modal documentation](https://react.carbondesignsystem.com/?path=/docs/components-modal)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+  - [Create Modal](#create-modal)
+  - [Form validation](#form-validation)
+
+## Overview
+
+The `CreateModal` pattern provides a way for a user to quickly generate a new
+resource. It is triggered by a user's action, appears on top of the main page
+content, and is persistent until dismissed. The purpose of this modal should be
+immediately apparent to the user, with a clear and obvious path to completion.
+
+To build this pattern, we recommend including the following ingredients:
+
+- [Modal](https://react.carbondesignsystem.com/?path=/docs/components-modal)
+- [Button](https://react.carbondesignsystem.com/?path=/docs/components-button)
+- [Form](https://react.carbondesignsystem.com/?path=/docs/components-form)
+- [FormGroup](https://react.carbondesignsystem.com/?path=/docs/components-formgroup)
+- [TextInput](https://react.carbondesignsystem.com/?path=/docs/components-textinput)
+- [TextArea](https://react.carbondesignsystem.com/?path=/docs/components-textarea)
+- [RadioButton](https://react.carbondesignsystem.com/?path=/docs/components-radiobutton)
+- [Dropdown](https://react.carbondesignsystem.com/?path=/docs/components-dropdown)
+- [Loading](https://react.carbondesignsystem.com/?path=/docs/components-loading)
+
+```jsx
+import {
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  TextInput,
+  TextArea,
+  RadioButton,
+  Dropdown,
+  Loading,
+} from '@carbon/react';
+```
+
+## Example usage
+
+> 💡 Check our
+> [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateModal/example)
+> example implementation.
+
+[![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateModal/example)
+
+### Create Modal
+
+<Canvas
+  of={stories.CreateModal}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.CreateModal),
+    },
+  ]}
+/>
+
+### With Form Validation
+
+<Canvas
+  of={stories.WithFormValidation}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.WithFormValidation),
+    },
+  ]}
+/>
+
+### Form validation
+
+All forms, including that within the `CreateModal` should follow Carbon's
+guidelines for form validation.
+
+This includes the following:
+
+- The `Submit` button in the modal should be disabled, until all required inputs
+  are filled in and valid
+- All required inputs should only throw an invalid error after the element loses
+  focus
+- All optional form fields should have an `(optional)` text at the end of the
+  input `labelText`. Optional should always be in parentheses
+
+You can find more information on how to validate your form fields in
+[Carbon's Form usage page](https://carbondesignsystem.com/components/form/usage/).

--- a/packages/react/src/examples/CreateModal/CreateModal.stories.js
+++ b/packages/react/src/examples/CreateModal/CreateModal.stories.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import './_story-styles.scss';
+import DocsPage from './CreateModal.mdx';
+import { StandardCreateModal } from './example/preview-components/StandardCreateModal';
+import { CreateModalWithValidation } from './example/preview-components/CreateModalWithValidation';
+
+export default {
+  title: 'Examples/Create flows/Create Modal',
+  component: () => {},
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+  },
+};
+
+const CreateModalPattern = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Launch modal</Button>
+      <StandardCreateModal open={open} setOpen={setOpen} {...args} />
+    </>
+  );
+};
+
+const CreateModalWithValidationPattern = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        Launch CreateModal with form validation
+      </Button>
+      <CreateModalWithValidation open={open} setOpen={setOpen} {...args} />
+    </>
+  );
+};
+
+export const CreateModal = CreateModalPattern.bind({});
+CreateModal.args = {};
+
+export const WithFormValidation = CreateModalWithValidationPattern.bind({});
+WithFormValidation.args = {};

--- a/packages/react/src/examples/CreateModal/_story-styles.scss
+++ b/packages/react/src/examples/CreateModal/_story-styles.scss
@@ -1,0 +1,65 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/breakpoint' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config' as carbon-config;
+
+.create-modal .#{carbon-config.$prefix}--modal-close {
+  display: none;
+}
+
+.create-modal .#{carbon-config.$prefix}--modal-container {
+  @include breakpoint(md) {
+    max-block-size: 95%;
+  }
+  @include breakpoint(lg) {
+    max-block-size: 95%;
+  }
+}
+
+.create-modal .#{carbon-config.$prefix}--modal-header {
+  border-block-end: 1px solid $layer-accent-01;
+  margin-block-end: 0;
+  padding-block-end: $spacing-03;
+  padding-inline-end: 20%;
+}
+
+.create-modal
+  .#{carbon-config.$prefix}--modal-footer
+  .#{carbon-config.$prefix}--btn {
+  max-inline-size: none;
+}
+
+.create-modal__subtitle {
+  @include type.type-style('body-compact-01');
+
+  color: $text-secondary;
+  margin-block-end: $spacing-03;
+}
+
+.create-modal__description {
+  @include type.type-style('body-01');
+
+  margin: $spacing-03 0 $spacing-05 0;
+  padding-inline-end: calc(20% - #{$spacing-05});
+}
+
+.create-modal__form .#{carbon-config.$prefix}--fieldset {
+  margin-block-end: 0;
+  min-inline-size: 100%;
+}
+
+.create-modal__form > * {
+  margin-block-end: $spacing-05;
+
+  &:last-child {
+    margin-block-end: 0;
+  }
+}

--- a/packages/react/src/examples/CreateModal/example/App.tsx
+++ b/packages/react/src/examples/CreateModal/example/App.tsx
@@ -1,0 +1,45 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import { StandardCreateModal } from './preview-components/StandardCreateModal';
+import { CreateModalWithValidation } from './preview-components/CreateModalWithValidation';
+
+function App() {
+  const [openStandard, setOpenStandard] = useState(false);
+  const [openValidation, setOpenValidation] = useState(false);
+
+  return (
+    <div className="example-container">
+      <h1>Create Modal Examples</h1>
+
+      <section className="example-section">
+        <h2>Standard Create Modal</h2>
+        <Button onClick={() => setOpenStandard(true)}>
+          Launch Standard Modal
+        </Button>
+        <StandardCreateModal open={openStandard} setOpen={setOpenStandard} />
+      </section>
+
+      <section className="example-section">
+        <h2>Create Modal with Form Validation</h2>
+        <Button onClick={() => setOpenValidation(true)}>
+          Launch Modal with Validation
+        </Button>
+        <CreateModalWithValidation
+          open={openValidation}
+          setOpen={setOpenValidation}
+        />
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/packages/react/src/examples/CreateModal/example/components/CreateModal.tsx
+++ b/packages/react/src/examples/CreateModal/example/components/CreateModal.tsx
@@ -1,0 +1,102 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  Button,
+  ComposedModal,
+  Form,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@carbon/react';
+import React, { PropsWithChildren, ReactNode } from 'react';
+import cx from 'classnames';
+
+const blockClass = `create-modal`;
+
+export interface CreateModalProps extends PropsWithChildren {
+  className?: string;
+  onRequestClose?(): void;
+  onRequestSubmit?(): void;
+  open?: boolean;
+  title: string;
+  subtitle?: ReactNode;
+  description: ReactNode;
+  secondaryButtonText: string;
+  primaryButtonText: string;
+  disableSubmit?: boolean;
+  selectorPrimaryFocus: string;
+}
+
+export const CreateModal = React.forwardRef<HTMLDivElement, CreateModalProps>(
+  (props, ref) => {
+    const {
+      className,
+      children,
+      onRequestClose,
+      onRequestSubmit,
+      open,
+      title,
+      subtitle,
+      description,
+      secondaryButtonText,
+      primaryButtonText,
+      disableSubmit,
+      selectorPrimaryFocus,
+      ...rest
+    } = props;
+
+    return (
+      <ComposedModal
+        {...rest}
+        selectorPrimaryFocus={selectorPrimaryFocus}
+        className={cx(blockClass, className)}
+        {...{ open, ref }}
+        aria-label={title}
+        size="sm"
+        preventCloseOnClickOutside
+        onClose={() => {
+          onRequestClose?.();
+          return false;
+        }}
+      >
+        <ModalHeader title={title} titleClassName={`${blockClass}__title`}>
+          {subtitle && <p className={`${blockClass}__subtitle`}>{subtitle}</p>}
+        </ModalHeader>
+        <ModalBody hasForm>
+          {description && (
+            <p className={`${blockClass}__description`}>{description}</p>
+          )}
+          <Form
+            className={`${blockClass}__form`}
+            aria-label={title}
+            onSubmit={(e: React.FormEvent<HTMLFormElement>) =>
+              e.preventDefault()
+            }
+          >
+            {children}
+          </Form>
+        </ModalBody>
+        <ModalFooter>
+          <Button type="button" kind="secondary" onClick={onRequestClose}>
+            {secondaryButtonText}
+          </Button>
+          <Button
+            type="submit"
+            kind="primary"
+            onClick={onRequestSubmit}
+            disabled={disableSubmit}
+          >
+            {primaryButtonText}
+          </Button>
+        </ModalFooter>
+      </ComposedModal>
+    );
+  }
+);
+
+CreateModal.displayName = 'CreateModal';

--- a/packages/react/src/examples/CreateModal/example/index.html
+++ b/packages/react/src/examples/CreateModal/example/index.html
@@ -1,0 +1,21 @@
+<!--
+@license
+
+Copyright IBM Corp. 2026
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Create Modal Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/examples/CreateModal/example/index.scss
+++ b/packages/react/src/examples/CreateModal/example/index.scss
@@ -1,0 +1,102 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/config' with (
+  $font-path: '@ibm/plex'
+);
+@use '@carbon/styles';
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/breakpoint' as *;
+@use '@carbon/styles/scss/type';
+
+body {
+  padding: $spacing-05;
+  margin: 0;
+}
+
+#root {
+  display: flex;
+  align-items: center;
+}
+
+.example-container {
+  inline-size: 1200px;
+  margin-inline-start: $spacing-02;
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 400;
+    margin-block-end: $spacing-07;
+  }
+
+  .example-section {
+    padding: $spacing-07;
+    border: 1px solid var(--cds-border-subtle);
+    background-color: var(--cds-layer-01);
+    margin-block-end: $spacing-05;
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-block: 0 $spacing-06;
+    }
+  }
+}
+
+.create-modal .cds--modal-close {
+  display: none;
+}
+
+.create-modal .cds--modal-container {
+  @include breakpoint(md) {
+    max-block-size: 95%;
+  }
+  @include breakpoint(lg) {
+    max-block-size: 95%;
+  }
+}
+
+.create-modal .cds--modal-header {
+  border-block-end: 1px solid $layer-accent-01;
+  margin-block-end: 0;
+  padding-block-end: $spacing-03;
+  padding-inline-end: 20%;
+}
+
+.create-modal .cds--modal-footer .cds--btn {
+  max-inline-size: none;
+}
+
+.create-modal__subtitle {
+  @include type.type-style('body-compact-01');
+
+  color: $text-secondary;
+
+  margin-block-end: $spacing-03;
+}
+
+.create-modal__description {
+  @include type.type-style('body-01');
+
+  margin: $spacing-03 0 $spacing-05 0;
+  padding-inline-end: calc(20% - #{$spacing-05});
+}
+
+.create-modal__form .cds--fieldset {
+  margin-block-end: 0;
+  min-inline-size: 100%;
+}
+
+.create-modal__form > * {
+  margin-block-end: $spacing-05;
+
+  /* stylelint-disable-next-line max-nesting-depth */
+  &:last-child {
+    margin-block-end: 0;
+  }
+}

--- a/packages/react/src/examples/CreateModal/example/main.tsx
+++ b/packages/react/src/examples/CreateModal/example/main.tsx
@@ -1,0 +1,24 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.scss';
+
+// eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/packages/react/src/examples/CreateModal/example/package.json
+++ b/packages/react/src/examples/CreateModal/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "delete-and-remove-example",
+  "name": "create-modal-example",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -11,8 +11,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@carbon/react": "latest",
-    "@carbon/ibm-products": "latest"
+    "@carbon/react": "latest"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/packages/react/src/examples/CreateModal/example/preview-components/CreateModalWithValidation.tsx
+++ b/packages/react/src/examples/CreateModal/example/preview-components/CreateModalWithValidation.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { RadioButton, RadioButtonGroup, TextInput } from '@carbon/react';
+import { CreateModal } from '../components/CreateModal';
+
+interface CreateModalWithValidationProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const CreateModalWithValidation = ({
+  open,
+  setOpen,
+}: CreateModalWithValidationProps) => {
+  const [textInput, setTextInput] = useState('');
+  const [invalid, setInvalid] = useState(false);
+
+  const handleClose = () => {
+    // Reset form fields when modal closes
+    setTextInput('');
+    setInvalid(false);
+    setOpen(false);
+  };
+
+  return (
+    <CreateModal
+      open={open}
+      onRequestClose={handleClose}
+      title="Title"
+      subtitle="Your subtitle text will appear here"
+      description="This is example description text that will appear here in your modal"
+      primaryButtonText="Create"
+      secondaryButtonText="Cancel"
+      disableSubmit={textInput.length === 0}
+      selectorPrimaryFocus="#text-input-1"
+      onRequestSubmit={handleClose}
+    >
+      <TextInput
+        id="text-input-1"
+        labelText="Text input label"
+        placeholder="Placeholder"
+        value={textInput}
+        onChange={(e) => {
+          setTextInput(e.target.value);
+          setInvalid(false);
+        }}
+        onBlur={() => {
+          textInput.length === 0 && setInvalid(true);
+        }}
+        invalid={invalid}
+        invalidText="This is a required field"
+      />
+      <TextInput
+        id="text-input-2"
+        labelText="Text input label (optional)"
+        placeholder="Placeholder"
+      />
+      <TextInput
+        id="text-input-3"
+        labelText="Text input label (optional)"
+        placeholder="Placeholder"
+      />
+      <RadioButtonGroup
+        legendText="Radio button legend text goes here"
+        name="radio-button-group"
+        defaultSelected="radio-1"
+      >
+        <RadioButton labelText="Radio-1" value="radio-1" id="radio-1" />
+        <RadioButton labelText="Radio-2" value="radio-2" id="radio-2" />
+        <RadioButton labelText="Radio-3" value="radio-3" id="radio-3" />
+      </RadioButtonGroup>
+    </CreateModal>
+  );
+};

--- a/packages/react/src/examples/CreateModal/example/preview-components/StandardCreateModal.tsx
+++ b/packages/react/src/examples/CreateModal/example/preview-components/StandardCreateModal.tsx
@@ -1,0 +1,76 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Dropdown, TextArea, TextInput } from '@carbon/react';
+import { CreateModal } from '../components/CreateModal';
+
+const dropdownItems = ['Option 0', 'Option 1', 'Option 2'];
+
+interface StandardCreateModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const StandardCreateModal = ({
+  open,
+  setOpen,
+}: StandardCreateModalProps) => {
+  const [textInput, setTextInput] = useState('');
+  const [selectedDropdown, setSelectedDropdown] = useState<string | null>(null);
+  const [textArea, setTextArea] = useState('');
+
+  const handleClose = () => {
+    // Reset form fields when modal closes
+    setTextInput('');
+    setSelectedDropdown(null);
+    setTextArea('');
+    setOpen(false);
+  };
+
+  return (
+    <CreateModal
+      open={open}
+      onRequestClose={handleClose}
+      title="Title"
+      subtitle="Your subtitle text will appear here"
+      description="This is example description text that will appear here in your modal"
+      primaryButtonText="Create"
+      secondaryButtonText="Cancel"
+      selectorPrimaryFocus="#text-input-1"
+      onRequestSubmit={handleClose}
+    >
+      <TextInput
+        id="text-input-1"
+        labelText="Text input label"
+        helperText="Helper text goes here"
+        placeholder="Placeholder"
+        value={textInput}
+        onChange={(e) => setTextInput(e.target.value)}
+      />
+      <Dropdown
+        id="dropdown-1"
+        titleText="Dropdown label"
+        helperText="This is some helper text"
+        label="Dropdown menu options"
+        items={dropdownItems}
+        selectedItem={selectedDropdown}
+        onChange={({ selectedItem }) =>
+          setSelectedDropdown(selectedItem ?? null)
+        }
+      />
+      <TextArea
+        id="text-area-1"
+        placeholder="Placeholder text"
+        labelText="Text area label"
+        helperText="Optional helper text"
+        value={textArea}
+        onChange={(e) => setTextArea(e.target.value)}
+      />
+    </CreateModal>
+  );
+};

--- a/packages/react/src/examples/CreateModal/example/vite.config.js
+++ b/packages/react/src/examples/CreateModal/example/vite.config.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/react/src/examples/CreateSidePanel/CreateSidePanel.mdx
+++ b/packages/react/src/examples/CreateSidePanel/CreateSidePanel.mdx
@@ -1,0 +1,95 @@
+import { Story, Controls, Source, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import * as stories from './CreateSidePanel.stories';
+
+<Meta isTemplate />
+
+# Create Side Panel
+
+[Usage guidelines](https://carbondesignsystem.com/patterns/create-flows/usage/#side-panel)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Default](#default)
+- [With form validation](#with-form-validation)
+- [Feedback](#feedback)
+
+## Overview
+
+The CreateSidePanel pattern provides a recipe for building single-form creation
+interfaces in a slide-in side panel. It is used for medium-complexity creations
+where the user needs to retain page context — the underlying content remains
+visible and interactive while the panel is open.
+
+> NOTE: Patterns have multiple ways of accomplishing a user need and typically
+> use a combination of components with additional design considerations. The
+> pattern code we share is meant to serve as an example implementation that can
+> be built and extended further.
+
+To build this pattern, we recommend including the following components:
+
+- [SidePanel](https://react.carbondesignsystem.com/?path=/docs/components-sidepanel)
+  (with `slideIn` and `placement="right"`)
+- [Form](https://react.carbondesignsystem.com/?path=/docs/components-form)
+- [TextInput](https://react.carbondesignsystem.com/?path=/docs/components-textinput)
+- [Dropdown](https://react.carbondesignsystem.com/?path=/docs/components-dropdown)
+- [FormGroup](https://react.carbondesignsystem.com/?path=/docs/components-formgroup)
+- [Button](https://react.carbondesignsystem.com/?path=/docs/components-button)
+
+```jsx
+import { SidePanel } from '@carbon/react';
+import { Form, TextInput, Dropdown, FormGroup, Button } from '@carbon/react';
+```
+
+## Example usage
+
+> 💡 Check our
+> [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateSidePanel/example)
+> example implementation.
+
+[![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateSidePanel/example)
+
+## Default
+
+The default CreateSidePanel pattern provides a focused single-form creation
+experience inside a slide-in side panel with:
+
+- A slide-in panel that preserves page context
+- Form title and description sections
+- Submit and cancel action buttons in the panel footer
+
+<Canvas
+  of={stories.createSidePanel}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.createSidePanel),
+    },
+  ]}
+/>
+
+## With form validation
+
+The pattern can be extended to include form validation:
+
+- Field-level validation with error states
+- Submit button disabled until all required fields are valid
+- Invalid text displayed for fields with errors
+- Real-time validation on blur or change events
+
+<Canvas
+  of={stories.withFormValidation}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.withFormValidation),
+    },
+  ]}
+/>
+
+## Feedback
+
+Help us improve this pattern by providing feedback through
+[GitHub issues](https://github.com/carbon-design-system/carbon/issues/new/choose).

--- a/packages/react/src/examples/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/react/src/examples/CreateSidePanel/CreateSidePanel.stories.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  Button,
+  Content,
+  Header,
+  HeaderContainer,
+  HeaderName,
+} from '@carbon/react';
+import DocsPage from './CreateSidePanel.mdx';
+import { Default } from './example/preview-components/Default';
+import { WithValidation } from './example/preview-components/WithValidation';
+import './example/styles/_story-styles.scss';
+
+const prefix = 'create-side-panel-stories__';
+
+const PAGE_CONTENT_ID = 'create-side-panel-page-content';
+
+const PageShell = ({ children }) => (
+  <>
+    <HeaderContainer
+      render={() => (
+        <Header>
+          <HeaderName href="/" prefix="IBM">
+            Cloud Pak
+          </HeaderName>
+        </Header>
+      )}
+    />
+    <Content id={PAGE_CONTENT_ID}>{children}</Content>
+  </>
+);
+
+export default {
+  title: 'Examples/Create flows/Create Side Panel',
+  component: () => {},
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: { page: DocsPage },
+  },
+};
+
+export const createSidePanel = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <PageShell>
+      <div className={`${prefix}launcher-button`}>
+        <Button onClick={() => setOpen(!open)}>
+          {open ? 'Close SidePanel' : 'Open SidePanel'}
+        </Button>
+      </div>
+      <Default
+        open={open}
+        setOpen={setOpen}
+        selectorPageContent={`#${PAGE_CONTENT_ID}`}
+      />
+    </PageShell>
+  );
+};
+createSidePanel.storyName = 'Default';
+
+export const withFormValidation = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <PageShell>
+      <div className={`${prefix}launcher-button`}>
+        <Button onClick={() => setOpen(!open)}>
+          {open ? 'Close SidePanel' : 'Open SidePanel'}
+        </Button>
+      </div>
+      <WithValidation
+        open={open}
+        setOpen={setOpen}
+        selectorPageContent={`#${PAGE_CONTENT_ID}`}
+      />
+    </PageShell>
+  );
+};
+withFormValidation.storyName = 'With Form Validation';

--- a/packages/react/src/examples/CreateSidePanel/example/App.tsx
+++ b/packages/react/src/examples/CreateSidePanel/example/App.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import { Default } from './preview-components/Default';
+import { WithValidation } from './preview-components/WithValidation';
+import './index.scss';
+
+const createSidePanelProps = {
+  title: 'Create partitions',
+  subtitle: "Specify the details of the partitions you're creating",
+  primaryButtonText: 'Create',
+  secondaryButtonText: 'Cancel',
+  selectorPageContent: '#page-content',
+};
+
+export const App = () => {
+  const [openDefault, setOpenDefault] = useState(false);
+  const [openValidation, setOpenValidation] = useState(false);
+
+  return (
+    <div id="page-content" className="example-container">
+      <h1>Create Side Panel Examples</h1>
+
+      <section className="example-section">
+        <h2>Default</h2>
+        <Button onClick={() => setOpenDefault(true)}>Open side panel</Button>
+        <Default
+          open={openDefault}
+          setOpen={setOpenDefault}
+          {...createSidePanelProps}
+        />
+      </section>
+
+      <section className="example-section">
+        <h2>With Validation</h2>
+        <Button onClick={() => setOpenValidation(true)}>
+          Open side panel with validation
+        </Button>
+        <WithValidation
+          open={openValidation}
+          setOpen={setOpenValidation}
+          {...createSidePanelProps}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/react/src/examples/CreateSidePanel/example/components/CreateSidePanel.tsx
+++ b/packages/react/src/examples/CreateSidePanel/example/components/CreateSidePanel.tsx
@@ -1,0 +1,150 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { PropsWithChildren, ReactNode, RefObject, useMemo } from 'react';
+import { SidePanel } from '@carbon/ibm-products';
+import { Form } from '@carbon/react';
+
+const blockClass = `create-side-panel`;
+
+export interface CreateSidePanelProps extends PropsWithChildren {
+  /** Optional class applied to the outermost element. */
+  className?: string;
+  /** Disables the primary submit button — use for form validation. */
+  disableSubmit?: boolean;
+  /** Optional description rendered below the form title inside the panel body. */
+  formDescription?: ReactNode;
+  /** Required title for the form section inside the panel body. */
+  formTitle: ReactNode;
+  /** Unique identifier forwarded to the underlying SidePanel. */
+  id?: string;
+  /** Provide a ref to return focus to once the side panel is closed. */
+  launcherButtonRef?: RefObject<HTMLButtonElement | null>;
+  /** Called when the panel close action is triggered. */
+  onRequestClose?(): void;
+  /** Called when the primary submit button is clicked. */
+  onRequestSubmit?(): void | Promise<void>;
+  /** Controls whether the panel is open. */
+  open: boolean;
+  /** Label text shown above the panel title. */
+  label?: string;
+  /** Text for the primary (submit) action button. */
+  primaryButtonText: string;
+  /** Text for the secondary (cancel) action button. */
+  secondaryButtonText: string;
+  /**
+   * CSS selector for the element that contains all page content.
+   * Required for the `slideIn` variant so the page content can shrink.
+   */
+  selectorPageContent: string;
+  /** CSS selector for the element that should receive focus when the panel opens. */
+  selectorPrimaryFocus?: string;
+  /** Optional subtitle shown in the panel header. */
+  subtitle?: ReactNode;
+  /** Panel header title. */
+  title: string;
+  /** Optional decorator (e.g. Slug / AI label) rendered inside the SidePanel. */
+  decorator?: ReactNode;
+}
+
+export const CreateSidePanel = React.forwardRef<
+  HTMLDivElement,
+  CreateSidePanelProps
+>(
+  (
+    {
+      children,
+      className,
+      decorator,
+      disableSubmit = false,
+      formDescription,
+      formTitle,
+      id,
+      label,
+      launcherButtonRef,
+      onRequestClose,
+      onRequestSubmit,
+      open,
+      primaryButtonText,
+      secondaryButtonText,
+      selectorPageContent,
+      selectorPrimaryFocus,
+      subtitle,
+      title,
+      ...rest
+    },
+    ref
+  ) => {
+    const actions = useMemo(
+      () => [
+        {
+          key: 'submit',
+          kind: 'primary' as const,
+          label: primaryButtonText,
+          onClick: (e: React.MouseEvent) => {
+            e.preventDefault();
+            onRequestSubmit?.();
+          },
+          disabled: disableSubmit,
+          type: 'submit' as const,
+        },
+        {
+          key: 'cancel',
+          kind: 'secondary' as const,
+          label: secondaryButtonText,
+          onClick: onRequestClose,
+        },
+      ],
+      [
+        primaryButtonText,
+        secondaryButtonText,
+        disableSubmit,
+        onRequestClose,
+        onRequestSubmit,
+      ]
+    );
+
+    return (
+      <SidePanel
+        {...rest}
+        ref={ref}
+        id={id}
+        open={open}
+        title={title}
+        subtitle={subtitle}
+        labelText={label}
+        placement="right"
+        slideIn
+        animateTitle={false}
+        size="md"
+        className={`${blockClass}${className ? ` ${className}` : ''}`}
+        selectorPageContent={selectorPageContent}
+        selectorPrimaryFocus={selectorPrimaryFocus}
+        launcherButtonRef={launcherButtonRef}
+        onRequestClose={onRequestClose}
+        actions={actions}
+        decorator={decorator}
+        preventCloseOnClickOutside
+      >
+        {formTitle && (
+          <h3 className={`${blockClass}__form-title`}>{formTitle}</h3>
+        )}
+        {formDescription && (
+          <p className={`${blockClass}__form-description`}>{formDescription}</p>
+        )}
+        <Form
+          className={`${blockClass}__form`}
+          onSubmit={(e: React.FormEvent<HTMLFormElement>) => e.preventDefault()}
+        >
+          {children}
+        </Form>
+      </SidePanel>
+    );
+  }
+);
+
+CreateSidePanel.displayName = 'CreateSidePanel';

--- a/packages/react/src/examples/CreateSidePanel/example/index.html
+++ b/packages/react/src/examples/CreateSidePanel/example/index.html
@@ -1,0 +1,19 @@
+<!-- 
+ Copyright IBM Corp. 2026
+ 
+  This source code is licensed under the Apache-2.0 license found in the
+  LICENSE file in the root directory of this source tree.
+   -->
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CreateSidePanel Pattern Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/examples/CreateSidePanel/example/index.scss
+++ b/packages/react/src/examples/CreateSidePanel/example/index.scss
@@ -1,0 +1,52 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/config' with (
+  $font-path: '@ibm/plex'
+);
+@use '@carbon/styles';
+
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as theme;
+@use '@carbon/styles/scss/themes' as themes;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/motion' as *;
+@use './styles/_create-side-panel';
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+#root {
+  min-block-size: 100vh;
+}
+
+.example-container {
+  margin-inline-start: $spacing-02;
+  max-inline-size: 1200px;
+
+  h1 {
+    @include type.type-style('heading-05');
+
+    margin-block-end: $spacing-07;
+  }
+
+  .example-section {
+    padding: $spacing-07;
+    border: 1px solid theme.$border-subtle-01;
+    background-color: theme.$layer-01;
+    margin-block-end: $spacing-05;
+
+    h2 {
+      @include type.type-style('heading-03');
+
+      margin-block: 0 $spacing-06;
+    }
+  }
+}

--- a/packages/react/src/examples/CreateSidePanel/example/main.tsx
+++ b/packages/react/src/examples/CreateSidePanel/example/main.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.scss';
+
+// eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/packages/react/src/examples/CreateSidePanel/example/package.json
+++ b/packages/react/src/examples/CreateSidePanel/example/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "create-side-panel-pattern-example",
+  "description": "An example showing use of the CreateSidePanel pattern from the @carbon/ibm-products library.",
+  "keywords": [
+    "carbon",
+    "ibm",
+    "ibm-products",
+    "pattern",
+    "create-side-panel",
+    "side-panel"
+  ],
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@carbon/ibm-products": "latest",
+    "@carbon/react": "latest",
+    "@carbon/styles": "latest",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "sass": "^1.93.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^7.0.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/packages/react/src/examples/CreateSidePanel/example/preview-components/Default.jsx
+++ b/packages/react/src/examples/CreateSidePanel/example/preview-components/Default.jsx
@@ -1,0 +1,108 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Dropdown, FormGroup, NumberInput, TextInput } from '@carbon/react';
+import { CreateSidePanel } from '../components/CreateSidePanel';
+import '../styles/_create-side-panel.scss';
+
+const blockClass = `create-side-panel`;
+const storyPrefix = `create-side-panel-stories__`;
+const items = ['Day(s)', 'Month(s)', 'Year(s)'];
+
+export const Default = ({
+  primaryButtonText = 'Create',
+  secondaryButtonText = 'Cancel',
+  subtitle = '',
+  title = 'Create partitions',
+  selectorPageContent = '#ibm-products-page-content',
+  open,
+  setOpen,
+  ...rest
+}) => {
+  const clearAndClose = () => setOpen(false);
+
+  return (
+    <CreateSidePanel
+      open={open}
+      title={title}
+      subtitle={subtitle}
+      formTitle="Core configuration"
+      formDescription="We recommend you fill out and evaluate these details at a minimum before deploying your topic."
+      primaryButtonText={primaryButtonText}
+      secondaryButtonText={secondaryButtonText}
+      selectorPageContent={selectorPageContent}
+      selectorPrimaryFocus=".cds--text-input"
+      onRequestClose={clearAndClose}
+      onRequestSubmit={clearAndClose}
+      {...rest}
+    >
+      <TextInput
+        id="create-side-panel-topic-name-a"
+        labelText="Topic name"
+        className={`${storyPrefix}form-item`}
+        placeholder="Enter topic name"
+      />
+      <NumberInput
+        id="create-side-panel-partitions"
+        className={`${storyPrefix}form-item`}
+        label="Partitions"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+      <NumberInput
+        id="create-side-panel-replicas"
+        className={`${storyPrefix}form-item`}
+        label="Replicas"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+      <NumberInput
+        id="create-side-panel-min-in-sync"
+        className={`${storyPrefix}form-item`}
+        label="Minimum in-sync replicas"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+      <div className={`${storyPrefix}example-container`}>
+        <NumberInput
+          id="create-side-panel-retention-time"
+          className={`${storyPrefix}form-item`}
+          label="Retention time"
+          min={0}
+          max={50}
+          value={30}
+          iconDescription="Choose a number"
+        />
+        <Dropdown
+          id="create-side-panel-dropdown-options-a"
+          items={items}
+          initialSelectedItem="Day(s)"
+          label="Options"
+          titleText="Options"
+          className={`${storyPrefix}form-item`}
+        />
+      </div>
+      <NumberInput
+        id="create-side-panel-quantity"
+        className={`${storyPrefix}form-item`}
+        label="Quantity"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+    </CreateSidePanel>
+  );
+};

--- a/packages/react/src/examples/CreateSidePanel/example/preview-components/WithValidation.jsx
+++ b/packages/react/src/examples/CreateSidePanel/example/preview-components/WithValidation.jsx
@@ -1,0 +1,126 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Dropdown, NumberInput, TextInput } from '@carbon/react';
+import { CreateSidePanel } from '../components/CreateSidePanel';
+import '../styles/_create-side-panel.scss';
+
+const storyPrefix = `create-side-panel-stories__`;
+const items = ['Day(s)', 'Month(s)', 'Year(s)'];
+
+export const WithValidation = ({
+  primaryButtonText = 'Create',
+  secondaryButtonText = 'Cancel',
+  subtitle = '',
+  title = 'Create partitions',
+  selectorPageContent = '#ibm-products-page-content',
+  open,
+  setOpen,
+  ...rest
+}) => {
+  const [topicName, setTopicName] = useState('');
+  const [invalid, setInvalid] = useState(false);
+
+  const clearAndClose = () => {
+    setTopicName('');
+    setInvalid(false);
+    setOpen(false);
+  };
+
+  return (
+    <CreateSidePanel
+      open={open}
+      title={title}
+      subtitle={subtitle}
+      formTitle="Core configuration"
+      formDescription="We recommend you fill out and evaluate these details at a minimum before deploying your topic."
+      primaryButtonText={primaryButtonText}
+      secondaryButtonText={secondaryButtonText}
+      selectorPageContent={selectorPageContent}
+      selectorPrimaryFocus="#create-side-panel-topic-name-b"
+      onRequestClose={clearAndClose}
+      onRequestSubmit={clearAndClose}
+      disableSubmit={!topicName.length}
+      {...rest}
+    >
+      <TextInput
+        id="create-side-panel-topic-name-b"
+        labelText="Topic name"
+        className={`${storyPrefix}form-item`}
+        placeholder="Enter topic name"
+        value={topicName}
+        onChange={(e) => {
+          setTopicName(e.target.value);
+          setInvalid(false);
+        }}
+        onBlur={() => {
+          topicName.length === 0 && setInvalid(true);
+        }}
+        invalid={invalid}
+        invalidText="This is a required field"
+      />
+      <NumberInput
+        id="create-side-panel-partitions-b"
+        className={`${storyPrefix}form-item`}
+        label="Partitions"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+      <NumberInput
+        id="create-side-panel-replicas-b"
+        className={`${storyPrefix}form-item`}
+        label="Replicas"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+      <NumberInput
+        id="create-side-panel-min-in-sync-b"
+        className={`${storyPrefix}form-item`}
+        label="Minimum in-sync replicas"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+      <div className={`${storyPrefix}example-container`}>
+        <NumberInput
+          id="create-side-panel-retention-time-b"
+          className={`${storyPrefix}form-item`}
+          label="Retention time"
+          min={0}
+          max={50}
+          value={30}
+          iconDescription="Choose a number"
+        />
+        <Dropdown
+          id="create-side-panel-dropdown-options-b"
+          aria-label="Dropdown"
+          items={items}
+          initialSelectedItem="Day(s)"
+          label="Options"
+          titleText="Options"
+          className={`${storyPrefix}form-item`}
+        />
+      </div>
+      <NumberInput
+        id="create-side-panel-quantity-b"
+        className={`${storyPrefix}form-item`}
+        label="Quantity"
+        min={0}
+        max={50}
+        value={1}
+        iconDescription="Choose a number"
+      />
+    </CreateSidePanel>
+  );
+};

--- a/packages/react/src/examples/CreateSidePanel/example/styles/_create-side-panel.scss
+++ b/packages/react/src/examples/CreateSidePanel/example/styles/_create-side-panel.scss
@@ -1,0 +1,50 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/config' as carbon-config;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/ibm-products/scss/components/SidePanel';
+
+.create-side-panel__form-title {
+  @include type.type-style('heading-compact-02');
+
+  padding-block-end: $spacing-03;
+}
+
+.create-side-panel__form-description {
+  @include type.type-style('body-01');
+
+  margin-block-end: $spacing-05;
+}
+
+.create-side-panel__form .cds--form-item {
+  margin-block-end: $spacing-05;
+
+  &:last-child {
+    margin-block-end: 0;
+  }
+}
+
+// Story-specific helpers (mirrors the component's _storybook-styles.scss)
+.create-side-panel-stories__example-container {
+  display: grid;
+  align-items: flex-end;
+  grid-gap: $spacing-03;
+  grid-template-columns: 1fr 1fr;
+}
+
+.create-side-panel-stories__example-form-group
+  > legend.cds--label {
+  margin-block-end: 0;
+  padding-block-end: $spacing-03;
+  padding-block-start: $spacing-03;
+}
+
+.create-side-panel-stories__form-item {
+  margin-block-end: $spacing-05;
+}

--- a/packages/react/src/examples/CreateSidePanel/example/styles/_create-side-panel.scss
+++ b/packages/react/src/examples/CreateSidePanel/example/styles/_create-side-panel.scss
@@ -8,7 +8,7 @@
 @use '@carbon/styles/scss/config' as carbon-config;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
-@use '@carbon/ibm-products/scss/components/SidePanel';
+@use '@carbon/ibm-products-styles/scss/components/SidePanel';
 
 .create-side-panel__form-title {
   @include type.type-style('heading-compact-02');

--- a/packages/react/src/examples/CreateSidePanel/example/styles/_story-styles.scss
+++ b/packages/react/src/examples/CreateSidePanel/example/styles/_story-styles.scss
@@ -1,0 +1,15 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/spacing' as *;
+
+.create-side-panel-stories__launcher-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-block-size: calc(100vh - #{$spacing-09});
+}

--- a/packages/react/src/examples/CreateSidePanel/example/vite.config.ts
+++ b/packages/react/src/examples/CreateSidePanel/example/vite.config.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/react/src/examples/CreateTearsheet/CreateTearsheet.mdx
+++ b/packages/react/src/examples/CreateTearsheet/CreateTearsheet.mdx
@@ -1,0 +1,223 @@
+import { Story, Controls, Source, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import * as stories from './CreateTearsheet.stories';
+
+<Meta isTemplate />
+
+# Create Tearsheet Pattern
+
+[Usage guidelines](https://carbondesignsystem.com/patterns/create-flows/usage/#wide-tearsheet)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [What is a Pattern?](#what-is-a-pattern)
+- [Getting Started](#getting-started)
+- [Example Usage](#example-usage)
+- [Architecture](#architecture)
+- [Customization](#customization)
+
+## Overview
+
+The `CreateTearsheet` is a **pattern** (not a component) that provides a recipe
+for building multi-step workflow interfaces for creating resources or completing
+complex tasks. It demonstrates how to compose the Tearsheet component with
+StepFlow from `@carbon/utilities-react` for managing step navigation and state.
+
+> 💡 Try our
+> [StackBlitz example](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateTearsheet/example)
+> for a complete implementation.
+
+[![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateTearsheet/example)
+
+## What is a Pattern?
+
+Unlike components that are exported from the package, **patterns are recipes**
+that you copy into your codebase and customize to fit your specific needs. This
+approach offers:
+
+- **Full Control**: Modify the code to match your exact requirements
+- **No Breaking Changes**: Updates to the pattern don't affect your
+  implementation
+- **Seamless Customization**: Adapt the pattern without workarounds or prop
+  drilling
+- **Scalability**: Build upon the foundation with your own features
+
+The CreateTearsheet pattern consists of:
+
+- `CreateTearsheet.tsx` - Main tearsheet wrapper component
+- `CreateTearsheetStep.tsx` - Individual step component
+- `CreateTearsheetContext.tsx` - Context for sharing state
+- Styles and utilities
+
+## Getting Started
+
+1. **Copy the pattern code** from the
+   [example directory](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateTearsheet/example/components)
+   into your project
+2. **Install dependencies**: `@carbon/react`, `@carbon/utilities-react`
+3. **Import and use** the pattern components in your application
+4. **Customize** as needed for your use case
+
+The pattern uses:
+
+- **Tearsheet component** (`@carbon/react`): Provides the modal container
+  and layout
+- **StepProvider** (`@carbon/utilities-react`): Manages step navigation and form
+  state
+- **Carbon React components**: For form inputs and UI elements
+
+### Key Features
+
+- **Multi-step workflow**: Guide users through complex creation processes
+- **Progress indication**: Visual feedback with vertical progress indicators
+- **Responsive design**: Progress indicator automatically switches to a side
+  panel on small screens
+- **Step management**: Built-in navigation with back, next, and submit actions
+- **Form state management**: Integrated state management across steps
+
+### Key Implementation Steps
+
+1. **Copy Pattern Files**: Copy the pattern components from the example
+   directory into your project
+2. **StepProvider Wrapper**: Always wrap `CreateTearsheet` with `StepProvider`
+   for step management
+3. **Form State Management**: Use `useStepContext()` hook to access and update
+   form state across steps
+4. **Open State**: Manage `open` state in parent component and pass both `open`
+   and `setOpen` props
+5. **Customization**: Modify the copied pattern files to fit your specific needs
+
+## Example Usage
+
+### Create Tearsheet
+
+<Canvas
+  of={stories.multiStepTearsheet}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.multiStepTearsheet),
+    },
+  ]}
+/>
+
+### With Intro Step
+
+<Canvas
+  of={stories.withIntroStep}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.withIntroStep),
+    },
+  ]}
+/>
+
+### With Step in Error State
+
+<Canvas
+  of={stories.withErrorState}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.withErrorState),
+    },
+  ]}
+/>
+
+## Customization
+
+Since this is a pattern (not a component), you have full control to customize:
+
+### Modify Validation Logic
+
+Edit the `handleNextDisabledState` function in your copied
+`CreateTearsheet.tsx`:
+
+```jsx
+const handleNextDisabledState = (formState, currentStep) => {
+  // Add your custom validation logic
+  if (currentStep === 1 && !formState?.requiredField) {
+    return true;
+  }
+  return false;
+};
+```
+
+### Add Custom Buttons
+
+Modify the footer section in `CreateTearsheet.tsx`:
+
+```jsx
+<Tearsheet.Footer>
+  <ButtonSet>
+    {/* Add your custom buttons */}
+    <Button kind="ghost">Save Draft</Button>
+    <Button kind="secondary" onClick={handlePrevious}>
+      Back
+    </Button>
+    <Button onClick={handleNext}>Next</Button>
+  </ButtonSet>
+</Tearsheet.Footer>
+```
+
+### Customize Step Layout
+
+Edit `CreateTearsheetStep.tsx` to change the layout structure:
+
+```jsx
+// Modify the Grid/Column structure
+<Grid>
+  <Column xlg={16} lg={16} md={8} sm={4}>
+    {/* Your custom layout */}
+  </Column>
+</Grid>
+```
+
+## Architecture
+
+The CreateTearsheet pattern is built on top of:
+
+- **Tearsheet component** (`@carbon/react`): Provides the modal container
+  and layout with responsive behavior
+- **StepProvider** (`@carbon/utilities-react`): Manages step navigation and
+  state through `useStepContext`
+- **React Context**: Custom `CreateTearsheetContext` for sharing state like
+  `open` prop
+- **Carbon React components**: For form inputs and UI elements
+
+### Step Management
+
+Steps are managed using the `StepProvider` and `useStepContext` from
+`@carbon/utilities-react`. The provider wraps the CreateTearsheet and provides:
+
+- Current step tracking
+- Navigation methods (`handleNext`, `handlePrevious`, `handleGoToStep`)
+- Form state management (`formState`, `setFormState`)
+- Total step count
+
+**Important**: Always wrap your `CreateTearsheet` with `<StepProvider>` for
+proper step management.
+
+### Responsive Behavior
+
+The progress indicator adapts to screen size:
+
+- **Large screens**: Vertical progress indicator displayed in the influencer
+  panel
+- **Small screens**: Progress indicator automatically switches to a side panel
+  for better mobile experience
+
+### State Management
+
+- **Step state**: Managed by `StepProvider` from `@carbon/utilities-react`
+- **Form state**: Shared across steps via `useStepContext()` hook
+- **Open state**: Managed in parent component and passed via props
+- **Auto-reset**: Tearsheet automatically resets to step 1 when closed using
+  `useEffect`
+
+## Feedback
+
+Help us improve this pattern by providing feedback through
+[GitHub issues](https://github.com/carbon-design-system/carbon/issues/new/choose).

--- a/packages/react/src/examples/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/react/src/examples/CreateTearsheet/CreateTearsheet.stories.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import './example/styles/_create-tearsheet.scss';
+import './example/styles/_story-styles.scss';
+import DocsPage from './CreateTearsheet.mdx';
+import { MultiStepTearsheet } from './example/preview-components/MultiStepTearsheet';
+import { MultiStepWithIntro } from './example/preview-components/MultiStepWithIntro';
+import { MultiStepWithStepInErrorState } from './example/preview-components/MultiStepWithStepInErrorState';
+import { TruncatedText } from '../../components/TruncatedText';
+
+export default {
+  title: 'Examples/Create flows/Create Tearsheet',
+  component: MultiStepTearsheet,
+  tags: ['autodocs'],
+  argTypes: {
+    description: {
+      control: {
+        type: 'select',
+        labels: {
+          0: 'With plain String',
+          1: 'With TruncatedText and 1 line',
+          2: 'With TruncatedText and 2 lines',
+        },
+        default: 0,
+      },
+      description:
+        'A description of the flow, displayed in the header area of the tearsheet.\n Note: `TruncatedText` can be passed as a React node to apply custom text formatting, including ellipsis truncation and a definition tooltip when the content is too long.',
+      options: [0, 1, 2],
+      mapping: {
+        0: 'Specify details for the new topic you want to create',
+        1: (
+          <TruncatedText
+            align="bottom"
+            lines={1}
+            value="This is a description for the tearsheet, providing an opportunity to describe the flow over a couple of lines in the header of the tearsheet."
+          />
+        ),
+        2: (
+          <TruncatedText
+            align="bottom"
+            lines={2}
+            value="This is a description for the tearsheet, providing an opportunity to describe the flow over a couple of lines in the header of the tearsheet."
+          />
+        ),
+      },
+    },
+    initialStep: {
+      control: { type: 'number', min: 1 },
+      description:
+        'The step number to open when the tearsheet is first displayed. Use this to open the tearsheet at a specific step instead of starting at step 1.',
+    },
+    label: { control: { type: 'text' } },
+    title: { control: { type: 'text' } },
+    onClose: { control: { disable: true } },
+    navigation: { control: { disable: true } },
+    open: { control: { disable: true } },
+    children: { control: { disable: true } },
+  },
+  parameters: {
+    docs: { page: DocsPage },
+  },
+};
+
+const createTearsheetProps = {
+  title: 'Create topic',
+  description: 0,
+  submitButtonText: 'Create',
+  cancelButtonText: 'Cancel',
+  backButtonText: 'Back',
+  nextButtonText: 'Next',
+  className: 'test-class-name',
+  label: '',
+};
+
+export const multiStepTearsheet = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <style>{`.tearsheet-create-multi-step { opacity: 0 }`}</style>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Close CreateTearsheet' : 'Open CreateTearsheet'}
+      </Button>
+      <MultiStepTearsheet {...args} open={open} setOpen={setOpen} />
+    </>
+  );
+};
+multiStepTearsheet.storyName = 'Create tearsheet';
+multiStepTearsheet.args = {
+  ...createTearsheetProps,
+};
+
+export const withIntroStep = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <style>{`.tearsheet-create-multi-step { opacity: 0 }`}</style>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Close CreateTearsheet' : 'Open CreateTearsheet'}
+      </Button>
+      <MultiStepWithIntro {...args} open={open} setOpen={setOpen} />
+    </>
+  );
+};
+withIntroStep.storyName = 'Create tearsheet with intro step';
+withIntroStep.args = {
+  ...createTearsheetProps,
+};
+
+export const withErrorState = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <style>{`.tearsheet-create-multi-step { opacity: 0 }`}</style>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Close CreateTearsheet' : 'Open CreateTearsheet'}
+      </Button>
+      <MultiStepWithStepInErrorState {...args} open={open} setOpen={setOpen} />
+    </>
+  );
+};
+withErrorState.storyName = 'Create tearsheet with step in error state';
+withErrorState.args = {
+  ...createTearsheetProps,
+};

--- a/packages/react/src/examples/CreateTearsheet/example/App.tsx
+++ b/packages/react/src/examples/CreateTearsheet/example/App.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import { MultiStepTearsheet } from './preview-components/MultiStepTearsheet';
+import { MultiStepWithIntro } from './preview-components/MultiStepWithIntro';
+import { MultiStepWithStepInErrorState } from './preview-components/MultiStepWithStepInErrorState';
+import './index.scss';
+
+export const App = () => {
+  const [openMultiStep, setOpenMultiStep] = useState(false);
+  const [openWithIntro, setOpenWithIntro] = useState(false);
+  const [openWithError, setOpenWithError] = useState(false);
+
+  const commonProps = {
+    title: 'Create topic',
+    description: 'Specify details for the new topic you want to create',
+    submitButtonText: 'Create',
+    cancelButtonText: 'Cancel',
+    backButtonText: 'Back',
+    nextButtonText: 'Next',
+  };
+
+  return (
+    <div className="app-container" style={{ padding: '2rem' }}>
+      <h1>CreateTearsheet Patterns</h1>
+      <p style={{ marginBottom: '2rem' }}>
+        Examples demonstrating the CreateTearsheet pattern with StepFlow.
+      </p>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: '1rem',
+          flexDirection: 'column',
+          maxWidth: '400px',
+        }}
+      >
+        <Button onClick={() => setOpenMultiStep(!openMultiStep)}>
+          {openMultiStep ? 'Close' : 'Open'} Multi-step Tearsheet
+        </Button>
+
+        <Button onClick={() => setOpenWithIntro(!openWithIntro)}>
+          {openWithIntro ? 'Close' : 'Open'} Tearsheet with Intro Step
+        </Button>
+
+        <Button onClick={() => setOpenWithError(!openWithError)}>
+          {openWithError ? 'Close' : 'Open'} Tearsheet with Error State
+        </Button>
+      </div>
+
+      <MultiStepTearsheet
+        {...commonProps}
+        open={openMultiStep}
+        setOpen={setOpenMultiStep}
+      />
+
+      <MultiStepWithIntro
+        {...commonProps}
+        open={openWithIntro}
+        setOpen={setOpenWithIntro}
+      />
+
+      <MultiStepWithStepInErrorState
+        {...commonProps}
+        open={openWithError}
+        setOpen={setOpenWithError}
+      />
+    </div>
+  );
+};
+
+export default App;

--- a/packages/react/src/examples/CreateTearsheet/example/README.md
+++ b/packages/react/src/examples/CreateTearsheet/example/README.md
@@ -1,0 +1,62 @@
+# CreateTearsheet Pattern Example
+
+This example demonstrates the CreateTearsheet pattern using the new Tearsheet
+architecture with StepFlow from `@carbon/utilities-react`.
+
+## Structure
+
+```
+/example
+  /components        ← Pattern implementation (private, not exported)
+    CreateTearsheet.tsx
+    CreateTearsheetStep.tsx
+    CreateTearsheetDivider.tsx
+  /styles
+    _create-tearsheet.scss
+  /assets
+    create_tearsheet_anatomy.jpg
+  index.html
+  main.tsx
+  App.tsx
+  package.json
+  README.md
+```
+
+## Running the Example
+
+### Local Development
+
+1. Install dependencies:
+
+```bash
+yarn install
+```
+
+2. Run the development server:
+
+```bash
+yarn dev
+```
+
+3. Open your browser to the URL shown in the terminal (typically
+   `http://localhost:5173`)
+
+### StackBlitz
+
+This example is configured to run on StackBlitz. You can open it directly from
+the Storybook documentation.
+
+## Key Features
+
+- **New Tearsheet Architecture**: Uses the new Tearsheet component from
+  `@carbon/ibm-products/es/components/Tearsheet/next`
+- **StepFlow Integration**: Leverages `@carbon/utilities-react` for step
+  management
+- **Progress Indicators**: Supports both vertical and horizontal progress
+  indicators
+- **Flexible Layout**: Wide and narrow variants available
+- **Form State Management**: Built-in state management across steps
+
+## License
+
+Apache-2.0

--- a/packages/react/src/examples/CreateTearsheet/example/components/CreateTearsheet.tsx
+++ b/packages/react/src/examples/CreateTearsheet/example/components/CreateTearsheet.tsx
@@ -1,0 +1,340 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {
+  ReactNode,
+  RefObject,
+  Children,
+  isValidElement,
+  useState,
+  ReactElement,
+  useEffect,
+  useMemo,
+} from 'react';
+import {
+  StepGroup,
+  StepContextType,
+  useStepContext,
+} from '@carbon/utilities-react';
+import { ArrowRight } from '@carbon/react/icons';
+import { preview__Tearsheet as Tearsheet } from '@carbon/ibm-products';
+import { CreateTearsheetProvider } from './CreateTearsheetContext';
+import {
+  Button,
+  InlineLoading,
+  ProgressIndicator,
+  ProgressStep,
+} from '@carbon/react';
+
+export interface CreateTearsheetProps {
+  children?: ReactNode;
+  influencer?: ((a: StepContextType) => ReactNode) | null;
+  open?: boolean;
+  onClose?: () => void;
+  title?: string;
+  label?: string;
+  description?: string;
+  hasCloseIcon?: boolean;
+  closeIconDescription?: string;
+  selectorPrimaryFocus?: string;
+  setOpen?: (open: boolean) => void;
+  progressIndicator?: 'vertical' | 'horizontal';
+  launcherButtonRef?: RefObject<HTMLButtonElement | null>;
+  submitButtonText?: string;
+  cancelButtonText?: string;
+  backButtonText?: string;
+  nextButtonText?: string;
+  onRequestSubmit?: () => void | Promise<void>;
+  onNext?: (context: {
+    currentStep: number;
+    totalSteps: number;
+    formState: any;
+  }) => void | Promise<void>;
+  variant?: 'wide' | 'narrow';
+  influencerWidth?: string;
+  decorator?: ReactNode;
+  headerActions?: ReactNode;
+  steps?: Array<{ label?: string; secondaryLabel?: string }>;
+  hasError?: boolean;
+  handleNextDisabledState?: (formState: any, currentStep: number) => boolean;
+  handleBackDisabledState?: (currentStep: number) => boolean;
+  initialStep?: number;
+}
+
+export const CreateTearsheet = ({
+  children,
+  open,
+  setOpen,
+  onClose,
+  influencer,
+  title = 'Create',
+  label,
+  description,
+  hasCloseIcon = true,
+  closeIconDescription = 'Close',
+  selectorPrimaryFocus,
+  progressIndicator = 'vertical',
+  launcherButtonRef,
+  submitButtonText = 'Create',
+  cancelButtonText = 'Cancel',
+  backButtonText = 'Back',
+  nextButtonText = 'Next',
+  onRequestSubmit,
+  variant = 'wide',
+  influencerWidth,
+  decorator,
+  headerActions,
+  steps,
+  hasError,
+  handleNextDisabledState,
+  handleBackDisabledState,
+  onNext,
+  initialStep,
+  ...rest
+}: CreateTearsheetProps) => {
+  const {
+    totalSteps,
+    currentStep,
+    handleNext,
+    handlePrevious,
+    handleGoToStep,
+    formState,
+    setFormState,
+  } = useStepContext();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [influencerPanelOpen, setInfluencerPanelOpen] = useState(false);
+
+  // Set initial step when tearsheet opens or when initialStep changes
+  useEffect(() => {
+    if (open && initialStep && initialStep !== currentStep) {
+      handleGoToStep(initialStep);
+    }
+  }, [open, initialStep]);
+
+  // Reset to step 1 when tearsheet closes
+  useEffect(() => {
+    if (!open && currentStep !== 1) {
+      handleGoToStep(1);
+      setFormState({});
+    }
+  }, [open, currentStep, handleGoToStep, setFormState]);
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    const abortAction = await onRequestSubmit?.();
+
+    if (abortAction) {
+      return;
+    }
+    setOpen?.(false);
+    handleGoToStep(1);
+    setFormState({});
+    setIsLoading(false);
+  };
+
+  const handleNextClick = async () => {
+    setIsLoading(true);
+    const abortAction = await onNext?.({
+      currentStep,
+      totalSteps,
+      formState,
+    });
+    setIsLoading(false);
+    if (abortAction) {
+      return;
+    }
+    handleNext();
+  };
+
+  // Extract step labels from children if not provided, excluding steps with includeStep={false} and introStep={true}
+  const stepLabels =
+    steps ||
+    Children.toArray(children)
+      .filter((child) => {
+        if (!isValidElement(child)) {
+          return false;
+        }
+        const childProps = (child as any).props;
+        // Exclude steps that have includeStep explicitly set to false
+        if (childProps?.includeStep === false) {
+          return false;
+        }
+        // Exclude intro steps from progress indicator
+        if (childProps?.hideSteps === true) {
+          return false;
+        }
+        return true;
+      })
+      .map((child: any, index) => ({
+        label: child.props?.label || child.props?.title || `Step ${index + 1}`,
+        secondaryLabel: child.props?.secondaryLabel,
+        invalid: child.props?.invalid,
+      }));
+
+  // Get all valid children (excluding those with includeStep={false})
+  const validChildren = Children.toArray(children).filter((child) => {
+    if (!isValidElement(child)) {
+      return false;
+    }
+    const childProps = (child as any).props;
+    return childProps?.includeStep !== false;
+  });
+
+  // Get current step child
+  const currentStepChild = validChildren[currentStep - 1];
+
+  const hideSteps = isValidElement(currentStepChild)
+    ? (currentStepChild as ReactElement<any>).props?.hideSteps
+    : false;
+
+  // Get invalid state from current step
+  const currentStepInvalid = isValidElement(currentStepChild)
+    ? (currentStepChild as ReactElement<any>).props?.invalid
+    : false;
+
+  // Calculate the progress indicator step index by counting non-hidden steps before current step
+  const progressIndicatorStepIndex = validChildren
+    .slice(0, currentStep)
+    .filter((child) => {
+      if (!isValidElement(child)) {
+        return false;
+      }
+      const childProps = (child as any).props;
+      return childProps?.hideSteps !== true;
+    }).length;
+
+  // Use provided validation functions or default behavior
+  const isNextDisabled = handleNextDisabledState
+    ? handleNextDisabledState(formState, currentStep) ||
+      isLoading ||
+      hasError ||
+      currentStepInvalid
+    : isLoading || hasError || currentStepInvalid;
+
+  const isBackDisabled = handleBackDisabledState
+    ? handleBackDisabledState(currentStep) || isLoading
+    : currentStep === 1 || isLoading;
+
+  // Create actions array for the footer
+  const actions = useMemo(
+    () => [
+      {
+        key: 'cancel',
+        kind: 'ghost' as const,
+        label: cancelButtonText,
+        onClick: () => {
+          onClose?.();
+          setOpen?.(false);
+        },
+        disabled: isLoading,
+      },
+      {
+        key: 'back',
+        kind: 'secondary' as const,
+        label: backButtonText,
+        onClick: () => {
+          handlePrevious();
+        },
+        disabled: isBackDisabled,
+      },
+      {
+        key: 'next',
+        kind: 'primary' as const,
+        label: currentStep === totalSteps ? submitButtonText : nextButtonText,
+        onClick: () => {
+          if (currentStep === totalSteps) {
+            handleSubmit();
+          } else {
+            handleNextClick();
+          }
+        },
+        disabled: isNextDisabled,
+        renderIcon: isLoading ? () => <InlineLoading /> : undefined,
+      },
+    ],
+    [
+      cancelButtonText,
+      backButtonText,
+      submitButtonText,
+      nextButtonText,
+      currentStep,
+      totalSteps,
+      isLoading,
+      isBackDisabled,
+      isNextDisabled,
+      onClose,
+      setOpen,
+      handlePrevious,
+      handleSubmit,
+      handleNextClick,
+    ]
+  );
+
+  return (
+    <CreateTearsheetProvider value={{ open }}>
+      <Tearsheet
+        open={open}
+        variant={variant}
+        onClose={() => {
+          onClose?.();
+          setOpen?.(false);
+        }}
+        launcherButtonRef={launcherButtonRef}
+        influencerWidth={influencerWidth}
+        decorator={decorator}
+        preventCloseOnClickOutside
+        {...rest}
+      >
+        <Tearsheet.Header hideCloseButton>
+          <Tearsheet.HeaderContent
+            label={label || ''}
+            title={title || ''}
+            description={description || ''}
+            headerActions={headerActions}
+          />
+        </Tearsheet.Header>
+        {progressIndicator === 'vertical' && !hideSteps && (
+          <Tearsheet.Influencer
+            influencerPanelOpen={influencerPanelOpen}
+            onInfluencerPanelClose={() => setInfluencerPanelOpen(false)}
+          >
+            <ProgressIndicator vertical className="influencer__content">
+              {stepLabels.map((step, index) => (
+                <ProgressStep
+                  key={index}
+                  complete={progressIndicatorStepIndex > index + 1}
+                  current={progressIndicatorStepIndex === index + 1}
+                  label={step.label}
+                  secondaryLabel={step.secondaryLabel}
+                  invalid={step.invalid}
+                />
+              ))}
+            </ProgressIndicator>
+          </Tearsheet.Influencer>
+        )}
+        <Tearsheet.Body>
+          <Tearsheet.MainContent isFlush={true}>
+            <Button
+              size="sm"
+              kind="ghost"
+              className="showInfluencer"
+              onClick={() => setInfluencerPanelOpen(true)}
+            >
+              Show Influencer
+              <ArrowRight size={16} />
+            </Button>
+            <StepGroup>{children}</StepGroup>
+          </Tearsheet.MainContent>
+        </Tearsheet.Body>
+        <Tearsheet.Footer actions={actions} buttonSize="2xl" />
+      </Tearsheet>
+    </CreateTearsheetProvider>
+  );
+};
+
+CreateTearsheet.displayName = 'CreateTearsheet';

--- a/packages/react/src/examples/CreateTearsheet/example/components/CreateTearsheetContext.tsx
+++ b/packages/react/src/examples/CreateTearsheet/example/components/CreateTearsheetContext.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { createContext, useContext, ReactNode } from 'react';
+
+interface CreateTearsheetContextType {
+  open?: boolean;
+}
+
+const CreateTearsheetContext = createContext<
+  CreateTearsheetContextType | undefined
+>(undefined);
+
+export const CreateTearsheetProvider = ({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: CreateTearsheetContextType;
+}) => {
+  return (
+    <CreateTearsheetContext.Provider value={value}>
+      {children}
+    </CreateTearsheetContext.Provider>
+  );
+};
+
+export const useCreateTearsheetContext = () => {
+  const context = useContext(CreateTearsheetContext);
+  if (context === undefined) {
+    throw new Error(
+      'useCreateTearsheetContext must be used within a CreateTearsheetProvider'
+    );
+  }
+  return context;
+};

--- a/packages/react/src/examples/CreateTearsheet/example/components/CreateTearsheetStep.tsx
+++ b/packages/react/src/examples/CreateTearsheet/example/components/CreateTearsheetStep.tsx
@@ -1,0 +1,164 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {
+  useEffect,
+  PropsWithChildren,
+  isValidElement,
+  forwardRef,
+  RefObject,
+  useRef,
+} from 'react';
+import { Heading, FormGroup, Grid, Column } from '@carbon/react';
+import cx from 'classnames';
+import { useStepContext } from '@carbon/utilities-react';
+import { useCreateTearsheetContext } from './CreateTearsheetContext';
+
+const blockClass = 'create-tearsheet-step';
+
+// Default values for props
+const defaults = {
+  hasFieldset: true,
+  includeStep: true,
+};
+
+type fieldsetLegendTextProps =
+  | {
+      hasFieldset: false;
+      fieldsetLegendText?: string;
+      fieldsetLegendId?: React.ReactNode;
+    }
+  | {
+      hasFieldset?: true;
+      fieldsetLegendText?: string;
+      fieldsetLegendId?: React.ReactNode;
+    };
+
+interface CreateTearsheetStepBaseProps extends PropsWithChildren {
+  children?: React.ReactNode;
+  className?: string;
+  description?: React.ReactNode;
+  subtitle?: string;
+  title: React.ReactNode;
+  label?: string;
+  secondaryLabel?: string;
+  onMount?: () => void;
+  primaryFocusElement?: string;
+  includeStep?: boolean;
+  invalid?: boolean;
+  hideSteps?: boolean;
+  disableSubmit?: boolean;
+}
+
+type CreateTearsheetStepProps = CreateTearsheetStepBaseProps &
+  fieldsetLegendTextProps;
+
+export const CreateTearsheetStep = forwardRef<
+  HTMLDivElement,
+  CreateTearsheetStepProps
+>(
+  (
+    {
+      children,
+      className,
+      description,
+      subtitle,
+      title,
+      label,
+      secondaryLabel,
+      onMount,
+      primaryFocusElement,
+      fieldsetLegendText,
+      fieldsetLegendId,
+      hasFieldset = defaults.hasFieldset,
+      includeStep = defaults.includeStep,
+      invalid,
+      hideSteps,
+      disableSubmit,
+      ...rest
+    },
+    ref
+  ) => {
+    const localRef = useRef<HTMLDivElement>(null);
+    const stepRef = ref || localRef;
+    const { currentStep, totalSteps } = useStepContext();
+    const { open } = useCreateTearsheetContext();
+
+    useEffect(() => {
+      if (onMount) {
+        onMount();
+      }
+    }, [onMount]);
+
+    useEffect(() => {
+      if (primaryFocusElement && open) {
+        const element = document.querySelector(
+          primaryFocusElement
+        ) as HTMLElement;
+        setTimeout(() => {
+          element?.focus();
+        });
+      }
+    }, [primaryFocusElement, currentStep, open]);
+
+    const renderDescription = () => {
+      if (description) {
+        if (typeof description === 'string') {
+          return <p className={`${blockClass}__description`}>{description}</p>;
+        }
+        if (isValidElement(description)) {
+          return (
+            <div className={`${blockClass}__description`}>{description}</div>
+          );
+        }
+      }
+      return null;
+    };
+
+    // Don't render the step at all if includeStep is false
+    if (!includeStep) {
+      return null;
+    }
+
+    return (
+      <div ref={stepRef as RefObject<HTMLDivElement>}>
+        <Grid
+          {...rest}
+          className={cx(blockClass, className, {
+            [`${blockClass}--visible-step`]: includeStep,
+          })}
+        >
+          <Column xlg={12} lg={12} md={8} sm={4}>
+            <Heading className={`${blockClass}__title`}>{title}</Heading>
+
+            {subtitle && (
+              <h5 className={`${blockClass}__subtitle`}>{subtitle}</h5>
+            )}
+
+            {renderDescription()}
+          </Column>
+
+          <Column span={100}>
+            {hasFieldset ? (
+              <FormGroup
+                legendText={fieldsetLegendText}
+                className={`${blockClass}__fieldset`}
+                legendId={fieldsetLegendId}
+              >
+                {children}
+              </FormGroup>
+            ) : (
+              <div className={`${blockClass}__content`}>{children}</div>
+            )}
+          </Column>
+        </Grid>
+      </div>
+    );
+  }
+);
+
+CreateTearsheetStep.displayName = 'CreateTearsheetStep';

--- a/packages/react/src/examples/CreateTearsheet/example/index.html
+++ b/packages/react/src/examples/CreateTearsheet/example/index.html
@@ -1,0 +1,19 @@
+<!-- 
+ Copyright IBM Corp. 2026
+ 
+  This source code is licensed under the Apache-2.0 license found in the
+  LICENSE file in the root directory of this source tree.
+   -->
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CreateTearsheet Pattern Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/examples/CreateTearsheet/example/index.scss
+++ b/packages/react/src/examples/CreateTearsheet/example/index.scss
@@ -1,0 +1,56 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/config' with (
+  $font-path: '@ibm/plex'
+);
+@use '@carbon/styles';
+
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as theme;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/motion' as *;
+@use './styles/_create-tearsheet';
+@use './styles/_story-styles';
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+#root {
+  min-block-size: 100vh;
+}
+
+.app-container {
+  max-inline-size: 1200px;
+}
+
+.example-container {
+  margin-inline-start: $spacing-02;
+  max-inline-size: 1200px;
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 400;
+    margin-block-end: $spacing-07;
+  }
+
+  .example-section {
+    padding: $spacing-07;
+    border: 1px solid var(--cds-border-subtle);
+    background-color: var(--cds-layer-01);
+    margin-block-end: $spacing-05;
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-block: 0 $spacing-06;
+    }
+  }
+}

--- a/packages/react/src/examples/CreateTearsheet/example/main.tsx
+++ b/packages/react/src/examples/CreateTearsheet/example/main.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles/_create-tearsheet.scss';
+
+const root = createRoot(document.getElementById('root')!);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/react/src/examples/CreateTearsheet/example/package.json
+++ b/packages/react/src/examples/CreateTearsheet/example/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "create-tearsheet-pattern-example",
+  "description": "An example showing use of the CreateTearsheet pattern from the @carbon/ibm-products component library.",
+  "keywords": [
+    "carbon",
+    "ibm",
+    "ibm-products",
+    "pattern",
+    "create-tearsheet",
+    "tearsheet"
+  ],
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@carbon/ibm-products": "latest",
+    "@carbon/react": "latest",
+    "@carbon/styles": "latest",
+    "@carbon/utilities-react": "latest",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "sass": "^1.93.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^8.0.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/packages/react/src/examples/CreateTearsheet/example/preview-components/MultiStepTearsheet.jsx
+++ b/packages/react/src/examples/CreateTearsheet/example/preview-components/MultiStepTearsheet.jsx
@@ -1,0 +1,398 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  Column,
+  Grid,
+  InlineNotification,
+  RadioButtonGroup,
+  RadioButton,
+  TextInput,
+  Toggle,
+  NumberInput,
+  Checkbox,
+  Link,
+} from '@carbon/react';
+import { StepProvider, useStepContext } from '@carbon/utilities-react';
+import cx from 'classnames';
+import { CreateTearsheet } from '../components/CreateTearsheet';
+import { CreateTearsheetStep } from '../components/CreateTearsheetStep';
+
+const blockClass = `tearsheet-create-multi-step`;
+
+const Step1 = ({
+  shouldReject,
+  setShouldReject,
+  hasSubmitError,
+  setHasSubmitError,
+  isInvalid,
+  setIsInvalid,
+  shouldIncludeAdditionalStep,
+  setShouldIncludeAdditionalStep,
+  simulatedDelay,
+  blockClass,
+  rest,
+}) => {
+  const { formState, setFormState } = useStepContext();
+  const { topicName, topicDescription, topicVersion } = formState || {};
+
+  return (
+    <CreateTearsheetStep
+      {...rest}
+      primaryFocusElement="#tearsheet-multi-step-story-text-input-multi-step-1"
+      title="Topic name"
+      fieldsetLegendText="Topic information"
+      subtitle="This is the unique name used to recognize your topic"
+      description={
+        <div>
+          It will also be used by your producers and consumers as part of the
+          connection information, so make it something easy to recognize.{' '}
+          <Link href="#">Learn more.</Link>
+        </div>
+      }
+    >
+      <Grid>
+        <Column xlg={8} lg={8} md={8} sm={4}>
+          <TextInput
+            labelText="Topic name"
+            placeholder="Enter topic name"
+            id="tearsheet-multi-step-story-text-input-multi-step-1"
+            value={topicName || ''}
+            onChange={(event) => {
+              if (event.target.value.length) {
+                setIsInvalid(false);
+              }
+              setFormState((prev) => ({
+                ...prev,
+                topicName: event.target.value,
+              }));
+            }}
+            invalid={isInvalid}
+            invalidText="This is a required field"
+          />
+          <TextInput
+            labelText="Topic description (optional)"
+            id="tearsheet-multi-step-story-text-input-multi-step-1-input-2"
+            value={topicDescription || ''}
+            placeholder="Enter topic description"
+            onChange={(event) =>
+              setFormState((prev) => ({
+                ...prev,
+                topicDescription: event.target.value,
+              }))
+            }
+          />
+          <TextInput
+            labelText="Topic version (optional)"
+            id="tearsheet-multi-step-story-text-input-multi-step-1-input-3"
+            value={topicVersion || ''}
+            placeholder="Enter topic version"
+            onChange={(event) =>
+              setFormState((prev) => ({
+                ...prev,
+                topicVersion: event.target.value,
+              }))
+            }
+          />
+
+          {hasSubmitError && (
+            <InlineNotification
+              kind="error"
+              title="Error"
+              subtitle="Resolve errors to continue"
+              id="step-submit-error"
+              onClose={() => setHasSubmitError(false)}
+            />
+          )}
+          <Toggle
+            className={`${blockClass}__error--toggle`}
+            id="simulated-error-toggle"
+            size="sm"
+            labelText="Simulate error"
+            onToggle={(event) => setShouldReject(event)}
+          />
+          <Checkbox
+            labelText={`Include additional step`}
+            id="include-additional-step-checkbox"
+            onChange={(event, { checked }) =>
+              setShouldIncludeAdditionalStep(checked)
+            }
+            checked={shouldIncludeAdditionalStep}
+          />
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+const CustomStep = ({ ...rest }) => {
+  const { formState, setFormState } = useStepContext();
+  const { location } = formState || {};
+
+  return (
+    <CreateTearsheetStep {...rest} primaryFocusElement="#custom-step-input">
+      <Grid>
+        <Column xlg={8} lg={8} md={8} sm={4}>
+          <TextInput
+            value={location || ''}
+            onChange={(event) => {
+              setFormState((prev) => ({
+                ...prev,
+                location: event.target.value,
+              }));
+            }}
+            id="custom-step-input"
+            labelText="Location"
+            placeholder="Enter location"
+          />
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+const Step3Partitions = () => {
+  const { formState, setFormState } = useStepContext();
+  const { partitions = 1 } = formState || {};
+
+  return (
+    <CreateTearsheetStep
+      title="Partitions"
+      subtitle="One or more partitions make up a topic. A partition is an ordered list of messages."
+      description="Partitions are distributed across the brokers in order to increase the scalability of your topic. You can also use them to distribute messages across the members of a consumer group."
+      fieldsetLegendText="Partition information"
+      primaryFocusElement="#carbon-number"
+    >
+      <Grid>
+        <Column xlg={3} lg={3} md={8} sm={4}>
+          <NumberInput
+            iconDescription="Choose a number"
+            id="carbon-number"
+            min={1}
+            max={100}
+            value={partitions}
+            label="Partitions"
+            helperText="1 partition is sufficient for getting started but, production systems often have more."
+            invalidText="Max partitions is 100, min is 1"
+            onChange={(event) => {
+              const value = event?.imaginaryTarget?.value;
+              setFormState((prev) => ({
+                ...prev,
+                partitions: value,
+              }));
+            }}
+          />
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+const Step4MessageRetention = () => {
+  const { formState, setFormState } = useStepContext();
+  const { messageRetention = 'one-day' } = formState || {};
+
+  useEffect(() => {
+    setFormState((prev) => ({
+      ...prev,
+      messageRetention: messageRetention,
+    }));
+  }, []);
+
+  return (
+    <CreateTearsheetStep
+      title="Message retention"
+      subtitle="This is how long messages are retained before they are deleted."
+      description="If your messages are not read by a consumer within this time, they will be missed."
+      fieldsetLegendText="Message retention scheduling"
+      primaryFocusElement="#one-day"
+    >
+      <Grid>
+        <Column xlg={8} lg={8} md={8} sm={4}>
+          <RadioButtonGroup
+            legendText="Message retention"
+            name="radio-button-group"
+            valueSelected={messageRetention}
+            onChange={(value) => {
+              setFormState((prev) => ({
+                ...prev,
+                messageRetention: value,
+              }));
+            }}
+            orientation="vertical"
+          >
+            <RadioButton labelText="A day" value="one-day" id="one-day" />
+            <RadioButton labelText="A week" value="one-week" id="one-week" />
+            <RadioButton labelText="A month" value="one-month" id="one-month" />
+          </RadioButtonGroup>
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+export const MultiStepTearsheet = ({
+  backButtonText = 'Back',
+  cancelButtonText = 'Cancel',
+  className = 'tearsheet-create-multi-step',
+  description = '',
+  influencerWidth = undefined,
+  label = '',
+  nextButtonText = 'Next',
+  slug = undefined,
+  decorator = undefined,
+  submitButtonText = 'Create',
+  title = 'Create',
+  open,
+  setOpen,
+  initialStep,
+  ...rest
+}) => {
+  const [simulatedDelay] = useState(750);
+  const [shouldReject, setShouldReject] = useState(false);
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [shouldIncludeAdditionalStep, setShouldIncludeAdditionalStep] =
+    useState(false);
+
+  const clearCreateData = () => {
+    setHasSubmitError(false);
+    setIsInvalid(false);
+    setOpen(false);
+    setShouldIncludeAdditionalStep(false);
+  };
+  const Decorator = () => (
+    <AILabel className="decorator-container" size="xs">
+      <AILabelContent>
+        <div>
+          <p className="secondary">AI Explained</p>
+          <h1>84%</h1>
+          <p className="secondary bold">Confidence score</p>
+          <p className="secondary">
+            This is not really Lorem Ipsum but the spell checker did not like
+            the previous text with it&apos;s non-words which is why this
+            unwieldy sentence, should one choose to call it that, here.
+          </p>
+          <hr />
+          <p className="secondary">Model type</p>
+          <p className="bold">Foundation model</p>
+        </div>
+      </AILabelContent>
+    </AILabel>
+  );
+
+  const handleNextDisabledState = (formState, currentStep) => {
+    // Step 1: Topic name is required
+    if (currentStep === 1 && !formState?.topicName) {
+      return true;
+    }
+    // Step 2 (or 3 if dynamic step included): Location is required
+    const locationStepIndex = shouldIncludeAdditionalStep ? 3 : 2;
+    if (currentStep === locationStepIndex && !formState?.location) {
+      return true;
+    }
+
+    // Step 4 (or 5): Message retention is required
+    const retentionStepIndex = shouldIncludeAdditionalStep ? 5 : 4;
+    if (currentStep === retentionStepIndex && !formState?.messageRetention) {
+      return true;
+    }
+    return false;
+  };
+
+  const handleBackDisabledState = (currentStep) => {
+    return currentStep === 1;
+  };
+
+  return (
+    <StepProvider>
+      <CreateTearsheet
+        influencerWidth={influencerWidth}
+        label={label}
+        className={cx(blockClass, className)}
+        submitButtonText={submitButtonText}
+        cancelButtonText={cancelButtonText}
+        backButtonText={backButtonText}
+        nextButtonText={nextButtonText}
+        description={description}
+        title={title}
+        open={open}
+        onClose={clearCreateData}
+        onRequestSubmit={async () => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              clearCreateData();
+              resolve();
+            }, simulatedDelay);
+          });
+        }}
+        onNext={async ({ currentStep }) => {
+          return new Promise((resolve) => {
+            if (shouldReject) {
+              setTimeout(() => {
+                resolve(true);
+                setHasSubmitError(true);
+              }, simulatedDelay);
+            } else if (currentStep == 1) {
+              setTimeout(() => {
+                resolve();
+              }, simulatedDelay);
+            } else {
+              resolve();
+            }
+          });
+        }}
+        decorator={decorator && <Decorator />}
+        initialStep={initialStep}
+        {...rest}
+        hasError={hasSubmitError}
+        handleNextDisabledState={handleNextDisabledState}
+        handleBackDisabledState={handleBackDisabledState}
+      >
+        <Step1
+          shouldReject={shouldReject}
+          setShouldReject={setShouldReject}
+          hasSubmitError={hasSubmitError}
+          setHasSubmitError={setHasSubmitError}
+          isInvalid={isInvalid}
+          setIsInvalid={setIsInvalid}
+          shouldIncludeAdditionalStep={shouldIncludeAdditionalStep}
+          setShouldIncludeAdditionalStep={setShouldIncludeAdditionalStep}
+          simulatedDelay={simulatedDelay}
+          blockClass={blockClass}
+          title="Topic Name"
+        />
+        {shouldIncludeAdditionalStep && (
+          <CreateTearsheetStep
+            onPrevious={() => {
+              console.log('custom onPrevious handler');
+            }}
+            title="Dynamic step"
+            subtitle="Dynamic step subtitle"
+            description="This is an example showing how to include a dynamic step into the CreateTearsheet"
+            hasFieldset={false}
+            includeStep={shouldIncludeAdditionalStep}
+            primaryFocusElement="body"
+          >
+            dynamic step content
+          </CreateTearsheetStep>
+        )}
+        <CustomStep
+          title="Location"
+          subtitle="Custom step subtitle"
+          description="Custom step description (see storybook implementation for new custom step capability)"
+          hasFieldset={false}
+        />
+        <Step3Partitions title="Partitions" />
+        <Step4MessageRetention title="Message retention" />
+      </CreateTearsheet>
+    </StepProvider>
+  );
+};

--- a/packages/react/src/examples/CreateTearsheet/example/preview-components/MultiStepWithIntro.jsx
+++ b/packages/react/src/examples/CreateTearsheet/example/preview-components/MultiStepWithIntro.jsx
@@ -1,0 +1,423 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  Button,
+  Column,
+  Grid,
+  InlineNotification,
+  RadioButtonGroup,
+  RadioButton,
+  RadioTile,
+  TextInput,
+  TileGroup,
+  Toggle,
+  NumberInput,
+  AILabel,
+  AILabelContent,
+} from '@carbon/react';
+import { StepProvider, useStepContext } from '@carbon/utilities-react';
+import cx from 'classnames';
+import { CreateTearsheet } from '../components/CreateTearsheet';
+import { CreateTearsheetStep } from '../components/CreateTearsheetStep';
+import { NoDataEmptyState } from '@carbon/ibm-products';
+
+const blockClass = `tearsheet-create-multi-step`;
+
+const IntroStep = ({ selectedCategory, setSelectedCategory }) => {
+  return (
+    <CreateTearsheetStep
+      title="Select a category"
+      subtitle="This is the category of item you will create"
+      hideSteps
+      hasFieldset={false}
+      primaryFocusElement="#tile-1"
+    >
+      <TileGroup
+        defaultSelected={selectedCategory}
+        legend="Categories"
+        name="Select a category"
+        onChange={(value) => setSelectedCategory(value)}
+        valueSelected={selectedCategory}
+      >
+        <RadioTile
+          className={`tearsheet-create-multi-step--custom-tile`}
+          value="standard"
+          id="tile-1"
+          tabIndex={selectedCategory === 'standard' ? 0 : -1}
+        >
+          <NoDataEmptyState />
+          <span className={`tearsheet-create-multi-step--custom-tile-label`}>
+            Standard
+          </span>
+        </RadioTile>
+        <RadioTile
+          className={`tearsheet-create-multi-step--custom-tile`}
+          value="premium"
+          id="tile-2"
+          tabIndex={selectedCategory === 'premium' ? 0 : -1}
+        >
+          <NoDataEmptyState size="lg" />
+          <span className={`tearsheet-create-multi-step--custom-tile-label`}>
+            Premium
+          </span>
+        </RadioTile>
+        <RadioTile
+          className={`tearsheet-create-multi-step--custom-tile`}
+          value="plus"
+          id="tile-3"
+          tabIndex={selectedCategory === 'plus' ? 0 : -1}
+        >
+          <NoDataEmptyState size="lg" />
+          <span className={`tearsheet-create-multi-step--custom-tile-label`}>
+            Plus
+          </span>
+        </RadioTile>
+      </TileGroup>
+    </CreateTearsheetStep>
+  );
+};
+
+const TopicNameStep = ({
+  shouldReject,
+  setShouldReject,
+  hasSubmitError,
+  setHasSubmitError,
+  isInvalid,
+  setIsInvalid,
+  simulatedDelay,
+  blockClass,
+}) => {
+  const { formState, setFormState } = useStepContext();
+  const { topicName, topicDescription, topicVersion } = formState || {};
+
+  return (
+    <CreateTearsheetStep
+      primaryFocusElement="#tearsheet-multi-step-story-text-input-multi-step-1"
+      onNext={() => {
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            if (shouldReject) {
+              setHasSubmitError(true);
+              reject();
+            }
+            setIsInvalid(false);
+            resolve();
+          }, simulatedDelay);
+        });
+      }}
+      title="Topic name"
+      fieldsetLegendText="Topic information"
+      subtitle="This is the unique name used to recognize your topic"
+      description="It will also be used by your producers and consumers as part of the
+           connection information, so make it something easy to recognize."
+    >
+      <Grid>
+        <Column xlg={8} lg={8} md={8} sm={4}>
+          <TextInput
+            labelText="Topic name"
+            id="tearsheet-multi-step-story-text-input-multi-step-1"
+            value={topicName || ''}
+            placeholder="Enter topic name"
+            onChange={(event) => {
+              if (event.target.value.length) {
+                setIsInvalid(false);
+              }
+              setFormState((prev) => ({
+                ...prev,
+                topicName: event.target.value,
+              }));
+            }}
+            invalid={isInvalid}
+            invalidText="This is a required field"
+          />
+          <TextInput
+            labelText="Topic description (optional)"
+            id="tearsheet-multi-step-story-text-input-multi-step-1-input-2"
+            value={topicDescription || ''}
+            placeholder="Enter topic description"
+            onChange={(event) =>
+              setFormState((prev) => ({
+                ...prev,
+                topicDescription: event.target.value,
+              }))
+            }
+          />
+          <TextInput
+            labelText="Topic version (optional)"
+            id="tearsheet-multi-step-story-text-input-multi-step-1-input-3"
+            value={topicVersion || ''}
+            placeholder="Enter topic version"
+            onChange={(event) =>
+              setFormState((prev) => ({
+                ...prev,
+                topicVersion: event.target.value,
+              }))
+            }
+          />
+          {hasSubmitError && (
+            <InlineNotification
+              kind="error"
+              title="Error"
+              subtitle="Resolve errors to continue"
+              onClose={() => setHasSubmitError(false)}
+            />
+          )}
+          <Toggle
+            className={`${blockClass}__error--toggle`}
+            id="simulated-error-toggle"
+            size="sm"
+            labelText="Simulate error"
+            onToggle={(event) => setShouldReject(event)}
+          />
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+const PartitionsStep = () => {
+  const { formState, setFormState } = useStepContext();
+  const { partitions = 1 } = formState || {};
+
+  return (
+    <CreateTearsheetStep
+      title="Partitions"
+      subtitle="One or more partitions make up a topic. A partition is an ordered
+           list of messages."
+      description="Partitions are distributed across the brokers in order to increase
+           the scalability of your topic. You can also use them to distribute
+           messages across the members of a consumer group."
+      fieldsetLegendText="Partition information"
+      primaryFocusElement="#carbon-number"
+    >
+      <Grid>
+        <Column xlg={3} lg={3} md={8} sm={4}>
+          <NumberInput
+            iconDescription="Choose a number"
+            id="carbon-number"
+            min={1}
+            max={100}
+            value={partitions}
+            label="Partitions"
+            helperText="1 partition is sufficient for getting started but, production systems often have more."
+            invalidText="Max partitions is 100, min is 1"
+            onChange={(event) => {
+              const value = event?.imaginaryTarget?.value;
+              setFormState((prev) => ({
+                ...prev,
+                partitions: value,
+              }));
+            }}
+          />
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+const MessageRetentionStep = () => {
+  const { formState, setFormState } = useStepContext();
+  const { messageRetention = 'one-day' } = formState || {};
+
+  return (
+    <CreateTearsheetStep
+      title="Message retention"
+      onNext={() => Promise.resolve()}
+      subtitle="This is how long messages are retained before they are deleted."
+      description="If your messages are not read by a consumer within this time, they
+           will be missed."
+      fieldsetLegendText="Message retention scheduling"
+      primaryFocusElement="#one-day"
+    >
+      <Grid>
+        <Column xlg={8} lg={8} md={8} sm={4}>
+          <RadioButtonGroup
+            legendText="Message retention"
+            name="radio-button-group"
+            valueSelected={messageRetention}
+            onChange={(value) =>
+              setFormState((prev) => ({
+                ...prev,
+                messageRetention: value,
+              }))
+            }
+            orientation="vertical"
+          >
+            <RadioButton labelText="A day" value="one-day" id="one-day" />
+            <RadioButton labelText="A week" value="one-week" id="one-week" />
+            <RadioButton labelText="A month" value="one-month" id="one-month" />
+          </RadioButtonGroup>
+        </Column>
+      </Grid>
+    </CreateTearsheetStep>
+  );
+};
+
+export const MultiStepWithIntro = ({
+  backButtonText = 'Back',
+  cancelButtonText = 'Cancel',
+  className = 'tearsheet-create-multi-step',
+  description = '',
+  influencerWidth = undefined,
+  label = '',
+  nextButtonText = 'Next',
+  slug = undefined,
+  decorator = undefined,
+  submitButtonText = 'Create',
+  title = 'Create',
+  open,
+  setOpen,
+}) => {
+  const [simulatedDelay] = useState(750);
+  const [shouldReject, setShouldReject] = useState(false);
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState('standard');
+
+  const clearCreateData = () => {
+    setHasSubmitError(false);
+    setIsInvalid(false);
+    setOpen(false);
+    setSelectedCategory('standard');
+  };
+
+  const handleNextDisabledState = (formState, currentStep) => {
+    // Step 1 is intro step - always enabled
+    if (currentStep === 1) {
+      return false;
+    }
+
+    // Calculate step indices based on selected category
+    let topicNameStepIndex = 2;
+    let partitionsStepIndex = 3;
+    let retentionStepIndex = 4;
+
+    if (selectedCategory === 'plus') {
+      // Plus has conditional step after intro
+      topicNameStepIndex = 3;
+      partitionsStepIndex = 4;
+      retentionStepIndex = 5;
+    } else if (selectedCategory === 'standard') {
+      // Standard has conditional step after intro
+      topicNameStepIndex = 3;
+      partitionsStepIndex = 4;
+      retentionStepIndex = 5;
+    }
+
+    // Topic name step - require topic name
+    if (currentStep === topicNameStepIndex && !formState?.topicName) {
+      return true;
+    }
+
+    // Partitions step - always has default value
+    if (currentStep === partitionsStepIndex) {
+      return false;
+    }
+
+    // Message retention step - always has default value
+    if (currentStep === retentionStepIndex) {
+      return false;
+    }
+
+    return false;
+  };
+
+  const handleBackDisabledState = (currentStep) => {
+    return currentStep === 1;
+  };
+  const Decorator = () => (
+    <AILabel className="decorator-container" size="xs">
+      <AILabelContent>
+        <div>
+          <p className="secondary">AI Explained</p>
+          <h1>84%</h1>
+          <p className="secondary bold">Confidence score</p>
+          <p className="secondary">
+            This is not really Lorem Ipsum but the spell checker did not like
+            the previous text with it&apos;s non-words which is why this
+            unwieldy sentence, should one choose to call it that, here.
+          </p>
+          <hr />
+          <p className="secondary">Model type</p>
+          <p className="bold">Foundation model</p>
+        </div>
+      </AILabelContent>
+    </AILabel>
+  );
+
+  return (
+    <StepProvider>
+      <CreateTearsheet
+        influencerWidth={influencerWidth}
+        label={label}
+        className={cx(blockClass, className)}
+        submitButtonText={submitButtonText}
+        cancelButtonText={cancelButtonText}
+        backButtonText={backButtonText}
+        nextButtonText={nextButtonText}
+        description={description}
+        title={title}
+        open={open}
+        onClose={clearCreateData}
+        onRequestSubmit={() =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              clearCreateData();
+              resolve();
+            }, simulatedDelay);
+          })
+        }
+        decorator={decorator && <Decorator />}
+        hasError={hasSubmitError}
+        handleNextDisabledState={handleNextDisabledState}
+        handleBackDisabledState={handleBackDisabledState}
+      >
+        <IntroStep
+          selectedCategory={selectedCategory}
+          setSelectedCategory={setSelectedCategory}
+          title={title}
+          hideSteps={true}
+        />
+        {selectedCategory === 'plus' && (
+          <CreateTearsheetStep
+            title="Conditional step"
+            subtitle="This step will only show for plus category creation flows"
+            hasFieldset={false}
+            primaryFocusElement="body"
+          >
+            This step will only show for plus create flows
+          </CreateTearsheetStep>
+        )}
+        {selectedCategory === 'standard' && (
+          <CreateTearsheetStep
+            title="Standard step only"
+            hasFieldset={false}
+            primaryFocusElement="body"
+          >
+            This step will only show for standard create flows
+          </CreateTearsheetStep>
+        )}
+        <TopicNameStep
+          shouldReject={shouldReject}
+          setShouldReject={setShouldReject}
+          hasSubmitError={hasSubmitError}
+          setHasSubmitError={setHasSubmitError}
+          isInvalid={isInvalid}
+          setIsInvalid={setIsInvalid}
+          simulatedDelay={simulatedDelay}
+          blockClass={blockClass}
+          title="Topic name"
+        />
+        <PartitionsStep title="Partitions" />
+        <MessageRetentionStep title="Message Retention" />
+      </CreateTearsheet>
+    </StepProvider>
+  );
+};

--- a/packages/react/src/examples/CreateTearsheet/example/preview-components/MultiStepWithStepInErrorState.jsx
+++ b/packages/react/src/examples/CreateTearsheet/example/preview-components/MultiStepWithStepInErrorState.jsx
@@ -1,0 +1,174 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  Button,
+  Column,
+  Grid,
+  TextInput,
+  NumberInput,
+  AILabel,
+  AILabelContent,
+} from '@carbon/react';
+import { StepProvider } from '@carbon/utilities-react';
+import cx from 'classnames';
+import { CreateTearsheet } from '../components/CreateTearsheet';
+import { CreateTearsheetStep } from '../components/CreateTearsheetStep';
+
+const blockClass = `tearsheet-create-multi-step`;
+
+export const MultiStepWithStepInErrorState = ({
+  backButtonText = 'Back',
+  cancelButtonText = 'Cancel',
+  className = 'tearsheet-create-multi-step',
+  description = '',
+  influencerWidth = undefined,
+  label = '',
+  nextButtonText = 'Next',
+  slug = undefined,
+  decorator = undefined,
+  submitButtonText = 'Create',
+  title = 'Create',
+  open,
+  setOpen,
+}) => {
+  const [simulatedDelay] = useState(750);
+  const [stepOneTextInputValue, setStepOneTextInputValue] = useState('');
+  const [topicDescriptionValue, setTopicDescriptionValue] = useState('');
+  const [stepTwoTextInputValue, setStepTwoTextInputValue] = useState(1);
+  useState('one-day');
+  const [stepOneIsInvalid, setStepOneIsInvalid] = useState(true);
+  const [stepTwoIsInvalid, setStepTwoIsInvalid] = useState(false);
+
+  const clearCreateData = () => {
+    setStepOneTextInputValue('');
+    setTopicDescriptionValue('');
+    setStepTwoTextInputValue(1);
+    setStepOneIsInvalid(true);
+    setStepTwoIsInvalid(true);
+    setOpen(false);
+  };
+
+  const Decorator = () => (
+    <AILabel className="decorator-container" size="xs">
+      <AILabelContent>
+        <div>
+          <p className="secondary">AI Explained</p>
+          <h1>84%</h1>
+          <p className="secondary bold">Confidence score</p>
+          <p className="secondary">
+            This is not really Lorem Ipsum but the spell checker did not like
+            the previous text with it&apos;s non-words which is why this
+            unwieldy sentence, should one choose to call it that, here.
+          </p>
+          <hr />
+          <p className="secondary">Model type</p>
+          <p className="bold">Foundation model</p>
+        </div>
+      </AILabelContent>
+    </AILabel>
+  );
+
+  return (
+    <StepProvider>
+      <CreateTearsheet
+        influencerWidth={influencerWidth}
+        label={label}
+        className={cx(blockClass, className)}
+        submitButtonText={submitButtonText}
+        cancelButtonText={cancelButtonText}
+        backButtonText={backButtonText}
+        nextButtonText={nextButtonText}
+        description={description}
+        title={title}
+        open={open}
+        onClose={clearCreateData}
+        onRequestSubmit={() =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              clearCreateData();
+              resolve();
+            }, simulatedDelay);
+          })
+        }
+        decorator={decorator && <Decorator />}
+      >
+        <CreateTearsheetStep
+          title="Topic name"
+          fieldsetLegendText="Topic information"
+          disableSubmit={stepOneIsInvalid}
+          subtitle="This is the unique name used to recognize your topic"
+          invalid={stepOneIsInvalid}
+          primaryFocusElement="#tearsheet-multi-step-story-text-input-multi-step-1"
+        >
+          <Grid>
+            <Column xlg={8} lg={8} md={8} sm={4}>
+              <TextInput
+                labelText="Topic name"
+                id="tearsheet-multi-step-story-text-input-multi-step-1"
+                value={stepOneTextInputValue}
+                placeholder="Enter topic name"
+                onChange={(event) => {
+                  setStepOneIsInvalid(!event.target.value.length);
+                  setStepOneTextInputValue(event.target.value);
+                }}
+                invalid={stepOneIsInvalid}
+                invalidText="This is a required field"
+                onBlur={() => {}}
+              />
+              <TextInput
+                labelText="Topic description (optional)"
+                id="tearsheet-multi-step-story-text-input-multi-step-1-input-2"
+                value={topicDescriptionValue}
+                placeholder="Enter topic description"
+                onChange={(event) =>
+                  setTopicDescriptionValue(event.target.value)
+                }
+              />
+            </Column>
+          </Grid>
+        </CreateTearsheetStep>
+        <CreateTearsheetStep
+          title="Partitions"
+          disableSubmit={stepTwoIsInvalid}
+          subtitle="One or more partitions make up a topic. A partition is an ordered
+           list of messages."
+          description="Partitions are distributed across the brokers in order to increase
+           the scalability of your topic. You can also use them to distribute
+           messages across the members of a consumer group."
+          fieldsetLegendText="Partition information"
+          invalid={stepTwoIsInvalid}
+          primaryFocusElement="#carbon-number"
+        >
+          <Grid>
+            <Column xlg={3} lg={3} md={8} sm={4}>
+              <NumberInput
+                iconDescription="Choose a number"
+                id="carbon-number"
+                min={1}
+                max={100}
+                value={stepTwoTextInputValue}
+                label="Partitions"
+                helperText="1 partition is sufficient for getting started but, production systems often have more."
+                invalidText="Max partitions is 100, min is 1"
+                hideSteppers
+                onChange={(event) => {
+                  event.target.value > 0 && event.target.value <= 100
+                    ? setStepTwoIsInvalid(false)
+                    : setStepTwoIsInvalid(true);
+                  setStepTwoTextInputValue(event.target.value);
+                }}
+              />
+            </Column>
+          </Grid>
+        </CreateTearsheetStep>
+      </CreateTearsheet>
+    </StepProvider>
+  );
+};

--- a/packages/react/src/examples/CreateTearsheet/example/styles/_create-tearsheet.scss
+++ b/packages/react/src/examples/CreateTearsheet/example/styles/_create-tearsheet.scss
@@ -14,8 +14,8 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/utilities/hide-at-breakpoint' as *;
 @use '@carbon/styles/scss/config' as carbon-config;
-@use '@carbon/ibm-products/scss/components/Tearsheet';
-@use '@carbon/ibm-products/scss/components/EmptyStates';
+@use '@carbon/ibm-products-styles/scss/components/Tearsheet';
+@use '@carbon/ibm-products-styles/scss/components/EmptyStates';
 
 // CreateTearsheet uses the following IBM Products components:
 // TearsheetShell

--- a/packages/react/src/examples/CreateTearsheet/example/styles/_create-tearsheet.scss
+++ b/packages/react/src/examples/CreateTearsheet/example/styles/_create-tearsheet.scss
@@ -1,0 +1,221 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Other Carbon settings.
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/components/button/tokens' as *;
+@use '@carbon/styles/scss/grid' as *;
+@use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/utilities/hide-at-breakpoint' as *;
+@use '@carbon/styles/scss/config' as carbon-config;
+@use '@carbon/ibm-products/scss/components/Tearsheet';
+@use '@carbon/ibm-products/scss/components/EmptyStates';
+
+// CreateTearsheet uses the following IBM Products components:
+// TearsheetShell
+
+@mixin hideAtLargeScreens() {
+  @include hide-at-lg;
+  @include hide-at-md;
+  @include hide-at-xlg;
+  @include hide-at-max;
+}
+
+@keyframes step-content-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-$spacing-04);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// CreateTearsheet step animations
+.create-tearsheet-step {
+  // stylelint-disable-next-line carbon/motion-easing-use
+  animation: step-content-entrance $duration-slow-01;
+  animation-fill-mode: forwards;
+  animation-timing-function: $standard-easing;
+  margin-inline-start: 0;
+  opacity: 0;
+  padding-inline: $spacing-03;
+
+  .#{carbon-config.$prefix}--css-grid {
+    padding: 0;
+    margin: 0;
+    margin-inline-start: 0;
+  }
+}
+
+@media (prefers-reduced-motion) {
+  .create-tearsheet-step {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+// Hidden step state
+.create-tearsheet-step--hidden-step {
+  display: none;
+}
+
+// Visible step state
+@media screen and (prefers-reduced-motion: reduce) {
+  .create-tearsheet-step--visible-step {
+    // stylelint-disable-next-line carbon/motion-easing-use
+    animation: none;
+    animation-fill-mode: forwards;
+    animation-timing-function: $standard-easing;
+    opacity: 0;
+  }
+}
+
+.create-tearsheet-step--visible-step {
+  // stylelint-disable-next-line carbon/motion-easing-use
+  animation: step-content-entrance $duration-slow-01;
+  animation-fill-mode: forwards;
+  animation-timing-function: $standard-easing;
+  opacity: 0;
+}
+
+// CreateTearsheet step elements
+.create-tearsheet-step__title {
+  margin-block-end: $spacing-05;
+  @include type.type-style('heading-03');
+}
+
+.create-tearsheet-step__subtitle {
+  @include type.type-style('heading-compact-01');
+
+  margin-block-end: $spacing-03;
+}
+
+.create-tearsheet-step__description {
+  @include type.type-style('body-01');
+
+  margin-block-end: $spacing-06;
+}
+
+.create-tearsheet-step__content {
+  min-block-size: 100%;
+  overflow-x: hidden;
+  @supports (overflow-inline: hidden) {
+    overflow-inline: hidden;
+  }
+
+  padding-block: $spacing-06;
+
+  .#{carbon-config.$prefix}--form {
+    block-size: inherit;
+  }
+
+  .#{carbon-config.$prefix}--grid {
+    padding: 0;
+    margin: 0;
+  }
+
+  .#{carbon-config.$prefix}--fieldset {
+    margin-block-end: 0;
+  }
+}
+
+.create-tearsheet-step__fieldset {
+  margin-block-end: 0;
+
+  > * {
+    margin-block-end: $spacing-05;
+  }
+}
+
+// Section styles
+.create-tearsheet__section--title {
+  margin-block-end: $spacing-05;
+}
+
+.create-tearsheet__section--subtitle {
+  @include type.type-style('heading-compact-01');
+
+  margin-block-end: $spacing-03;
+}
+
+.create-tearsheet__section--description {
+  @include type.type-style('body-01');
+
+  margin-block-end: $spacing-06;
+}
+
+// CreateTearsheet divider
+.cds--tearsheet-create__section--divider {
+  position: relative;
+  display: block;
+  margin: $spacing-06 calc(-1 * #{$spacing-08}) $spacing-07
+    calc(-1 * #{$spacing-06});
+  background-color: $layer-accent-01;
+  block-size: 1px;
+  inline-size: 100%;
+}
+
+// Preview component styles
+.tearsheet-create-multi-step {
+  .#{carbon-config.$prefix}--btn-set
+    .#{carbon-config.$prefix}--btn.#{carbon-config.$prefix}--btn--disabled {
+    box-shadow: -0.0625rem 0 0 0 $button-separator;
+  }
+
+  .#{carbon-config.$prefix}--side-nav--ux {
+    position: initial;
+    background-color: transparent;
+  }
+
+  .#{carbon-config.$prefix}--fieldset {
+    margin-block-end: 0;
+  }
+}
+
+.tearsheet-create-multi-step__error--toggle {
+  margin-block-start: $spacing-05;
+}
+
+.influencer__content,
+.create-tearsheet-step {
+  margin-block-start: $spacing-06;
+}
+
+.default__action-buttons {
+  display: grid;
+  grid-auto-rows: minmax(auto, auto);
+  grid-template-columns: repeat(6, 1fr);
+
+  > button {
+    inline-size: 100%;
+    /* stylelint-disable-next-line declaration-no-important */
+    max-inline-size: none !important;
+  }
+
+  :first-child {
+    grid-column: span 4;
+  }
+}
+
+.#{carbon-config.$prefix}--inline-loading {
+  position: absolute;
+  inline-size: $spacing-07;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+}
+
+.showInfluencer {
+  display: flex;
+  align-items: center;
+  gap: $spacing-03;
+  @include hideAtLargeScreens();
+}

--- a/packages/react/src/examples/CreateTearsheet/example/styles/_story-styles.scss
+++ b/packages/react/src/examples/CreateTearsheet/example/styles/_story-styles.scss
@@ -1,0 +1,60 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/type';
+@use '@carbon/type/scss/font-family';
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config' as carbon-config;
+
+// Preview component styles for create-tearsheet-step
+.step__description {
+  @include type.type-style('body-compact-01');
+
+  padding-block-end: $spacing-04;
+}
+
+p.step__description:last-of-type {
+  padding-block-end: $spacing-07;
+}
+
+.create-tearsheet-step____step--title {
+  @include font-family.font-weight('semibold');
+}
+
+.create-tearsheet-step__fieldset .#{carbon-config.$prefix}--form-item {
+  margin-block-end: $spacing-05;
+}
+
+// Tile group styles
+.#{carbon-config.$prefix}--tile-group div {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+// Custom tile styles
+.cds--create-tearsheet-step--custom-tile {
+  block-size: 240px;
+  inline-size: 280px;
+  margin-inline-end: $spacing-05;
+}
+
+.cds--create-tearsheet-step--custom-tile
+  .cds--empty-state__illustration.cds--empty-state__illustration--lg {
+  block-size: 120px;
+  min-inline-size: 120px;
+}
+
+.cds--create-tearsheet-step--custom-tile-label {
+  position: absolute;
+  inset-block-end: $spacing-05;
+  inset-inline-start: $spacing-05;
+}
+
+// Error toggle style
+.create-tearsheet-step__error--toggle {
+  margin-block-start: $spacing-05;
+}

--- a/packages/react/src/examples/CreateTearsheet/example/vite.config.ts
+++ b/packages/react/src/examples/CreateTearsheet/example/vite.config.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/react/src/examples/CreateTearsheetNarrow/CreateTearsheet.mdx
+++ b/packages/react/src/examples/CreateTearsheetNarrow/CreateTearsheet.mdx
@@ -1,0 +1,98 @@
+import { Story, Controls, Source, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import * as stories from './CreateTearsheet.stories';
+
+<Meta isTemplate />
+
+# Create Tearsheet Narrow
+
+[Usage guidelines](https://carbondesignsystem.com/patterns/create-flows/usage/#narrow-tearsheet)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Default](#default)
+- [With form validation](#with-form-validation)
+
+## Overview
+
+The CreateTearsheetNarrow pattern provides a recipe for building single-form
+creation interfaces in a narrow tearsheet format. It demonstrates how to use the
+Tearsheet component with the `variant="narrow"` prop for creating resources or
+completing tasks in a compact, focused layout.
+
+> NOTE: Patterns have multiple ways of accomplishing a user need and typically
+> use a combination of components with additional design considerations. The
+> pattern code we share is meant to serve as an example implementation that can
+> be built and extended further.
+
+To build this pattern, we recommend including the following components:
+
+- [Tearsheet](https://react.carbondesignsystem.com/?path=/docs/components-tearsheet)
+  (with `variant="narrow"`)
+- [Form](https://react.carbondesignsystem.com/?path=/docs/components-form)
+- [TextInput](https://react.carbondesignsystem.com/?path=/docs/components-textinput)
+- [NumberInput](https://react.carbondesignsystem.com/?path=/docs/components-numberinput)
+- [Dropdown](https://react.carbondesignsystem.com/?path=/docs/components-dropdown)
+- [FormGroup](https://react.carbondesignsystem.com/?path=/docs/components-formgroup)
+- [Button](https://react.carbondesignsystem.com/?path=/docs/components-button)
+
+```jsx
+import { Tearsheet } from '@carbon/react';
+import {
+  Form,
+  TextInput,
+  NumberInput,
+  Dropdown,
+  FormGroup,
+  Button,
+} from '@carbon/react';
+```
+
+## Example usage
+
+> 💡 Check our
+> [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateTearsheetNarrow/example)
+> example implementation.
+
+[![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/CreateTearsheetNarrow/example)
+
+## Default
+
+The default CreateTearsheetNarrow pattern provides a basic single-form creation
+interface with:
+
+- A narrow tearsheet layout optimized for focused workflows
+- Form title and description
+- Form groups for organizing related inputs
+- Submit and cancel actions in the footer
+
+<Canvas
+  of={stories.createTearsheetNarrow}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.createTearsheetNarrow),
+    },
+  ]}
+/>
+
+## With form validation
+
+The pattern can be extended to include form validation:
+
+- Field-level validation with error states
+- Submit button disabled until form is valid
+- Invalid text displayed for fields with errors
+- Real-time validation on blur or change events
+
+<Canvas
+  of={stories.withFormValidation}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.withFormValidation),
+    },
+  ]}
+/>

--- a/packages/react/src/examples/CreateTearsheetNarrow/CreateTearsheet.stories.js
+++ b/packages/react/src/examples/CreateTearsheetNarrow/CreateTearsheet.stories.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import DocsPage from './CreateTearsheet.mdx';
+import { Default } from './example/preview-components/Default';
+import { WithValidation } from './example/preview-components/WithValidation';
+import './example/styles/_story-styles.scss';
+
+export default {
+  title: 'Examples/Create flows/Create Tearsheet Narrow',
+  component: Default,
+  tags: ['autodocs'],
+  parameters: {
+    docs: { page: DocsPage },
+  },
+};
+
+const createTearsheetProps = {
+  title: 'Create partition',
+  description: 'Select the number of partitions you want to create',
+  submitButtonText: 'Create',
+  cancelButtonText: 'Cancel',
+  className: 'test-class-name',
+  label: 'Test label',
+};
+
+export const createTearsheetNarrow = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <style>{`.tearsheet-create-narrow { opacity: 0 }`}</style>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Close CreateTearsheetNarrow' : 'Open CreateTearsheetNarrow'}
+      </Button>
+      <Default {...args} open={open} setOpen={setOpen} />
+    </>
+  );
+};
+createTearsheetNarrow.storyName = 'Default';
+createTearsheetNarrow.args = {
+  ...createTearsheetProps,
+};
+
+export const withFormValidation = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <style>{`.tearsheet-create-narrow { opacity: 0 }`}</style>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Close CreateTearsheetNarrow' : 'Open CreateTearsheetNarrow'}
+      </Button>
+      <WithValidation {...args} open={open} setOpen={setOpen} />
+    </>
+  );
+};
+withFormValidation.storyName = 'With Form Validation';
+withFormValidation.args = {
+  ...createTearsheetProps,
+};

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/App.tsx
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/App.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import { Default } from './preview-components/Default';
+import { WithValidation } from './preview-components/WithValidation';
+import './index.scss';
+
+export const App = () => {
+  const [openDefault, setOpenDefault] = useState(false);
+  const [openValidation, setOpenValidation] = useState(false);
+
+  const createTearsheetProps = {
+    title: 'Create partition',
+    description: 'Select the number of partitions you want to create',
+    submitButtonText: 'Create',
+    cancelButtonText: 'Cancel',
+    className: 'test-class-name',
+    label: 'Test label',
+  };
+
+  return (
+    <div className="example-container">
+      <h1>Create Tearsheet Narrow Examples</h1>
+
+      <section className="example-section">
+        <h2>Default</h2>
+        <Button onClick={() => setOpenDefault(true)}>
+          Open default tearsheet
+        </Button>
+        <Default
+          open={openDefault}
+          setOpen={setOpenDefault}
+          {...createTearsheetProps}
+        />
+      </section>
+
+      <section className="example-section">
+        <h2>With Validation</h2>
+        <Button onClick={() => setOpenValidation(true)}>
+          Open tearsheet with validation
+        </Button>
+        <WithValidation
+          open={openValidation}
+          setOpen={setOpenValidation}
+          {...createTearsheetProps}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/components/CreateTearsheetNarrow.tsx
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/components/CreateTearsheetNarrow.tsx
@@ -1,0 +1,128 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { ReactNode, RefObject, useMemo } from 'react';
+import { preview__Tearsheet as Tearsheet } from '@carbon/ibm-products';
+import { Form } from '@carbon/react';
+
+export interface CreateTearsheetNarrowProps {
+  children?: ReactNode;
+  open?: boolean;
+  onClose?: () => void;
+  setOpen?: (open: boolean) => void;
+  title?: string;
+  label?: string;
+  description?: string | ReactNode;
+  formTitle?: string;
+  formDescription?: string | ReactNode;
+  hasCloseIcon?: boolean;
+  closeIconDescription?: string;
+  selectorPrimaryFocus?: string;
+  launcherButtonRef?: RefObject<HTMLButtonElement | null>;
+  submitButtonText?: string;
+  cancelButtonText?: string;
+  onRequestSubmit?: () => void | Promise<void>;
+  decorator?: ReactNode;
+  headerActions?: ReactNode;
+  disableSubmit?: boolean;
+  className?: string;
+}
+
+export const CreateTearsheetNarrow = ({
+  children,
+  open,
+  setOpen,
+  onClose,
+  title = 'Create',
+  label,
+  description,
+  formTitle,
+  formDescription,
+  hasCloseIcon = true,
+  closeIconDescription = 'Close',
+  selectorPrimaryFocus,
+  launcherButtonRef,
+  submitButtonText = 'Create',
+  cancelButtonText = 'Cancel',
+  onRequestSubmit,
+  headerActions,
+  disableSubmit = false,
+  className,
+  ...rest
+}: CreateTearsheetNarrowProps) => {
+  const handleSubmit = async (e?: React.FormEvent<HTMLFormElement>) => {
+    e?.preventDefault();
+    await onRequestSubmit?.();
+    setOpen?.(false);
+  };
+
+  // Create actions array for the footer
+  const actions = useMemo(
+    () => [
+      {
+        key: 'cancel',
+        kind: 'ghost' as const,
+        label: cancelButtonText,
+        onClick: () => {
+          onClose?.();
+          setOpen?.(false);
+        },
+      },
+      {
+        key: 'submit',
+        kind: 'primary' as const,
+        label: submitButtonText,
+        onClick: () => {
+          handleSubmit();
+        },
+        disabled: disableSubmit,
+      },
+    ],
+    [cancelButtonText, submitButtonText, disableSubmit, onClose, setOpen]
+  );
+
+  return (
+    <Tearsheet
+      open={open}
+      variant="narrow"
+      onClose={() => {
+        onClose?.();
+        setOpen?.(false);
+      }}
+      launcherButtonRef={launcherButtonRef}
+      selectorPrimaryFocus={selectorPrimaryFocus}
+      preventCloseOnClickOutside
+      className={className}
+      {...rest}
+    >
+      <Tearsheet.Header hideCloseButton={hasCloseIcon}>
+        <Tearsheet.HeaderContent
+          label={label || ''}
+          title={title || ''}
+          description={description || ''}
+          headerActions={headerActions}
+        />
+      </Tearsheet.Header>
+      <Tearsheet.Body className="create-tearsheet-narrow__body">
+        <Tearsheet.MainContent isFlush={true}>
+          {formTitle && (
+            <h3 className="create-tearsheet-narrow__form-title">{formTitle}</h3>
+          )}
+          {formDescription && (
+            <p className="create-tearsheet-narrow__form-description">
+              {formDescription}
+            </p>
+          )}
+          <Form onSubmit={handleSubmit}>{children}</Form>
+        </Tearsheet.MainContent>
+      </Tearsheet.Body>
+      <Tearsheet.Footer actions={actions} buttonSize="2xl" />
+    </Tearsheet>
+  );
+};
+
+CreateTearsheetNarrow.displayName = 'CreateTearsheetNarrow';

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/index.html
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/index.html
@@ -1,0 +1,19 @@
+<!-- 
+ Copyright IBM Corp. 2026
+ 
+  This source code is licensed under the Apache-2.0 license found in the
+  LICENSE file in the root directory of this source tree.
+   -->
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CreateTearsheetNarrow Pattern Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/index.scss
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/index.scss
@@ -1,0 +1,52 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/config' with (
+  $font-path: '@ibm/plex'
+);
+@use '@carbon/styles';
+@use '@carbon/ibm-products/scss/components/Tearsheet';
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as theme;
+@use '@carbon/styles/scss/themes' as themes;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/motion' as *;
+@use './styles/_create-tearsheet-narrow';
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+#root {
+  min-block-size: 100vh;
+}
+
+.example-container {
+  margin-inline-start: $spacing-02;
+  max-inline-size: 1200px;
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 400;
+    margin-block-end: $spacing-07;
+  }
+
+  .example-section {
+    padding: $spacing-07;
+    border: 1px solid var(--cds-border-subtle);
+    background-color: var(--cds-layer-01);
+    margin-block-end: $spacing-05;
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-block: 0 $spacing-06;
+    }
+  }
+}

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/index.scss
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/index.scss
@@ -9,7 +9,7 @@
   $font-path: '@ibm/plex'
 );
 @use '@carbon/styles';
-@use '@carbon/ibm-products/scss/components/Tearsheet';
+@use '@carbon/ibm-products-styles/scss/components/Tearsheet';
 
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as theme;

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/main.tsx
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/main.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.scss';
+
+// eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/package.json
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "create-tearsheet-narrow-pattern-example",
+  "description": "An example showing use of the CreateTearsheetNarrow pattern from the @carbon/ibm-products library.",
+  "keywords": [
+    "carbon",
+    "ibm",
+    "ibm-products",
+    "pattern",
+    "create-tearsheet",
+    "tearsheet"
+  ],
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@carbon/ibm-products": "latest",
+    "@carbon/react": "latest",
+    "@carbon/styles": "latest",
+    "@carbon/utilities-react": "latest",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "sass": "^1.93.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^7.0.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/preview-components/Default.jsx
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/preview-components/Default.jsx
@@ -1,0 +1,155 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { TextInput, NumberInput, Dropdown, FormGroup } from '@carbon/react';
+import cx from 'classnames';
+import { CreateTearsheetNarrow } from '../components/CreateTearsheetNarrow';
+import '../styles/_create-tearsheet-narrow.scss';
+
+const blockClass = `tearsheet-create-narrow`;
+
+export const Default = ({
+  cancelButtonText = 'Cancel',
+  className = 'tearsheet-create-narrow',
+  description = '',
+  label = '',
+  submitButtonText = 'Create',
+  title = 'Create',
+  open,
+  setOpen,
+  ...rest
+}) => {
+  const [topicName, setTopicName] = useState('');
+  const [partitionCount, setPartitionCount] = useState(1);
+  const [replicaCount, setReplicaCount] = useState(1);
+  const [minimumInSyncReplicaCount, setMinimumInSyncReplicaCount] = useState(1);
+  const [retentionTime, setRetentionTime] = useState(1);
+  const [quantity, setQuantity] = useState(1);
+  const [items] = useState(['Day(s)', 'Month(s)', 'Year(s)']);
+
+  const numberInputsInvalid =
+    partitionCount <= 0 ||
+    replicaCount <= 0 ||
+    minimumInSyncReplicaCount <= 0 ||
+    retentionTime <= 0 ||
+    quantity <= 0;
+
+  const clearCreateData = () => {
+    setTopicName('');
+    setPartitionCount(1);
+    setReplicaCount(1);
+    setMinimumInSyncReplicaCount(1);
+    setRetentionTime(1);
+    setQuantity(1);
+    setOpen(false);
+  };
+
+  return (
+    <CreateTearsheetNarrow
+      label={label}
+      className={cx(blockClass, className)}
+      submitButtonText={submitButtonText}
+      cancelButtonText={cancelButtonText}
+      description={description}
+      title={title}
+      formTitle="Core configuration"
+      formDescription="We recommend you fill out and evaluate these details at a minimum before deploying your topic."
+      open={open}
+      onClose={clearCreateData}
+      setOpen={setOpen}
+      onRequestSubmit={async () => {
+        // Perform submit action here
+        console.log('Submit clicked');
+      }}
+      hasCloseIcon={true}
+      selectorPrimaryFocus="#tearsheet-narrow-story-text-input-1"
+      disableSubmit={!topicName || numberInputsInvalid}
+      {...rest}
+    >
+      <FormGroup
+        className={`${blockClass}__form ${blockClass}__example-form-group`}
+        legendText="Topic information"
+      >
+        <TextInput
+          labelText="Topic name"
+          id="tearsheet-narrow-story-text-input-1"
+          value={topicName}
+          placeholder="Enter topic name"
+          onChange={(event) => setTopicName(event.target.value)}
+        />
+        <NumberInput
+          iconDescription="Choose a number"
+          id="partition-count"
+          min={1}
+          max={100}
+          value={partitionCount}
+          label="Partitions"
+          invalidText="Max partitions is 100, min is 1"
+          onChange={(event) => setPartitionCount(event.imaginaryTarget.value)}
+        />
+        <NumberInput
+          iconDescription="Choose a number"
+          id="replica-count"
+          min={1}
+          max={100}
+          value={replicaCount}
+          label="Replicas"
+          invalidText="Max replicas is 10, min is 1"
+          onChange={(event) => setReplicaCount(event.imaginaryTarget.value)}
+        />
+        <NumberInput
+          iconDescription="Choose a number"
+          id="minimum-in-sync-count"
+          min={1}
+          max={100}
+          value={minimumInSyncReplicaCount}
+          label="Minimum in-sync replicas"
+          invalidText="Max is 5, min is 1"
+          onChange={(event) =>
+            setMinimumInSyncReplicaCount(event.imaginaryTarget.value)
+          }
+        />
+      </FormGroup>
+      <FormGroup
+        className={`${blockClass}__form ${blockClass}__example-form-group`}
+        legendText="Scheduling"
+      >
+        <div className={`${blockClass}__flex-container`}>
+          <NumberInput
+            iconDescription="Choose a number"
+            id="retention-time"
+            min={1}
+            max={60}
+            value={retentionTime}
+            label="Retention time"
+            invalidText="Max is 60, min is 1"
+            onChange={(event) => setRetentionTime(event.imaginaryTarget.value)}
+          />
+          <Dropdown
+            id="create-tearsheet-narrow-dropdown-options-c"
+            initialSelectedItem="Day(s)"
+            items={items}
+            label="Options"
+            titleText="Options"
+          />
+        </div>
+        <NumberInput
+          iconDescription="Choose a number"
+          id="quantity"
+          min={1}
+          max={100}
+          value={quantity}
+          label="Quantity"
+          invalidText="Max is 10, min is 1"
+          onChange={(event) => setQuantity(event.imaginaryTarget.value)}
+        />
+      </FormGroup>
+    </CreateTearsheetNarrow>
+  );
+};

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/preview-components/WithValidation.jsx
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/preview-components/WithValidation.jsx
@@ -1,0 +1,165 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { TextInput, NumberInput, Dropdown, FormGroup } from '@carbon/react';
+import cx from 'classnames';
+import { CreateTearsheetNarrow } from '../components/CreateTearsheetNarrow';
+import '../styles/_create-tearsheet-narrow.scss';
+
+const blockClass = `tearsheet-create-narrow`;
+
+export const WithValidation = ({
+  cancelButtonText = 'Cancel',
+  className = 'tearsheet-create-narrow',
+  description = '',
+  label = '',
+  submitButtonText = 'Create',
+  title = 'Create',
+  open,
+  setOpen,
+  ...rest
+}) => {
+  const [topicName, setTopicName] = useState('');
+  const [partitionCount, setPartitionCount] = useState(1);
+  const [replicaCount, setReplicaCount] = useState(1);
+  const [minimumInSyncReplicaCount, setMinimumInSyncReplicaCount] = useState(1);
+  const [retentionTime, setRetentionTime] = useState(1);
+  const [quantity, setQuantity] = useState(1);
+  const [items] = useState(['Day(s)', 'Month(s)', 'Year(s)']);
+  const [invalid, setInvalid] = useState(false);
+
+  const numberInputsInvalid =
+    partitionCount <= 0 ||
+    replicaCount <= 0 ||
+    minimumInSyncReplicaCount <= 0 ||
+    retentionTime <= 0 ||
+    quantity <= 0;
+
+  const clearCreateData = () => {
+    setTopicName('');
+    setPartitionCount(1);
+    setReplicaCount(1);
+    setMinimumInSyncReplicaCount(1);
+    setRetentionTime(1);
+    setQuantity(1);
+    setInvalid(false);
+    setOpen(false);
+  };
+
+  return (
+    <CreateTearsheetNarrow
+      label={label}
+      className={cx(blockClass, className)}
+      submitButtonText={submitButtonText}
+      cancelButtonText={cancelButtonText}
+      description={description}
+      title={title}
+      formTitle="Core configuration"
+      formDescription="We recommend you fill out and evaluate these details at a minimum before deploying your topic."
+      open={open}
+      onClose={clearCreateData}
+      setOpen={setOpen}
+      onRequestSubmit={async () => {
+        // Perform submit action here
+        console.log('Submit clicked');
+      }}
+      hasCloseIcon={true}
+      selectorPrimaryFocus="#tearsheet-narrow-story-text-input-1"
+      disableSubmit={!topicName || numberInputsInvalid}
+      {...rest}
+    >
+      <FormGroup
+        className={`${blockClass}__form ${blockClass}__example-form-group`}
+        legendText="Topic information"
+      >
+        <TextInput
+          labelText="Topic name"
+          id="tearsheet-narrow-story-text-input-1"
+          value={topicName}
+          placeholder="Enter topic name"
+          onChange={(event) => {
+            setTopicName(event.target.value);
+            if (event.target.value.length) {
+              setInvalid(false);
+            }
+          }}
+          onBlur={() => !topicName.length && setInvalid(true)}
+          invalid={invalid}
+          invalidText="This is a required field"
+        />
+        <NumberInput
+          iconDescription="Choose a number"
+          id="partition-count"
+          min={1}
+          max={100}
+          value={partitionCount}
+          label="Partitions"
+          invalidText="Max partitions is 100, min is 1"
+          onChange={(event) => setPartitionCount(event.imaginaryTarget.value)}
+        />
+        <NumberInput
+          iconDescription="Choose a number"
+          id="replica-count"
+          min={1}
+          max={100}
+          value={replicaCount}
+          label="Replicas"
+          invalidText="Max replicas is 10, min is 1"
+          onChange={(event) => setReplicaCount(event.imaginaryTarget.value)}
+        />
+        <NumberInput
+          iconDescription="Choose a number"
+          id="minimum-in-sync-count"
+          min={1}
+          max={100}
+          value={minimumInSyncReplicaCount}
+          label="Minimum in-sync replicas"
+          invalidText="Max is 5, min is 1"
+          onChange={(event) =>
+            setMinimumInSyncReplicaCount(event.imaginaryTarget.value)
+          }
+        />
+      </FormGroup>
+      <FormGroup
+        className={`${blockClass}__form ${blockClass}__example-form-group`}
+        legendText="Scheduling"
+      >
+        <div className={`${blockClass}__flex-container`}>
+          <NumberInput
+            iconDescription="Choose a number"
+            id="retention-time"
+            min={1}
+            max={60}
+            value={retentionTime}
+            label="Retention time"
+            invalidText="Max is 60, min is 1"
+            onChange={(event) => setRetentionTime(event.imaginaryTarget.value)}
+          />
+          <Dropdown
+            id="create-tearsheet-narrow-dropdown-options-c"
+            initialSelectedItem="Day(s)"
+            items={items}
+            label="Options"
+            titleText="Options"
+          />
+        </div>
+        <NumberInput
+          iconDescription="Choose a number"
+          id="quantity"
+          min={1}
+          max={100}
+          value={quantity}
+          label="Quantity"
+          invalidText="Max is 10, min is 1"
+          onChange={(event) => setQuantity(event.imaginaryTarget.value)}
+        />
+      </FormGroup>
+    </CreateTearsheetNarrow>
+  );
+};

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/styles/_create-tearsheet-narrow.scss
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/styles/_create-tearsheet-narrow.scss
@@ -1,0 +1,61 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config' as carbon-config;
+
+.create-tearsheet__section--title {
+  margin-block-end: $spacing-05;
+}
+
+.create-tearsheet__section--subtitle {
+  @include type.type-style('heading-compact-01');
+
+  margin-block-end: $spacing-03;
+}
+
+.create-tearsheet__section--description {
+  @include type.type-style('body-01');
+
+  margin-block-end: $spacing-06;
+}
+
+.create-tearsheet-narrow__body .cds--tearsheet__next__main-content {
+  padding: $spacing-05;
+}
+
+.create-tearsheet-narrow__form-title {
+  @include type.type-style('heading-compact-02');
+
+  padding-block-end: $spacing-03;
+}
+
+.create-tearsheet-narrow__form-description {
+  @include type.type-style('body-01');
+}
+
+.tearsheet-create-narrow__example-form-group
+  > legend.cds--label {
+  padding-block-start: $spacing-05;
+}
+
+.tearsheet-create-narrow__example-form-group
+  .cds--form-item {
+  margin-block-end: $spacing-05;
+}
+
+.tearsheet-create-narrow__flex-container {
+  display: flex;
+  align-items: baseline;
+}
+
+.tearsheet-create-narrow__flex-container .cds--form-item,
+.tearsheet-create-narrow__flex-container
+  .cds--dropdown__wrapper.cds--list-box__wrapper {
+  inline-size: 50%;
+}

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/styles/_story-styles.scss
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/styles/_story-styles.scss
@@ -1,0 +1,15 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/spacing' as *;
+
+.create-tearsheet-narrow-stories__launcher-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-block-size: calc(100vh - #{$spacing-09});
+}

--- a/packages/react/src/examples/CreateTearsheetNarrow/example/vite.config.ts
+++ b/packages/react/src/examples/CreateTearsheetNarrow/example/vite.config.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/react/src/examples/DeleteAndRemove/DeleteAndRemove.mdx
+++ b/packages/react/src/examples/DeleteAndRemove/DeleteAndRemove.mdx
@@ -1,0 +1,160 @@
+import { Story, Controls, Source, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import * as stories from './DeleteAndRemove.stories';
+
+<Meta isTemplate />
+
+# Delete and remove
+
+[Usage guidelines](https://carbondesignsystem.com/patterns/delete-and-remove/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [High impact deletion](#high-impact-deletion)
+- [High impact deletion with connected items](#high-impact-deletion-with-connected-items)
+- [High impact batch deletion](#high-impact-batch-deletion)
+- [Medium impact deletion or removal](#medium-impact-deletion-or-removal)
+- [Low impact deletion or removal](#low-impact-deletion-or-removal)
+
+## Overview
+
+"Removing" is an action that moves information from one location to another.
+Removal can be both destructive and non-destructive. "Deletion" is the most
+common type of removal and is destructive.
+
+> NOTE: Patterns have multiple ways of accomplishing a user need and typically
+> use a combination of components with additional design considerations. The
+> pattern code we share is meant to serve as an example implementation that can
+> be built and extended further.
+
+To build these patterns, we recommend including the following components:
+
+- [Modal](https://react.carbondesignsystem.com/?path=/docs/components-modal)
+- [Button](https://react.carbondesignsystem.com/?path=/docs/components-button)
+- [Checkbox](https://react.carbondesignsystem.com/?path=/docs/components-checkbox)
+- [TextInput](https://react.carbondesignsystem.com/?path=/docs/components-textinput)
+- [FormLabel](https://react.carbondesignsystem.com/?path=/docs/components-formlabel)
+- [InlineLoading](https://react.carbondesignsystem.com/?path=/docs/components-inlineloading)
+- [Link](https://react.carbondesignsystem.com/?path=/docs/components-link)
+- [ToastNotification](https://react.carbondesignsystem.com/?path=/story/components-notifications-toast)
+
+```jsx
+import {
+  Button,
+  Checkbox,
+  FormLabel,
+  InlineLoading,
+  Link,
+  Modal,
+  TextInput,
+  ToastNotification,
+} from '@carbon/react';
+```
+
+## Example usage
+
+> 💡 Check our
+> [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/DeleteAndRemove/example)
+> example implementation.
+
+[![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/DeleteAndRemove/example)
+
+## High impact deletion
+
+When deleting is high-impact, a confirmation dialog should be presented to the
+user which displays:
+
+- The name of the resource
+- Consequences of the deletion
+- This action cannot be undone.
+- An editable text field for the name of the resource to be entered
+
+<Canvas
+  of={stories.highImpactDeletion}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.highImpactDeletion),
+    },
+  ]}
+/>
+
+## High impact deletion with connected items
+
+It is similar to the high-impact deletion pattern, but the confirmation dialog
+also displays:
+
+- A list of all the connected items
+- A checkbox to confirm the deletion of all its connected items
+
+<Canvas
+  of={stories.highImpactDeletionWithConnectedItems}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig(stories.highImpactDeletionWithConnectedItems),
+    },
+  ]}
+/>
+
+## High impact batch deletion
+
+In batch deletion, a confirmation dialog should be presented to the user which
+displays:
+
+- The names of the items selected
+- The consequences of the deletion
+- The phrase, "This action cannot be undone"
+- A checkbox to confirm the deletion of the selected resources
+- A note of items that cannot be deleted in batch selection (optional)
+
+<Canvas
+  of={stories.highImpactBatchDeletion}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig(stories.highImpactBatchDeletion),
+    },
+  ]}
+/>
+
+## Medium impact deletion or removal
+
+When deleting is medium-impact, the user is not required to confirm the resource
+name by typing it into a text field.
+
+> NOTE: The medium-impact removal pattern is similar to medium-impact deletion
+> pattern, with the only difference being the usage of "remove" or "delete" in
+> the text. Use "remove" when the action is reversible or not truly destructive.
+
+<Canvas
+  of={stories.mediumImpactDeletion}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.mediumImpactDeletion),
+    },
+  ]}
+/>
+
+## Low impact deletion or removal
+
+In low impact situations, user confirmation may not be required.
+
+> NOTE: The low-impact removal pattern is similar to low-impact deletion
+> pattern, with the only difference being the usage of "remove" or "delete" in
+> the text.
+
+<Canvas
+  of={stories.lowImpactDeletion}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(stories.lowImpactDeletion),
+    },
+  ]}
+/>

--- a/packages/react/src/examples/DeleteAndRemove/DeleteAndRemove.mdx
+++ b/packages/react/src/examples/DeleteAndRemove/DeleteAndRemove.mdx
@@ -61,6 +61,80 @@ import {
 
 [![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/packages/react/src/examples/DeleteAndRemove/example)
 
+### Example
+
+Here's a quick example of high impact deletion to get you started.
+
+```jsx
+export const HighImpactDeletion = () => {
+  const [open, setOpen] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState('inactive');
+  const [loaderDescription, setLoaderDescription] = useState('Deleting');
+  const [resourceName, setResourceName] = useState('');
+  const [isValidName, setIsValidName] = useState(false);
+
+  const handleDelete = async () => {
+    setLoadingStatus('active');
+    await deleteItem();
+    setLoadingStatus('finished');
+    setLoaderDescription('Deleted!');
+    setOpen(false);
+  };
+
+  const validateInput = (evt) => {
+    setResourceName(evt.target.value);
+    setIsValidName(evt.target.value === 'Bx1001');
+  };
+
+  const resetLoaderStatus = () => {
+    setLoadingStatus('inactive');
+    setLoaderDescription('Deleting...');
+  };
+
+  return (
+    <div>
+      <Button
+        size="md"
+        kind="danger"
+        onClick={() => {
+          setResourceName('');
+          setOpen(true);
+        }}
+      >
+        Delete
+      </Button>
+      <Modal
+        open={open}
+        danger
+        modalHeading="Confirm delete"
+        modalLabel="Delete Bx1001"
+        primaryButtonText="Delete"
+        secondaryButtonText="Cancel"
+        primaryButtonDisabled={!isValidName}
+        loadingStatus={loadingStatus}
+        loadingDescription={loaderDescription}
+        onRequestClose={() => setOpen(false)}
+        onRequestSubmit={handleDelete}
+        onLoadingSuccess={resetLoaderStatus}
+      >
+        <p style={{ marginBottom: '1rem' }}>
+          Deleting &apos;Bx1001&apos; will permanently delete the
+          configuration. This action cannot be undone.
+        </p>
+        <TextInput
+          data-modal-primary-focus
+          id="text-input-1"
+          labelText="Type Bx1001 to confirm"
+          placeholder="Name of resource"
+          value={resourceName}
+          onChange={validateInput}
+        />
+      </Modal>
+    </div>
+  );
+};
+```
+
 ## High impact deletion
 
 When deleting is high-impact, a confirmation dialog should be presented to the

--- a/packages/react/src/examples/DeleteAndRemove/DeleteAndRemove.stories.js
+++ b/packages/react/src/examples/DeleteAndRemove/DeleteAndRemove.stories.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import './_story-styles.scss';
+import DocsPage from './DeleteAndRemove.mdx';
+import { HighImpactDeletion } from './example/preview-components/HighImpactDeletion';
+import { HighImpactDeletionWithConnectedItems } from './example/preview-components/HighImpactDeletionWithConnectedItems';
+import { HighImpactBatchDeletion } from './example/preview-components/HighImpactBatchDeletion';
+import { MediumImpactDeletion } from './example/preview-components/MediumImpactDeletion';
+import { LowImpactDeletion } from './example/preview-components/LowImpactDeletion';
+
+export default {
+  title: 'Examples/Delete and remove',
+  component: () => {},
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+  },
+};
+
+const HighImpactDeletionPattern = (args) => {
+  return <HighImpactDeletion {...args} />;
+};
+
+export const highImpactDeletion = HighImpactDeletionPattern.bind({});
+highImpactDeletion.storyName = 'High impact deletion';
+highImpactDeletion.args = {};
+
+const HighImpactDeletionWithConnectedItemsPattern = (args) => {
+  return <HighImpactDeletionWithConnectedItems {...args} />;
+};
+
+export const highImpactDeletionWithConnectedItems =
+  HighImpactDeletionWithConnectedItemsPattern.bind({});
+highImpactDeletionWithConnectedItems.storyName =
+  'Deletion with connected items';
+highImpactDeletionWithConnectedItems.args = {};
+
+const HighImpactBatchDeletionPattern = (args) => {
+  return <HighImpactBatchDeletion {...args} />;
+};
+
+export const highImpactBatchDeletion = HighImpactBatchDeletionPattern.bind({});
+highImpactBatchDeletion.storyName = 'Batch deletion';
+highImpactBatchDeletion.args = {};
+
+const MediumImpactDeletionPattern = (args) => {
+  return <MediumImpactDeletion {...args} />;
+};
+
+export const mediumImpactDeletion = MediumImpactDeletionPattern.bind({});
+mediumImpactDeletion.storyName = 'Medium impact deletion';
+mediumImpactDeletion.args = {};
+
+const LowImpactDeletionPattern = (args) => {
+  return <LowImpactDeletion {...args} />;
+};
+
+export const lowImpactDeletion = LowImpactDeletionPattern.bind({});
+lowImpactDeletion.storyName = 'Low impact deletion';
+lowImpactDeletion.args = {};

--- a/packages/react/src/examples/DeleteAndRemove/_story-styles.scss
+++ b/packages/react/src/examples/DeleteAndRemove/_story-styles.scss
@@ -1,0 +1,28 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/config';
+
+.app {
+  margin: spacing.$spacing-04;
+  .#{config.$prefix}--inline-loading {
+    min-block-size: unset;
+  }
+}
+
+.notification {
+  position: absolute;
+  inset-block-start: spacing.$spacing-04;
+  inset-inline-end: spacing.$spacing-04;
+}
+
+.no-bullets {
+  margin: 0;
+  list-style-type: none;
+  padding-inline-start: spacing.$spacing-07;
+}

--- a/packages/react/src/examples/DeleteAndRemove/example/App.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/App.tsx
@@ -1,0 +1,50 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { HighImpactDeletion } from './preview-components/HighImpactDeletion';
+import { HighImpactDeletionWithConnectedItems } from './preview-components/HighImpactDeletionWithConnectedItems';
+import { HighImpactBatchDeletion } from './preview-components/HighImpactBatchDeletion';
+import { MediumImpactDeletion } from './preview-components/MediumImpactDeletion';
+import { LowImpactDeletion } from './preview-components/LowImpactDeletion';
+
+function App() {
+  return (
+    <div className="example-container">
+      <h1>Delete and Remove Examples</h1>
+
+      <section className="example-section">
+        <h2>High Impact Deletion</h2>
+        <HighImpactDeletion />
+      </section>
+
+      <section className="example-section">
+        <h2>Deletion with Connected Items</h2>
+        <HighImpactDeletionWithConnectedItems />
+      </section>
+
+      <section className="example-section">
+        <h2>Batch Deletion</h2>
+        <HighImpactBatchDeletion />
+      </section>
+
+      <section className="example-section">
+        <h2>Medium Impact Deletion</h2>
+        <MediumImpactDeletion />
+      </section>
+
+      <section className="example-section">
+        <h2>Low Impact Deletion</h2>
+        <LowImpactDeletion />
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/packages/react/src/examples/DeleteAndRemove/example/components/DeleteAndRemove.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/components/DeleteAndRemove.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { ReactNode, useState, useEffect } from 'react';
+import { Modal, ToastNotification } from '@carbon/react';
+import { getCurrentTime } from './utils';
+
+export interface DeleteAndRemoveProps {
+  open: boolean;
+  onRequestClose: () => void;
+  onRequestSubmit: () => void;
+  onSecondarySubmit?: () => void;
+  modalHeading: string;
+  modalLabel?: string;
+  primaryButtonText?: string;
+  secondaryButtonText?: string;
+  primaryButtonDisabled?: boolean;
+  loadingStatus?: 'inactive' | 'active' | 'finished' | 'error';
+  loadingDescription?: string;
+  onLoadingSuccess?: () => void;
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  danger?: boolean;
+  successNotificationTitle?: string;
+  successNotificationSubtitle?: string;
+  showSuccessNotification?: boolean;
+  children?: ReactNode;
+}
+
+export const DeleteAndRemove = ({
+  open,
+  onRequestClose,
+  onRequestSubmit,
+  onSecondarySubmit,
+  modalHeading,
+  modalLabel,
+  primaryButtonText = 'Delete',
+  secondaryButtonText = 'Cancel',
+  primaryButtonDisabled,
+  loadingStatus,
+  loadingDescription,
+  onLoadingSuccess,
+  size,
+  danger = true,
+  successNotificationTitle = 'Success',
+  successNotificationSubtitle,
+  showSuccessNotification = false,
+  children,
+  ...rest
+}: DeleteAndRemoveProps) => {
+  const [openNotification, setOpenNotification] = useState(false);
+
+  useEffect(() => {
+    if (showSuccessNotification && loadingStatus === 'finished') {
+      setOpenNotification(true);
+    }
+    if (loadingStatus === 'inactive') {
+      setOpenNotification(false);
+    }
+  }, [showSuccessNotification, loadingStatus]);
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onRequestClose={onRequestClose}
+        danger={danger}
+        modalHeading={modalHeading}
+        modalLabel={modalLabel}
+        primaryButtonText={primaryButtonText}
+        secondaryButtonText={secondaryButtonText}
+        onRequestSubmit={onRequestSubmit}
+        onSecondarySubmit={onSecondarySubmit ?? onRequestClose}
+        primaryButtonDisabled={primaryButtonDisabled}
+        loadingStatus={loadingStatus}
+        loadingDescription={loadingDescription}
+        onLoadingSuccess={onLoadingSuccess}
+        size={size}
+        {...rest}
+      >
+        {children}
+      </Modal>
+      {openNotification && successNotificationSubtitle && (
+        <ToastNotification
+          aria-label="closes notification"
+          caption={getCurrentTime()}
+          kind="success"
+          lowContrast
+          onClose={() => setOpenNotification(false)}
+          role="status"
+          statusIconDescription="notification"
+          subtitle={successNotificationSubtitle}
+          timeout={3000}
+          title={successNotificationTitle}
+          className="notification"
+        />
+      )}
+    </>
+  );
+};
+
+DeleteAndRemove.displayName = 'DeleteAndRemove';

--- a/packages/react/src/examples/DeleteAndRemove/example/components/utils.ts
+++ b/packages/react/src/examples/DeleteAndRemove/example/components/utils.ts
@@ -1,0 +1,21 @@
+// cspell:words ampm
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//  Returns the current time in the format HH:MM:SS AM/PM.
+export function getCurrentTime() {
+  const now = new Date();
+  let hours = now.getHours();
+  const minutes = now.getMinutes().toString().padStart(2, '0');
+  const seconds = now.getSeconds().toString().padStart(2, '0');
+  const ampm = hours >= 12 ? 'PM' : 'AM';
+
+  hours = hours % 12;
+  hours = hours ? hours : 12; // the hour '0' should be '12'
+  const formattedTime = `${hours}:${minutes}:${seconds} ${ampm}`;
+  return formattedTime;
+}

--- a/packages/react/src/examples/DeleteAndRemove/example/index.html
+++ b/packages/react/src/examples/DeleteAndRemove/example/index.html
@@ -1,0 +1,21 @@
+<!--
+@license
+
+Copyright IBM Corp. 2026
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Delete and Remove Examples</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/examples/DeleteAndRemove/example/index.scss
+++ b/packages/react/src/examples/DeleteAndRemove/example/index.scss
@@ -1,0 +1,62 @@
+//
+// Copyright IBM Corp. 2026
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/config' with (
+  $font-path: '@ibm/plex'
+);
+@use '@carbon/styles';
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as theme;
+@use '@carbon/styles/scss/themes' as themes;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/motion' as *;
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+#root {
+  min-block-size: 100vh;
+}
+
+.notification {
+  position: fixed;
+  z-index: 9999;
+  inset-block-start: $spacing-05;
+  inset-inline-end: $spacing-05;
+}
+
+.no-bullets {
+  list-style: none;
+  padding-inline-start: $spacing-05;
+}
+
+.example-container {
+  margin-inline-start: $spacing-02;
+  max-inline-size: 1200px;
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 400;
+    margin-block-end: $spacing-07;
+  }
+
+  .example-section {
+    padding: $spacing-07;
+    border: 1px solid var(--cds-border-subtle);
+    background-color: var(--cds-layer-01);
+    margin-block-end: $spacing-05;
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-block: 0 $spacing-06;
+    }
+  }
+}

--- a/packages/react/src/examples/DeleteAndRemove/example/main.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/main.tsx
@@ -1,0 +1,23 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.scss';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/packages/react/src/examples/DeleteAndRemove/example/package.json
+++ b/packages/react/src/examples/DeleteAndRemove/example/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "delete-and-remove-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "@carbon/react": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.3.4",
+    "sass": "^1.93.2",
+    "vite": "^6.0.11"
+  }
+}

--- a/packages/react/src/examples/DeleteAndRemove/example/preview-components/HighImpactBatchDeletion.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/preview-components/HighImpactBatchDeletion.tsx
@@ -1,0 +1,117 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button, Checkbox, FormLabel, Link } from '@carbon/react';
+import { Launch } from '@carbon/react/icons';
+import { DeleteAndRemove } from '../components/DeleteAndRemove';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const batchItems = [
+  { id: 1, name: 'Route1_name' },
+  { id: 2, name: 'Hpt-392-ser' },
+  { id: 3, name: 'Route2_name' },
+];
+
+const protectedItems = [
+  { id: 1, name: 'Route3_name' },
+  { id: 2, name: 'Route4_name' },
+];
+
+export const HighImpactBatchDeletion = () => {
+  const [open, setOpen] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState<
+    'inactive' | 'active' | 'finished' | 'error'
+  >('inactive');
+  const [loaderDescription, setLoaderDescription] = useState('Deleting');
+  const [isChecked, setIsChecked] = useState(false);
+
+  const deleteItem = async () => {
+    await wait(1000);
+    return true;
+  };
+
+  const handleDelete = async () => {
+    setLoadingStatus('active');
+    await deleteItem();
+    setLoadingStatus('finished');
+    setLoaderDescription('Deleted!');
+    setOpen(false);
+  };
+
+  const resetLoaderStatus = () => {
+    setLoadingStatus('inactive');
+    setLoaderDescription('Deleting...');
+  };
+
+  return (
+    <div className="app">
+      <Button
+        size="md"
+        kind="danger"
+        onClick={() => {
+          setIsChecked(false);
+          setOpen(true);
+        }}
+      >
+        Delete all
+      </Button>
+      <DeleteAndRemove
+        open={open}
+        onRequestClose={() => setOpen(false)}
+        onRequestSubmit={handleDelete}
+        modalHeading="Confirm delete"
+        modalLabel="Delete selected items"
+        primaryButtonDisabled={!isChecked}
+        size="sm"
+        loadingStatus={loadingStatus}
+        loadingDescription={loaderDescription}
+        onLoadingSuccess={resetLoaderStatus}
+        showSuccessNotification={true}
+        successNotificationSubtitle="Selected items have been successfully deleted."
+      >
+        <p style={{ marginBottom: '1rem' }}>
+          Decide if you want to keep these items. Deleting these items is
+          permanent. This action cannot be undone.
+        </p>
+        <FormLabel>
+          The following items will be deleted. Review each item to confirm that
+          they can be deleted.
+        </FormLabel>
+        <Checkbox
+          checked={isChecked}
+          id="checkbox-1"
+          labelText={`${batchItems.length} items: `}
+          onChange={(event, { checked }) => setIsChecked(checked)}
+        />
+        <ul className="no-bullets">
+          {batchItems.map((item) => (
+            <li key={item.id}>
+              <Link href="#" renderIcon={Launch}>
+                {item.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+        {protectedItems.length > 0 && (
+          <p style={{ marginTop: '1rem' }}>
+            Note - the following selected items cannot be deleted:{' '}
+            {protectedItems.map((item, index) => (
+              <span key={item.id}>
+                <Link href="#" renderIcon={Launch}>
+                  {item.name}
+                </Link>
+                {index < protectedItems.length - 1 && ', '}
+              </span>
+            ))}
+          </p>
+        )}
+      </DeleteAndRemove>
+    </div>
+  );
+};

--- a/packages/react/src/examples/DeleteAndRemove/example/preview-components/HighImpactDeletion.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/preview-components/HighImpactDeletion.tsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button, TextInput } from '@carbon/react';
+import { DeleteAndRemove } from '../components/DeleteAndRemove';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const HighImpactDeletion = () => {
+  const [open, setOpen] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState<
+    'inactive' | 'active' | 'finished' | 'error'
+  >('inactive');
+  const [loaderDescription, setLoaderDescription] = useState('Deleting');
+  const [resourceName, setResourceName] = useState('');
+  const [isValidName, setIsValidName] = useState(false);
+
+  const deleteItem = async () => {
+    await wait(1000);
+    return true;
+  };
+
+  const handleDelete = async () => {
+    setLoadingStatus('active');
+    await deleteItem();
+    setLoadingStatus('finished');
+    setLoaderDescription('Deleted!');
+    setOpen(false);
+  };
+
+  const validateInput = (evt) => {
+    setResourceName(evt.target.value);
+    setIsValidName(evt.target.value === 'Bx1001');
+  };
+
+  const resetLoaderStatus = () => {
+    setLoadingStatus('inactive');
+    setLoaderDescription('Deleting...');
+  };
+
+  return (
+    <div className="app">
+      <Button
+        size="md"
+        kind="danger"
+        onClick={() => {
+          setResourceName('');
+          setOpen(true);
+        }}
+      >
+        Delete
+      </Button>
+      <DeleteAndRemove
+        open={open}
+        onRequestClose={() => setOpen(false)}
+        onRequestSubmit={handleDelete}
+        modalHeading="Confirm delete"
+        modalLabel="Delete Bx1001"
+        primaryButtonDisabled={!isValidName}
+        loadingStatus={loadingStatus}
+        loadingDescription={loaderDescription}
+        onLoadingSuccess={resetLoaderStatus}
+        showSuccessNotification={true}
+        successNotificationSubtitle="Bx1001 has been successfully deleted."
+      >
+        <p style={{ marginBottom: '1rem' }}>
+          Deleting &apos;Bx1001&apos; will permanently delete the configuration.
+          This action cannot be undone.
+        </p>
+        <TextInput
+          data-modal-primary-focus
+          id="text-input-1"
+          labelText="Type Bx1001 to confirm"
+          placeholder="Name of resource"
+          value={resourceName}
+          onChange={validateInput}
+        />
+      </DeleteAndRemove>
+    </div>
+  );
+};

--- a/packages/react/src/examples/DeleteAndRemove/example/preview-components/HighImpactDeletionWithConnectedItems.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/preview-components/HighImpactDeletionWithConnectedItems.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button, Checkbox, FormLabel, Link, TextInput } from '@carbon/react';
+import { Launch } from '@carbon/react/icons';
+import { DeleteAndRemove } from '../components/DeleteAndRemove';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const connectedItems = [
+  { id: 1, name: 'Route1_name' },
+  { id: 2, name: 'Hpt-392-ser' },
+  { id: 3, name: 'Route2_name' },
+];
+
+export const HighImpactDeletionWithConnectedItems = () => {
+  const [open, setOpen] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState<
+    'inactive' | 'active' | 'finished' | 'error'
+  >('inactive');
+  const [loaderDescription, setLoaderDescription] = useState('Deleting');
+  const [resourceName, setResourceName] = useState('');
+  const [isValidName, setIsValidName] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+
+  const deleteItem = async () => {
+    await wait(1000);
+    return true;
+  };
+
+  const handleDelete = async () => {
+    setLoadingStatus('active');
+    await deleteItem();
+    setLoadingStatus('finished');
+    setLoaderDescription('Deleted!');
+    setOpen(false);
+  };
+
+  const validateInput = (evt) => {
+    setResourceName(evt.target.value);
+    setIsValidName(evt.target.value === 'Bx1001');
+  };
+
+  const resetLoaderStatus = () => {
+    setLoadingStatus('inactive');
+    setLoaderDescription('Deleting...');
+  };
+
+  return (
+    <div className="app">
+      <Button
+        size="md"
+        kind="danger"
+        onClick={() => {
+          setResourceName('');
+          setIsChecked(false);
+          setOpen(true);
+        }}
+      >
+        Delete
+      </Button>
+      <DeleteAndRemove
+        open={open}
+        onRequestClose={() => setOpen(false)}
+        onRequestSubmit={handleDelete}
+        modalHeading="Confirm delete"
+        modalLabel="Delete Bx1001"
+        primaryButtonDisabled={!isValidName || !isChecked}
+        loadingStatus={loadingStatus}
+        loadingDescription={loaderDescription}
+        onLoadingSuccess={resetLoaderStatus}
+        showSuccessNotification={true}
+        successNotificationSubtitle="Bx1001 and all connected items have been successfully deleted."
+      >
+        <p style={{ marginBottom: '1rem' }}>
+          When you delete the &apos;Bx1001&apos;, this resource and all
+          connected items are permanently deleted. This action cannot be undone.
+        </p>
+        <TextInput
+          data-modal-primary-focus
+          value={resourceName}
+          id="text-input-1"
+          labelText="Type Bx1001 to confirm"
+          placeholder="Name of resource"
+          onChange={validateInput}
+          style={{ marginBottom: '1rem' }}
+        />
+        <FormLabel>
+          The following connected items will also be deleted. Review each item
+          to confirm that they can be deleted.
+        </FormLabel>
+        <Checkbox
+          checked={isChecked}
+          id="checkbox-1"
+          labelText={`${connectedItems.length} items: `}
+          onChange={(event, { checked }) => setIsChecked(checked)}
+        />
+        <ul className="no-bullets">
+          {connectedItems.map((item) => (
+            <li key={item.id}>
+              <Link href="#" renderIcon={Launch}>
+                {item.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </DeleteAndRemove>
+    </div>
+  );
+};

--- a/packages/react/src/examples/DeleteAndRemove/example/preview-components/LowImpactDeletion.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/preview-components/LowImpactDeletion.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button, InlineLoading, ToastNotification } from '@carbon/react';
+import { TrashCan } from '@carbon/react/icons';
+import { getCurrentTime } from '../components/utils';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const LowImpactDeletion = () => {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const deleteItem = async () => {
+    await wait(1000);
+    return true;
+  };
+
+  const handleDelete = async () => {
+    setLoading(true);
+    const isDelete = await deleteItem();
+    setLoading(false);
+    if (isDelete) {
+      showNotification();
+    }
+  };
+
+  const showNotification = () => {
+    setOpen(true);
+  };
+
+  const hideNotification = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div className="app">
+      {loading ? (
+        <Button
+          size="md"
+          kind="danger"
+          iconDescription="Loading"
+          renderIcon={InlineLoading}
+        >
+          Deleting...
+        </Button>
+      ) : (
+        <Button
+          size="md"
+          kind="danger"
+          iconDescription="TrashCan"
+          renderIcon={TrashCan}
+          onClick={handleDelete}
+        >
+          Delete
+        </Button>
+      )}
+      {open && (
+        <ToastNotification
+          aria-label="closes notification"
+          caption={getCurrentTime()}
+          kind="success"
+          lowContrast
+          onClose={hideNotification}
+          role="status"
+          statusIconDescription="notification"
+          subtitle="Bx1001 has been successfully deleted."
+          timeout={3000}
+          title="Success"
+          className="notification"
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/react/src/examples/DeleteAndRemove/example/preview-components/MediumImpactDeletion.tsx
+++ b/packages/react/src/examples/DeleteAndRemove/example/preview-components/MediumImpactDeletion.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@carbon/react';
+import { DeleteAndRemove } from '../components/DeleteAndRemove';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const MediumImpactDeletion = () => {
+  const [open, setOpen] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState<
+    'inactive' | 'active' | 'finished' | 'error'
+  >('inactive');
+  const [loaderDescription, setLoaderDescription] = useState('Deleting');
+
+  const deleteItem = async () => {
+    await wait(1000);
+    return true;
+  };
+
+  const handleDelete = async () => {
+    setLoadingStatus('active');
+    await deleteItem();
+    setLoadingStatus('finished');
+    setLoaderDescription('Deleted!');
+    setOpen(false);
+  };
+
+  const resetLoaderStatus = () => {
+    setLoadingStatus('inactive');
+    setLoaderDescription('Deleting...');
+  };
+
+  return (
+    <div className="app">
+      <Button size="md" kind="danger" onClick={() => setOpen(true)}>
+        Delete
+      </Button>
+      <DeleteAndRemove
+        open={open}
+        onRequestClose={() => setOpen(false)}
+        onRequestSubmit={handleDelete}
+        modalHeading="Confirm delete"
+        modalLabel="Delete Bx1001"
+        loadingStatus={loadingStatus}
+        loadingDescription={loaderDescription}
+        onLoadingSuccess={resetLoaderStatus}
+        showSuccessNotification={true}
+        successNotificationSubtitle="Bx1001 has been successfully deleted."
+      >
+        <p>
+          When you delete &apos;Bx1001&apos;, this resource is permanently
+          deleted. This action cannot be undone.
+        </p>
+      </DeleteAndRemove>
+    </div>
+  );
+};

--- a/packages/react/src/examples/DeleteAndRemove/example/vite.config.js
+++ b/packages/react/src/examples/DeleteAndRemove/example/vite.config.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/react/tsconfig.declarations.json
+++ b/packages/react/tsconfig.declarations.json
@@ -13,6 +13,7 @@
     "**/*.mdx",
     "**/*.snap",
     ".storybook/**/*",
-    "icons/**/*"
+    "icons/**/*",
+    "src/examples/**/example/**"
   ]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -5,5 +5,5 @@
     "noImplicitAny": false
   },
   "include": ["src/**/*", "icons/src/index.ts"],
-  "exclude": ["**/*.figma.tsx"]
+  "exclude": ["**/*.figma.tsx", "src/examples/**/example/**"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,17 +1844,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.26.10":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.28.6":
   version: 7.29.7
   resolution: "@babel/runtime@npm:7.29.7"
   checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.28.6":
-  version: 7.29.2
-  resolution: "@babel/runtime@npm:7.29.2"
-  checksum: 10/f55ba4052aa0255055b34371a145fbe69c29b37b49eaea14805b095bfb4153701486416e89392fd27ec8abafa53868be86e960b9f8f959fff91f2c8ac2a14b02
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,7 +2168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/ibm-products@npm:latest":
+"@carbon/ibm-products@npm:2.98.0":
   version: 2.98.0
   resolution: "@carbon/ibm-products@npm:2.98.0"
   dependencies:
@@ -2351,7 +2351,6 @@ __metadata:
     "@babel/preset-typescript": "npm:^8.0.0"
     "@babel/runtime": "npm:^8.0.0"
     "@carbon/feature-flags": "npm:^1.9.0"
-    "@carbon/ibm-products": "npm:latest"
     "@carbon/icons-react": "npm:^11.88.0"
     "@carbon/layout": "npm:^11.59.0"
     "@carbon/motion": "npm:^11.52.0"
@@ -10000,6 +9999,7 @@ __metadata:
     "@babel/preset-react": "npm:^8.0.0"
     "@babel/runtime": "npm:^8.0.0"
     "@carbon/cli": "workspace:packages/cli"
+    "@carbon/ibm-products": "npm:2.98.0"
     "@commitlint/cli": "npm:^21.0.0"
     "@commitlint/config-conventional": "npm:^21.0.0"
     "@eslint/compat": "npm:^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,6 +1844,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.26.10":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.28.6":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
@@ -1998,6 +2005,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon-labs/react-resizer@npm:^0.25.0":
+  version: 0.25.0
+  resolution: "@carbon-labs/react-resizer@npm:0.25.0"
+  dependencies:
+    "@carbon-labs/utilities": "npm:0.28.0"
+    "@ibm/telemetry-js": "npm:^1.10.2"
+  checksum: 10/81a78f4886c73363dcec87807f7c78c176330a1b3de2a9e3cdf6f1080dab6ffc228d698a83a4f9efe318cd24ccc129e0f1f657746d64b61a4195abd1dd5d720c
+  languageName: node
+  linkType: hard
+
+"@carbon-labs/utilities@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@carbon-labs/utilities@npm:0.28.0"
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+  checksum: 10/99200f5c72a5723824adcfba9bbd5bd2204cea398dabc97bd61bcdcb759ef2ae8bfef8f96db121a754df70335a57d4e9283550e0dfe53f18b02ee4b5b95b6d57
+  languageName: node
+  linkType: hard
+
 "@carbon/actions-issues@workspace:actions/issues":
   version: 0.0.0-use.local
   resolution: "@carbon/actions-issues@workspace:actions/issues"
@@ -2095,7 +2122,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/feature-flags@npm:^1.9.0, @carbon/feature-flags@workspace:packages/feature-flags":
+"@carbon/feature-flags@npm:^1.4.0, @carbon/feature-flags@npm:^1.9.0, @carbon/feature-flags@workspace:packages/feature-flags":
   version: 0.0.0-use.local
   resolution: "@carbon/feature-flags@workspace:packages/feature-flags"
   dependencies:
@@ -2125,6 +2152,54 @@ __metadata:
     rimraf: "npm:^6.0.1"
   languageName: unknown
   linkType: soft
+
+"@carbon/ibm-products-styles@npm:^2.94.0":
+  version: 2.94.0
+  resolution: "@carbon/ibm-products-styles@npm:2.94.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.9.1"
+  peerDependencies:
+    "@carbon/grid": ^11.57.0
+    "@carbon/layout": ^11.54.0
+    "@carbon/motion": ^11.47.0
+    "@carbon/themes": ^11.76.1
+    "@carbon/type": ^11.62.0
+  checksum: 10/1b1012aa1220918bcd018ae6cd449a861623b16093b5de633858994ed6dea59f6d615b9cf26788233172b4f3fa61c385f5ef8df9220fa8e08a7ea91bef7e91ff
+  languageName: node
+  linkType: hard
+
+"@carbon/ibm-products@npm:latest":
+  version: 2.98.0
+  resolution: "@carbon/ibm-products@npm:2.98.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.10"
+    "@carbon-labs/react-resizer": "npm:^0.25.0"
+    "@carbon/feature-flags": "npm:^1.4.0"
+    "@carbon/ibm-products-styles": "npm:^2.94.0"
+    "@carbon/telemetry": "npm:^0.1.0"
+    "@carbon/utilities": "npm:^0.21.0"
+    "@carbon/utilities-react": "npm:0.24.0"
+    "@dnd-kit/core": "npm:^6.3.1"
+    "@dnd-kit/modifiers": "npm:^9.0.0"
+    "@dnd-kit/sortable": "npm:^10.0.0"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    "@ibm/telemetry-js": "npm:^1.9.1"
+    prop-types: "npm:^15.8.1"
+    react-table: "npm:^7.8.0"
+    react-window: "npm:^1.8.11"
+  peerDependencies:
+    "@carbon/grid": ^11.57.0
+    "@carbon/layout": ^11.54.0
+    "@carbon/motion": ^11.47.0
+    "@carbon/react": ^1.111.1
+    "@carbon/themes": ^11.76.1
+    "@carbon/type": ^11.62.0
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-is: ^16.13.1 || ^17.0.2 || ^18.3.1 || ^19.0.0
+  checksum: 10/ad160ffa18a6b8656fdeae45133a4d518be87d3c1c9bf5ea575f9590b90f7df63196fe8361b198d92837e8318b0e862680ffcfab543c509e7b9a1af7de3916cd
+  languageName: node
+  linkType: hard
 
 "@carbon/icon-build-helpers@npm:^1.65.0, @carbon/icon-build-helpers@workspace:packages/icon-build-helpers":
   version: 0.0.0-use.local
@@ -2276,6 +2351,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^8.0.0"
     "@babel/runtime": "npm:^8.0.0"
     "@carbon/feature-flags": "npm:^1.9.0"
+    "@carbon/ibm-products": "npm:latest"
     "@carbon/icons-react": "npm:^11.88.0"
     "@carbon/layout": "npm:^11.59.0"
     "@carbon/motion": "npm:^11.52.0"
@@ -2383,6 +2459,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@carbon/telemetry@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@carbon/telemetry@npm:0.1.0"
+  bin:
+    carbon-telemetry: bin/carbon-telemetry.js
+  checksum: 10/4a803573ab2ff78088d972a6b5570cc8bce3230306882d58eee99a37bbf98b167143401cb1435c0c5b607436de603e23fe3cdd9bb39d41e56a172bedcde8c1f3
+  languageName: node
+  linkType: hard
+
 "@carbon/test-utils@npm:^10.41.0, @carbon/test-utils@workspace:packages/test-utils":
   version: 0.0.0-use.local
   resolution: "@carbon/test-utils@workspace:packages/test-utils"
@@ -2470,6 +2555,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@carbon/utilities-react@npm:0.24.0":
+  version: 0.24.0
+  resolution: "@carbon/utilities-react@npm:0.24.0"
+  dependencies:
+    "@carbon/utilities": "npm:^0.21.0"
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+  checksum: 10/a622b570a51ea3313edf4edfca3b62006267eaeaf5572c17c1fecd6970603740bb1e436cc3325586e2914f3ed70816e99ee248de68f8637f4fb97851ebc59067
+  languageName: node
+  linkType: hard
+
 "@carbon/utilities-react@workspace:packages/utilities-react":
   version: 0.0.0-use.local
   resolution: "@carbon/utilities-react@workspace:packages/utilities-react"
@@ -2483,6 +2580,16 @@ __metadata:
     react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
   languageName: unknown
   linkType: soft
+
+"@carbon/utilities@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@carbon/utilities@npm:0.21.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+    "@internationalized/number": "npm:^3.6.1"
+  checksum: 10/ea392a9edb2bf36d527eb03565d76dad2c999bb16197766a06eb8169c44857fb895bad2a5239b7e54a7bb812c87b7b2a231de1d6d029769b449af253f1a4e87d
+  languageName: node
+  linkType: hard
 
 "@carbon/utilities@npm:^0.25.0, @carbon/utilities@workspace:packages/utilities":
   version: 0.0.0-use.local
@@ -2901,6 +3008,68 @@ __metadata:
   peerDependencies:
     postcss-selector-parser: ^7.1.1
   checksum: 10/56790acc910b516df87bf6fd43389a88da1922ffb004de4d6099559ece48c88a8185e29439c570d1102a414bbecbb34e33f1aeace76a63e9f72e0794517cf7d7
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/accessibility@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@dnd-kit/accessibility@npm:3.1.1"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10/961000456a36700a9cd13be51147a818bc100f7dfabb332b80438d02e06f3b556aa0ff46ddf13bdff3b70bc8f9b63dd5a392cc285597ab1f7026e672660c54b6
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "@dnd-kit/core@npm:6.3.1"
+  dependencies:
+    "@dnd-kit/accessibility": "npm:^3.1.1"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10/a5ae6fa8404765712aa80e308f58cb79bac9a306c274ec8272c405c2a59dd277d24b966348fe8ca6340bb3f0d75f90b8a021fa781edcf65255114d3cf2bef891
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/modifiers@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@dnd-kit/modifiers@npm:9.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.3.0
+    react: ">=16.8.0"
+  checksum: 10/2ae238a1b787029e95d92319d7e4a0e2ffba8fceed56c4b58dfee7ed6890df207bf89ce522d4126411051121954222bd8e1444fae321485b594ae518c7c4397d
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@dnd-kit/sortable@npm:10.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.3.0
+    react: ">=16.8.0"
+  checksum: 10/bc61c25e76905204a53f91294b8116bf106fa27247eebca2c66478450b2051d7177115a384054e7e5639e6c4430083ade63056f79ee45f549da537cf05bc5288
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10/6cfe46a5fcdaced943982e7ae66b08b89235493e106eb5bc833737c25905e13375c6ecc3aa0c357d136cb21dae3966213dba063f19b7a60b1235a29a7b05ff84
   languageName: node
   linkType: hard
 
@@ -17319,6 +17488,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:>=3.1.1 <6":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: 10/b7141dc148b5c6fdd51e77ecf0421fd2581681eb8756e0b3dfbd4fe765b5e2b5a6bc90214bb6f19a96b6aed44de17eda3407142a7be9e24ccd0774bbd9874d1b
+  languageName: node
+  linkType: hard
+
 "meow@npm:^13.0.0":
   version: 13.2.0
   resolution: "meow@npm:13.2.0"
@@ -20371,6 +20547,28 @@ __metadata:
   version: 19.2.0
   resolution: "react-is@npm:19.2.0"
   checksum: 10/5cf0230571da0b446c64c0ff7b0e6992b7a8b12b39542db4003de1611e3f108e26f30b93a85ded5cd89c5bcce97f57639524ae40e57bb2f4f1ebd0935b624abf
+  languageName: node
+  linkType: hard
+
+"react-table@npm:^7.8.0":
+  version: 7.8.0
+  resolution: "react-table@npm:7.8.0"
+  peerDependencies:
+    react: ^16.8.3 || ^17.0.0-0 || ^18.0.0
+  checksum: 10/0c87db8f8823f8eca7a5521d406fa0c75d79972d47768f0c8347af3fa51f9856eea449186a0e2db2effc54d1d74a4e3477855cdbe9adf836d7dfac3a6ec5cdbf
+  languageName: node
+  linkType: hard
+
+"react-window@npm:^1.8.11":
+  version: 1.8.11
+  resolution: "react-window@npm:1.8.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.0.0"
+    memoize-one: "npm:>=3.1.1 <6"
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/bdbac2b664c5a799443b97a32b2f60a00cc13cc14ca8a8b1e81e2dc7dd00d8d54f05743113972fe1a641b57ada5d874b59c3cbe7e8a07a88c6713a0fb65d60f6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,7 +2146,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibm-products-styles@npm:^2.94.0":
+"@carbon/ibm-products-styles@npm:2.94.0, @carbon/ibm-products-styles@npm:^2.94.0":
   version: 2.94.0
   resolution: "@carbon/ibm-products-styles@npm:2.94.0"
   dependencies:
@@ -2344,6 +2344,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^8.0.0"
     "@babel/runtime": "npm:^8.0.0"
     "@carbon/feature-flags": "npm:^1.9.0"
+    "@carbon/ibm-products-styles": "npm:2.94.0"
     "@carbon/icons-react": "npm:^11.88.0"
     "@carbon/layout": "npm:^11.59.0"
     "@carbon/motion": "npm:^11.52.0"


### PR DESCRIPTION
Closes #23281 
Closes #23283 

Migrates the **Create pattern** example components (CreateFullPage, CreateModal, CreateSidePanel, CreateTearsheet, CreateTearsheetNarrow) and the **Delete & Remove** example from `@carbon/ibm-products` into the `@carbon/react` Storybook as first-class pattern examples. These are documented as _patterns_ (recipes to copy, not exported components), built entirely on core Carbon React primitives and `@carbon/utilities-react`.

### Changelog

**New**

- Added `CreateFullPage` pattern example under `src/examples/CreateFullPage` — multi-step full-page creation flow using `ButtonSet fluid`, `StepProvider`/`StepGroup`/`useStepContext` from `@carbon/utilities-react`, and `preview__PageHeader` from `@carbon/ibm-products`
- Added `CreateModal` pattern example under `src/examples/CreateModal`
- Added `CreateSidePanel` pattern example under `src/examples/CreateSidePanel`
- Added `CreateTearsheet` pattern example under `src/examples/CreateTearsheet`
- Added `CreateTearsheetNarrow` pattern example under `src/examples/CreateTearsheetNarrow`
- Added `DeleteAndRemove` pattern example under `src/examples/DeleteAndRemove`
- Registered all new pattern story globs in `product-migrated-components.mjs` for the v12 Storybook build
- Added `@carbon/utilities-react` to `packages/react` devDependencies
- Added `@carbon/ibm-products` to root devDependencies to make `@carbon/ibm-products/scss/…` imports resolvable from deep example subdirectories
- Added a custom Dart Sass importer in `.storybook/main.ts` (`ibmProductsStylesImporter`) that intercepts `@carbon/ibm-products/…` URLs and resolves them against the monorepo root `node_modules`, working around Vite 8's `api: 'modern'` path-walking limitation
- Added ESLint ignore rule for `packages/*/src/examples/**/example/**` to exclude example sub-apps from library lint rules

**Changed**

- `CreateFullPage` footer uses `ButtonSet fluid` (core Carbon) instead of the `ActionSet` component from `@carbon/ibm-products`, with a `button-set-fluid-layout` SCSS mixin override to set a minimum button inline size of `120px`

**Removed**

- `ActionSet.tsx` from the `CreateFullPage` example — replaced by `ButtonSet fluid` from `@carbon/react`

#### Testing / Reviewing

1. Run the v12 Storybook build: `yarn lerna run build --scope='@carbon/react' --include-dependencies && cd packages/react && yarn storybook:v12:build --quiet`
2. Verify the build completes without Sass or module resolution errors
3. Start Storybook locally (`yarn storybook` from `packages/react`) and navigate to **Examples → Create flows** to verify each pattern renders correctly
4. Check the **Delete & Remove** story renders as expected
5. In `CreateFullPage`, confirm the footer button set uses the fluid `ButtonSet` layout with three buttons (Cancel / Back / Next or Create) and each button respects the `120px` minimum inline size

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- ~Followed the [required v12 migration documentation](https://github.com/carbon-design-system/carbon/blob/main/docs/working-with-v12.md#required-v12-migration-documentation) for any code change that affects v12, or struck through this item because the PR does not affect v12~
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)